### PR TITLE
Add temporal, trend, milestone, and ride-level awards (#36)

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -9,13 +9,23 @@
  *   - Beat Median: Faster than your median time on this segment
  *   - Top Quartile: In the top 25% of your own history
  *   - Consistency (Metronome): Low variance across recent efforts (CV < 0.05)
+ *   - Monthly Best: Fastest effort on a segment this calendar month (#36)
+ *   - Improvement Streak: 3+ consecutive faster times ending now (#36)
+ *   - Comeback: Beat median after 3+ sub-median efforts in a row (#36)
+ *   - Milestone: Round-number attempt count on a segment (#36)
+ *
+ * Ride-level awards (computed per-activity, not per-segment):
+ *   - Distance Record: Longest ride this year (#36)
+ *   - Elevation Record: Most climbing in a ride this year (#36)
+ *   - Segment Count: Most segments in a ride this year (#36)
  *
  * Data quality rules:
  *   - Minimum effort threshold: comparative awards (Year Best, Recent Best,
- *     Beat Median, Top Quartile) require ≥3 total efforts. Season First exempt.
+ *     Beat Median, Top Quartile, Monthly Best) require ≥3 total efforts.
+ *     Season First and Milestone exempt.
  *   - Calendar gate: Year Best suppressed before March 1.
  *   - High-variance filter: segments with CV > 0.5 (≥5 efforts) are
- *     traffic-dominated — all awards suppressed except Season First.
+ *     traffic-dominated — all awards suppressed except Season First and Milestone.
  */
 
 import { getSegment } from "./db.js";
@@ -37,6 +47,15 @@ const CONSISTENCY_CV_THRESHOLD = 0.05;
 
 /** Minimum recent efforts to evaluate consistency */
 const CONSISTENCY_MIN_EFFORTS = 5;
+
+/** Minimum consecutive improving efforts for a streak award */
+const STREAK_MIN_LENGTH = 3;
+
+/** Minimum consecutive sub-median efforts before a comeback triggers */
+const COMEBACK_MIN_SLUMP = 3;
+
+/** Effort counts that earn a milestone award */
+const MILESTONE_COUNTS = [10, 25, 50, 100, 250, 500, 1000];
 
 function formatTime(seconds) {
   const m = Math.floor(seconds / 60);
@@ -69,6 +88,13 @@ function cv(values) {
   const m = mean(values);
   if (m === 0) return 0;
   return stdev(values) / m;
+}
+
+/** Format a number with ordinal suffix (1st, 2nd, 3rd, etc.) */
+function ordinal(n) {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 
 /** Compute percentile rank (0-100) — what percentage of values is >= this value (lower time = better) */
@@ -114,6 +140,19 @@ export async function computeAwards(activity) {
     const isHighVariance =
       allEfforts.length >= MIN_EFFORTS_FOR_CV &&
       cv(allTimes) > HIGH_VARIANCE_CV_THRESHOLD;
+
+    // --- Milestone (#36) — exempt from CV filter ---
+    if (MILESTONE_COUNTS.includes(allEfforts.length)) {
+      awards.push({
+        type: "milestone",
+        segment: segment.name,
+        segment_id: segment.id,
+        time: effort.elapsed_time,
+        comparison: null,
+        delta: null,
+        message: `${ordinal(allEfforts.length)} effort on ${segment.name}!`,
+      });
+    }
 
     // --- Season First (exempt from CV filter) ---
     if (thisYearEfforts.length === 1) {
@@ -249,9 +288,169 @@ export async function computeAwards(activity) {
         });
       }
     }
+
+    // --- Monthly Best (#36) ---
+    const actMonth = activityDate.getMonth();
+    const thisMonthEfforts = allEfforts.filter((e) => {
+      const d = new Date(e.start_date_local);
+      return d.getMonth() === actMonth && d.getFullYear() === currentYear;
+    });
+    if (thisMonthEfforts.length >= 2 && allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
+      const bestThisMonth = Math.min(...thisMonthEfforts.map((e) => e.elapsed_time));
+      if (effort.elapsed_time === bestThisMonth) {
+        const monthName = activityDate.toLocaleDateString("en-US", { month: "long" });
+        awards.push({
+          type: "monthly_best",
+          segment: segment.name,
+          segment_id: segment.id,
+          time: effort.elapsed_time,
+          comparison: null,
+          delta: null,
+          message: `${monthName} Best on ${segment.name}! ${formatTime(effort.elapsed_time)} — fastest of ${thisMonthEfforts.length} efforts this month`,
+        });
+      }
+    }
+
+    // --- Improvement Streak (#36) ---
+    // 3+ consecutive faster times (chronologically) ending with this effort
+    if (sortedByDate.length >= STREAK_MIN_LENGTH) {
+      let streak = 1;
+      for (let i = 0; i < sortedByDate.length - 1; i++) {
+        if (sortedByDate[i].elapsed_time < sortedByDate[i + 1].elapsed_time) {
+          streak++;
+        } else {
+          break;
+        }
+      }
+      if (streak >= STREAK_MIN_LENGTH) {
+        awards.push({
+          type: "improvement_streak",
+          segment: segment.name,
+          segment_id: segment.id,
+          time: effort.elapsed_time,
+          comparison: null,
+          delta: sortedByDate[streak - 1].elapsed_time - effort.elapsed_time,
+          message: `${streak}-effort improvement streak on ${segment.name}! Each ride faster than the last — ${formatTime(effort.elapsed_time)}`,
+        });
+      }
+    }
+
+    // --- Comeback (#36) ---
+    // Beat median after 3+ consecutive sub-median efforts
+    if (allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
+      const sortedTimes = [...allTimes].sort((a, b) => a - b);
+      const med = median(sortedTimes);
+      if (effort.elapsed_time < med && sortedByDate.length > COMEBACK_MIN_SLUMP) {
+        // Check if the previous N efforts were all slower than median
+        let slumpLength = 0;
+        for (let i = 1; i < sortedByDate.length; i++) {
+          if (sortedByDate[i].elapsed_time >= med) {
+            slumpLength++;
+          } else {
+            break;
+          }
+        }
+        if (slumpLength >= COMEBACK_MIN_SLUMP) {
+          awards.push({
+            type: "comeback",
+            segment: segment.name,
+            segment_id: segment.id,
+            time: effort.elapsed_time,
+            comparison: null,
+            delta: Math.round(med - effort.elapsed_time),
+            message: `Comeback on ${segment.name}! Beat your median after ${slumpLength} slower efforts — ${formatTime(effort.elapsed_time)}`,
+          });
+        }
+      }
+    }
   }
 
   return awards;
+}
+
+/**
+ * Compute ride-level awards for an activity by comparing against other activities.
+ * These compare the whole ride (distance, elevation, segment count) rather than
+ * individual segment efforts.
+ *
+ * @param {Object} activity — The activity to evaluate
+ * @param {Array} allActivities — All activities for comparison (same sport type)
+ * @returns {Array} — Array of ride-level award objects
+ */
+export function computeRideLevelAwards(activity, allActivities) {
+  const awards = [];
+  const currentYear = new Date(activity.start_date_local).getFullYear();
+
+  // Filter to same sport type and same year, excluding this activity
+  const sameTypeThisYear = allActivities.filter(
+    (a) =>
+      a.sport_type === activity.sport_type &&
+      new Date(a.start_date_local).getFullYear() === currentYear &&
+      a.id !== activity.id
+  );
+
+  // Need at least 5 prior activities this year to make records meaningful
+  if (sameTypeThisYear.length < 5) return awards;
+
+  // --- Distance Record (#36) ---
+  if (activity.distance > 0) {
+    const maxPriorDistance = Math.max(...sameTypeThisYear.map((a) => a.distance || 0));
+    if (activity.distance > maxPriorDistance) {
+      awards.push({
+        type: "distance_record",
+        segment: null,
+        segment_id: null,
+        time: null,
+        comparison: null,
+        delta: null,
+        message: `Longest ${activity.sport_type === "Ride" ? "ride" : "activity"} this year! ${formatDistance(activity.distance)}`,
+      });
+    }
+  }
+
+  // --- Elevation Record (#36) ---
+  if (activity.total_elevation_gain > 0) {
+    const maxPriorElevation = Math.max(
+      ...sameTypeThisYear.map((a) => a.total_elevation_gain || 0)
+    );
+    if (activity.total_elevation_gain > maxPriorElevation) {
+      awards.push({
+        type: "elevation_record",
+        segment: null,
+        segment_id: null,
+        time: null,
+        comparison: null,
+        delta: null,
+        message: `Most climbing in a ${activity.sport_type === "Ride" ? "ride" : "activity"} this year! ${Math.round(activity.total_elevation_gain)}m elevation`,
+      });
+    }
+  }
+
+  // --- Segment Count (#36) ---
+  const segCount = (activity.segment_efforts || []).length;
+  if (segCount > 0) {
+    const maxPriorSegments = Math.max(
+      ...sameTypeThisYear.map((a) => (a.segment_efforts || []).length)
+    );
+    if (segCount > maxPriorSegments) {
+      awards.push({
+        type: "segment_count",
+        segment: null,
+        segment_id: null,
+        time: null,
+        comparison: null,
+        delta: null,
+        message: `Most segments in a single ${activity.sport_type === "Ride" ? "ride" : "activity"} this year! ${segCount} segments`,
+      });
+    }
+  }
+
+  return awards;
+}
+
+function formatDistance(meters) {
+  const km = meters / 1000;
+  return km >= 1 ? `${km.toFixed(1)} km` : `${Math.round(meters)} m`;
 }
 
 /**
@@ -262,9 +461,11 @@ export async function computeAwards(activity) {
 export async function computeAwardsForActivities(activities) {
   const result = new Map();
   for (const activity of activities) {
-    const awards = await computeAwards(activity);
-    if (awards.length > 0) {
-      result.set(activity.id, awards);
+    const segmentAwards = await computeAwards(activity);
+    const rideAwards = computeRideLevelAwards(activity, activities);
+    const allAwards = [...segmentAwards, ...rideAwards];
+    if (allAwards.length > 0) {
+      result.set(activity.id, allAwards);
     }
   }
   return result;

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -7,8 +7,8 @@
 import { html } from "htm/preact";
 import { signal } from "@preact/signals";
 import { useEffect, useRef } from "preact/hooks";
-import { getActivity, getSegment } from "../db.js";
-import { computeAwards } from "../awards.js";
+import { getActivity, getSegment, getAllActivities } from "../db.js";
+import { computeAwards, computeRideLevelAwards } from "../awards.js";
 import { navigate } from "../app.js";
 
 const activity = signal(null);
@@ -53,15 +53,29 @@ const AWARD_LABELS = {
   beat_median: { label: "Beat Median", color: "bg-purple-100 text-purple-800", icon: "◆" },
   top_quartile: { label: "Top Quartile", color: "bg-indigo-100 text-indigo-800", icon: "▲" },
   consistency: { label: "Metronome", color: "bg-teal-100 text-teal-800", icon: "≡" },
+  monthly_best: { label: "Monthly Best", color: "bg-orange-100 text-orange-800", icon: "◎" },
+  improvement_streak: { label: "On a Roll", color: "bg-emerald-100 text-emerald-800", icon: "⟫" },
+  comeback: { label: "Comeback", color: "bg-rose-100 text-rose-800", icon: "↺" },
+  milestone: { label: "Milestone", color: "bg-amber-100 text-amber-800", icon: "⬡" },
+  distance_record: { label: "Longest Ride", color: "bg-cyan-100 text-cyan-800", icon: "→" },
+  elevation_record: { label: "Most Climbing", color: "bg-sky-100 text-sky-800", icon: "⛰" },
+  segment_count: { label: "Most Segments", color: "bg-lime-100 text-lime-800", icon: "#" },
 };
 
 const AWARD_COLORS = {
-  year_best:    { bg: "#FEF9C3", text: "#854D0E", accent: "#EAB308" },
-  season_first: { bg: "#DCFCE7", text: "#166534", accent: "#22C55E" },
-  recent_best:  { bg: "#DBEAFE", text: "#1E40AF", accent: "#3B82F6" },
-  beat_median:  { bg: "#F3E8FF", text: "#6B21A8", accent: "#A855F7" },
-  top_quartile: { bg: "#E0E7FF", text: "#3730A3", accent: "#6366F1" },
-  consistency:  { bg: "#CCFBF1", text: "#115E59", accent: "#14B8A6" },
+  year_best:          { bg: "#FEF9C3", text: "#854D0E", accent: "#EAB308" },
+  season_first:       { bg: "#DCFCE7", text: "#166534", accent: "#22C55E" },
+  recent_best:        { bg: "#DBEAFE", text: "#1E40AF", accent: "#3B82F6" },
+  beat_median:        { bg: "#F3E8FF", text: "#6B21A8", accent: "#A855F7" },
+  top_quartile:       { bg: "#E0E7FF", text: "#3730A3", accent: "#6366F1" },
+  consistency:        { bg: "#CCFBF1", text: "#115E59", accent: "#14B8A6" },
+  monthly_best:       { bg: "#FFEDD5", text: "#9A3412", accent: "#F97316" },
+  improvement_streak: { bg: "#D1FAE5", text: "#065F46", accent: "#10B981" },
+  comeback:           { bg: "#FFE4E6", text: "#9F1239", accent: "#F43F5E" },
+  milestone:          { bg: "#FEF3C7", text: "#92400E", accent: "#F59E0B" },
+  distance_record:    { bg: "#CFFAFE", text: "#155E75", accent: "#06B6D4" },
+  elevation_record:   { bg: "#E0F2FE", text: "#075985", accent: "#0EA5E9" },
+  segment_count:      { bg: "#ECFCCB", text: "#3F6212", accent: "#84CC16" },
 };
 
 async function loadActivity(id) {
@@ -73,7 +87,10 @@ async function loadActivity(id) {
     activity.value = act;
 
     if (act.has_efforts) {
-      const awardsList = await computeAwards(act);
+      const segmentAwards = await computeAwards(act);
+      const allActivities = await getAllActivities();
+      const rideAwards = computeRideLevelAwards(act, allActivities);
+      const awardsList = [...segmentAwards, ...rideAwards];
       awards.value = awardsList;
 
       const history = new Map();
@@ -230,7 +247,7 @@ function renderShareCard(canvas, act, awardsList) {
   if (awardsList.length > 0) {
     // Summary pills
     const counts = {};
-    const order = ["season_first", "year_best", "recent_best", "beat_median", "top_quartile", "consistency"];
+    const order = ["season_first", "year_best", "monthly_best", "recent_best", "improvement_streak", "comeback", "beat_median", "top_quartile", "consistency", "milestone", "distance_record", "elevation_record", "segment_count"];
     for (const a of awardsList) counts[a.type] = (counts[a.type] || 0) + 1;
 
     let pillX = left;

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -63,6 +63,13 @@ const AWARD_LABELS = {
   beat_median: { label: "Beat Median", color: "bg-purple-100 text-purple-800" },
   top_quartile: { label: "Top Quartile", color: "bg-indigo-100 text-indigo-800" },
   consistency: { label: "Metronome", color: "bg-teal-100 text-teal-800" },
+  monthly_best: { label: "Monthly Best", color: "bg-orange-100 text-orange-800" },
+  improvement_streak: { label: "On a Roll", color: "bg-emerald-100 text-emerald-800" },
+  comeback: { label: "Comeback", color: "bg-rose-100 text-rose-800" },
+  milestone: { label: "Milestone", color: "bg-amber-100 text-amber-800" },
+  distance_record: { label: "Longest Ride", color: "bg-cyan-100 text-cyan-800" },
+  elevation_record: { label: "Most Climbing", color: "bg-sky-100 text-sky-800" },
+  segment_count: { label: "Most Segments", color: "bg-lime-100 text-lime-800" },
 };
 
 async function loadDashboard() {
@@ -276,7 +283,7 @@ export function Dashboard() {
               for (const a of awards) {
                 typeCounts.set(a.type, (typeCounts.get(a.type) || 0) + 1);
               }
-              const typeOrder = ["season_first", "year_best", "recent_best", "beat_median", "top_quartile", "consistency"];
+              const typeOrder = ["season_first", "year_best", "monthly_best", "recent_best", "improvement_streak", "comeback", "beat_median", "top_quartile", "consistency", "milestone", "distance_record", "elevation_record", "segment_count"];
               const summary = typeOrder
                 .filter((t) => typeCounts.has(t))
                 .map((t) => ({ type: t, count: typeCounts.get(t) }));
@@ -354,6 +361,34 @@ export function Dashboard() {
                   <div class="flex items-start gap-2">
                     <span class="text-xs px-2 py-0.5 rounded-full bg-teal-100 text-teal-800 whitespace-nowrap mt-0.5">Metronome</span>
                     <span>Remarkably consistent — low variance across your last 5 efforts.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-orange-100 text-orange-800 whitespace-nowrap mt-0.5">Monthly Best</span>
+                    <span>Fastest time on a segment this calendar month.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-800 whitespace-nowrap mt-0.5">On a Roll</span>
+                    <span>3+ consecutive improving times on a segment — each ride faster than the last.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-rose-100 text-rose-800 whitespace-nowrap mt-0.5">Comeback</span>
+                    <span>Beat your median after 3+ slower efforts in a row.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 whitespace-nowrap mt-0.5">Milestone</span>
+                    <span>Round-number attempt on a segment (10th, 25th, 50th, 100th, etc.).</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-cyan-100 text-cyan-800 whitespace-nowrap mt-0.5">Longest Ride</span>
+                    <span>Your longest ride of the year by distance.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-sky-100 text-sky-800 whitespace-nowrap mt-0.5">Most Climbing</span>
+                    <span>Most elevation gain in a single ride this year.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-lime-100 text-lime-800 whitespace-nowrap mt-0.5">Most Segments</span>
+                    <span>Most segments hit in a single ride this year.</span>
                   </div>
                 </div>
               </details>


### PR DESCRIPTION
New segment-level award types:
- Monthly Best: fastest effort on a segment this calendar month
- Improvement Streak (On a Roll): 3+ consecutive faster times
- Comeback: beat median after 3+ slower efforts in a row
- Milestone: round-number attempt (10th, 25th, 50th, 100th, etc.)

New ride-level award types:
- Distance Record: longest ride of the year
- Elevation Record: most climbing in a ride this year
- Segment Count: most segments in a single ride this year

Milestone is exempt from the high-variance filter (like Season First).
Ride-level awards require 5+ prior activities of same sport type this year.
Dashboard FAQ and ActivityDetail share card updated with all new types.

https://claude.ai/code/session_01YSVZrcD3Z6W5eDbRDczmZU