### PR TITLE
Add Best Month Ever, Closing In, Anniversary, and Endurance Record awards

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -13,11 +13,15 @@
  *   - Improvement Streak: 3+ consecutive faster times ending now (#36)
  *   - Comeback: Beat median after 3+ sub-median efforts in a row (#36)
  *   - Milestone: Round-number attempt count on a segment (#36)
+ *   - Best Month Ever: Fastest effort on segment in this calendar month across all years (#27)
+ *   - Closing In: Within 10% of all-time PR on a segment (#28)
+ *   - Anniversary: Rode this segment on same date N years ago (#30)
  *
  * Ride-level awards (computed per-activity, not per-segment):
  *   - Distance Record: Longest ride this year (#36)
  *   - Elevation Record: Most climbing in a ride this year (#36)
  *   - Segment Count: Most segments in a ride this year (#36)
+ *   - Endurance Record: Longest moving time this year (#31)
  *
  * Data quality rules:
  *   - Minimum effort threshold: comparative awards (Year Best, Recent Best,
@@ -363,6 +367,81 @@ export async function computeAwards(activity) {
         }
       }
     }
+
+    // --- Best Month Ever (#27) ---
+    // Fastest effort in this calendar month across ALL years
+    if (allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
+      const actMonth = activityDate.getMonth();
+      const sameMonthEfforts = allEfforts.filter(
+        (e) => new Date(e.start_date_local).getMonth() === actMonth
+      );
+      if (sameMonthEfforts.length >= 2) {
+        const bestEver = Math.min(...sameMonthEfforts.map((e) => e.elapsed_time));
+        if (effort.elapsed_time === bestEver) {
+          const priorBests = sameMonthEfforts
+            .filter((e) => e.effort_id !== effort.id && new Date(e.start_date_local).getFullYear() !== currentYear);
+          const hasPriorYears = priorBests.length > 0;
+          if (hasPriorYears) {
+            const monthName = activityDate.toLocaleDateString("en-US", { month: "long" });
+            const yearsSpanned = new Set(sameMonthEfforts.map((e) => new Date(e.start_date_local).getFullYear())).size;
+            awards.push({
+              type: "best_month_ever",
+              segment: segment.name,
+              segment_id: segment.id,
+              time: effort.elapsed_time,
+              comparison: null,
+              delta: null,
+              message: `Best ${monthName} ever on ${segment.name}! ${formatTime(effort.elapsed_time)} — fastest across ${yearsSpanned} years`,
+            });
+          }
+        }
+      }
+    }
+
+    // --- Closing In on PR (#28) ---
+    // Within 10% of all-time best (but not the best itself)
+    if (allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
+      const allTimeBest = Math.min(...allTimes);
+      if (effort.elapsed_time > allTimeBest) {
+        const gap = (effort.elapsed_time - allTimeBest) / allTimeBest;
+        if (gap <= 0.10) {
+          const pctLabel = gap <= 0.05 ? "5%" : "10%";
+          awards.push({
+            type: "closing_in",
+            segment: segment.name,
+            segment_id: segment.id,
+            time: effort.elapsed_time,
+            comparison: null,
+            delta: effort.elapsed_time - allTimeBest,
+            message: `Within ${pctLabel} of your PR on ${segment.name}! ${formatTime(effort.elapsed_time)} — just ${formatTime(effort.elapsed_time - allTimeBest)} off your best`,
+          });
+        }
+      }
+    }
+
+    // --- Anniversary (#30) ---
+    // Rode this segment on same month+day in a previous year
+    const actMonthDay = `${String(activityDate.getMonth() + 1).padStart(2, "0")}-${String(activityDate.getDate()).padStart(2, "0")}`;
+    const anniversaryEfforts = allEfforts.filter((e) => {
+      const d = new Date(e.start_date_local);
+      if (d.getFullYear() === currentYear) return false;
+      const md = `${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      return md === actMonthDay;
+    });
+    if (anniversaryEfforts.length > 0) {
+      const years = anniversaryEfforts.map((e) => new Date(e.start_date_local).getFullYear()).sort();
+      const oldestYear = years[0];
+      const span = currentYear - oldestYear;
+      awards.push({
+        type: "anniversary",
+        segment: segment.name,
+        segment_id: segment.id,
+        time: effort.elapsed_time,
+        comparison: anniversaryEfforts[0],
+        delta: anniversaryEfforts[0].elapsed_time - effort.elapsed_time,
+        message: `Anniversary on ${segment.name}! Also rode this segment on this date ${span} year${span > 1 ? "s" : ""} ago`,
+      });
+    }
   }
 
   return awards;
@@ -441,6 +520,23 @@ export function computeRideLevelAwards(activity, allActivities) {
         comparison: null,
         delta: null,
         message: `Most segments in a single ${activity.sport_type === "Ride" ? "ride" : "activity"} this year! ${segCount} segments`,
+      });
+    }
+  }
+
+  // --- Endurance Record (#31) ---
+  if (activity.moving_time > 0) {
+    const maxPriorMovingTime = Math.max(...sameTypeThisYear.map((a) => a.moving_time || 0));
+    if (activity.moving_time > maxPriorMovingTime) {
+      const label = activity.sport_type === "Ride" ? "ride" : "activity";
+      awards.push({
+        type: "endurance_record",
+        segment: null,
+        segment_id: null,
+        time: null,
+        comparison: null,
+        delta: null,
+        message: `Longest ${label} by time this year! ${formatTime(activity.moving_time)} moving time`,
       });
     }
   }

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -57,9 +57,13 @@ const AWARD_LABELS = {
   improvement_streak: { label: "On a Roll", color: "bg-emerald-100 text-emerald-800", icon: "⟫" },
   comeback: { label: "Comeback", color: "bg-rose-100 text-rose-800", icon: "↺" },
   milestone: { label: "Milestone", color: "bg-amber-100 text-amber-800", icon: "⬡" },
+  best_month_ever: { label: "Best Month Ever", color: "bg-fuchsia-100 text-fuchsia-800", icon: "◉" },
+  closing_in: { label: "Closing In", color: "bg-pink-100 text-pink-800", icon: "◈" },
+  anniversary: { label: "Anniversary", color: "bg-violet-100 text-violet-800", icon: "↻" },
   distance_record: { label: "Longest Ride", color: "bg-cyan-100 text-cyan-800", icon: "→" },
   elevation_record: { label: "Most Climbing", color: "bg-sky-100 text-sky-800", icon: "⛰" },
   segment_count: { label: "Most Segments", color: "bg-lime-100 text-lime-800", icon: "#" },
+  endurance_record: { label: "Longest by Time", color: "bg-slate-100 text-slate-800", icon: "⏱" },
 };
 
 const AWARD_COLORS = {
@@ -73,9 +77,13 @@ const AWARD_COLORS = {
   improvement_streak: { bg: "#D1FAE5", text: "#065F46", accent: "#10B981" },
   comeback:           { bg: "#FFE4E6", text: "#9F1239", accent: "#F43F5E" },
   milestone:          { bg: "#FEF3C7", text: "#92400E", accent: "#F59E0B" },
+  best_month_ever:    { bg: "#FAE8FF", text: "#86198F", accent: "#D946EF" },
+  closing_in:         { bg: "#FCE7F3", text: "#9D174D", accent: "#EC4899" },
+  anniversary:        { bg: "#EDE9FE", text: "#5B21B6", accent: "#8B5CF6" },
   distance_record:    { bg: "#CFFAFE", text: "#155E75", accent: "#06B6D4" },
   elevation_record:   { bg: "#E0F2FE", text: "#075985", accent: "#0EA5E9" },
   segment_count:      { bg: "#ECFCCB", text: "#3F6212", accent: "#84CC16" },
+  endurance_record:   { bg: "#F1F5F9", text: "#334155", accent: "#64748B" },
 };
 
 async function loadActivity(id) {
@@ -247,7 +255,7 @@ function renderShareCard(canvas, act, awardsList) {
   if (awardsList.length > 0) {
     // Summary pills
     const counts = {};
-    const order = ["season_first", "year_best", "monthly_best", "recent_best", "improvement_streak", "comeback", "beat_median", "top_quartile", "consistency", "milestone", "distance_record", "elevation_record", "segment_count"];
+    const order = ["season_first", "year_best", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "beat_median", "top_quartile", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
     for (const a of awardsList) counts[a.type] = (counts[a.type] || 0) + 1;
 
     let pillX = left;

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -67,9 +67,13 @@ const AWARD_LABELS = {
   improvement_streak: { label: "On a Roll", color: "bg-emerald-100 text-emerald-800" },
   comeback: { label: "Comeback", color: "bg-rose-100 text-rose-800" },
   milestone: { label: "Milestone", color: "bg-amber-100 text-amber-800" },
+  best_month_ever: { label: "Best Month Ever", color: "bg-fuchsia-100 text-fuchsia-800" },
+  closing_in: { label: "Closing In", color: "bg-pink-100 text-pink-800" },
+  anniversary: { label: "Anniversary", color: "bg-violet-100 text-violet-800" },
   distance_record: { label: "Longest Ride", color: "bg-cyan-100 text-cyan-800" },
   elevation_record: { label: "Most Climbing", color: "bg-sky-100 text-sky-800" },
   segment_count: { label: "Most Segments", color: "bg-lime-100 text-lime-800" },
+  endurance_record: { label: "Longest by Time", color: "bg-slate-100 text-slate-800" },
 };
 
 async function loadDashboard() {
@@ -283,7 +287,7 @@ export function Dashboard() {
               for (const a of awards) {
                 typeCounts.set(a.type, (typeCounts.get(a.type) || 0) + 1);
               }
-              const typeOrder = ["season_first", "year_best", "monthly_best", "recent_best", "improvement_streak", "comeback", "beat_median", "top_quartile", "consistency", "milestone", "distance_record", "elevation_record", "segment_count"];
+              const typeOrder = ["season_first", "year_best", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "beat_median", "top_quartile", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
               const summary = typeOrder
                 .filter((t) => typeCounts.has(t))
                 .map((t) => ({ type: t, count: typeCounts.get(t) }));
@@ -379,6 +383,18 @@ export function Dashboard() {
                     <span>Round-number attempt on a segment (10th, 25th, 50th, 100th, etc.).</span>
                   </div>
                   <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-fuchsia-100 text-fuchsia-800 whitespace-nowrap mt-0.5">Best Month Ever</span>
+                    <span>Fastest time in this calendar month across all years — your best March ever, for example.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-pink-100 text-pink-800 whitespace-nowrap mt-0.5">Closing In</span>
+                    <span>Within 10% of your all-time PR on a segment — you're close to a personal best.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-violet-100 text-violet-800 whitespace-nowrap mt-0.5">Anniversary</span>
+                    <span>Rode this segment on the same date in a previous year.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
                     <span class="text-xs px-2 py-0.5 rounded-full bg-cyan-100 text-cyan-800 whitespace-nowrap mt-0.5">Longest Ride</span>
                     <span>Your longest ride of the year by distance.</span>
                   </div>
@@ -389,6 +405,10 @@ export function Dashboard() {
                   <div class="flex items-start gap-2">
                     <span class="text-xs px-2 py-0.5 rounded-full bg-lime-100 text-lime-800 whitespace-nowrap mt-0.5">Most Segments</span>
                     <span>Most segments hit in a single ride this year.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-800 whitespace-nowrap mt-0.5">Longest by Time</span>
+                    <span>Longest ride by moving time this year — your biggest endurance effort.</span>
                   </div>
                 </div>
               </details>


### PR DESCRIPTION
New segment-level awards:
- Best Month Ever (#27): fastest effort in calendar month across all years
- Closing In (#28): within 10% (or 5%) of all-time PR on a segment
- Anniversary (#30): rode same segment on same date in a prior year

New ride-level award:
- Endurance Record (#31): longest moving time this year

All new awards respect existing data quality rules (min efforts,
high-variance filter). UI labels, colors, icons, FAQ entries, and
share card pill ordering updated for Dashboard and ActivityDetail.

Closes #27, closes #28, closes #30, closes #31

https://claude.ai/code/session_01LQS5Fvd9NRoCJKTrPQjRxb