### PR TITLE
Fix callback page stuck on "Exchanging authorization code"

### DIFF
--- a/callback.html
+++ b/callback.html
@@ -36,10 +36,6 @@
       const error = params.get("error");
       const statusEl = document.getElementById("status");
 
-      // Remove callback page from browser history so back button
-      // doesn't return here with a stale authorization code
-      history.replaceState(null, "", "/");
-
       if (error) {
         statusEl.innerHTML = `
           <p class="text-xl text-red-600">Authorization denied</p>


### PR DESCRIPTION
The premature history.replaceState(null, "", "/") changed the URL to "/"
before the token exchange completed. When the exchange succeeded,
window.location.replace("/#sync") was treated as a same-page hash change
(since the URL was already "/"), so the browser never reloaded the page.

Removing the replaceState fixes the redirect. The replace() method already
ensures the callback page is removed from browser history.

https://claude.ai/code/session_01BxBoqy2QXiicsJgR5m2hap