### PR TITLE
Fix award badges not showing; add Top 10% with superseding hierarchy

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -8,6 +8,8 @@
  *   - Recent Best: Best time among last 5 attempts (requires 3+ history)
  *   - Beat Median: Faster than your median time on this segment
  *   - Top Quartile: In the top 25% of your own history
+ *   - Top 10%: In the top 10% of your own history
+ *     (Superseding: Top 10% > Top Quartile > Beat Median — only highest awarded)
  *   - Consistency (Metronome): Low variance across recent efforts (CV < 0.05)
  *   - Monthly Best: Fastest effort on a segment this calendar month (#36)
  *   - Improvement Streak: 3+ consecutive faster times ending now (#36)
@@ -235,33 +237,30 @@ export async function computeAwards(activity) {
       }
     }
 
-    // --- Beat Median (#29) ---
+    // --- Beat Median / Top Quartile / Top 10% (superseding hierarchy) ---
+    // Top 10% supersedes Top Quartile supersedes Beat Median.
+    // Only the highest-tier award is granted per segment.
     if (allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
       const sortedTimes = [...allTimes].sort((a, b) => a - b);
       const med = median(sortedTimes);
+      const q1Index = Math.floor(sortedTimes.length * 0.25);
+      const q1Threshold = sortedTimes[q1Index];
+      const d1Index = Math.floor(sortedTimes.length * 0.10);
+      const d1Threshold = sortedTimes[d1Index];
+      const pctile = percentileRank(allTimes, effort.elapsed_time);
+      const rank = sortedTimes.filter((t) => t < effort.elapsed_time).length + 1;
 
-      if (effort.elapsed_time < med) {
-        const pctile = percentileRank(allTimes, effort.elapsed_time);
+      if (effort.elapsed_time <= d1Threshold) {
         awards.push({
-          type: "beat_median",
+          type: "top_decile",
           segment: segment.name,
           segment_id: segment.id,
           time: effort.elapsed_time,
           comparison: null,
-          delta: Math.round(med - effort.elapsed_time),
-          message: `Beat your median on ${segment.name}! ${formatTime(effort.elapsed_time)} — ${formatTime(Math.round(med - effort.elapsed_time))} under median (top ${100 - pctile}% of ${allEfforts.length} efforts)`,
+          delta: null,
+          message: `Top 10% on ${segment.name}! #${rank} of ${allEfforts.length} efforts — ${formatTime(effort.elapsed_time)}`,
         });
-      }
-    }
-
-    // --- Top Quartile (#29) ---
-    if (allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
-      const sortedTimes = [...allTimes].sort((a, b) => a - b);
-      const q1Index = Math.floor(sortedTimes.length * 0.25);
-      const q1Threshold = sortedTimes[q1Index];
-
-      if (effort.elapsed_time <= q1Threshold) {
-        const rank = sortedTimes.filter((t) => t < effort.elapsed_time).length + 1;
+      } else if (effort.elapsed_time <= q1Threshold) {
         awards.push({
           type: "top_quartile",
           segment: segment.name,
@@ -270,6 +269,16 @@ export async function computeAwards(activity) {
           comparison: null,
           delta: null,
           message: `Top quartile on ${segment.name}! #${rank} of ${allEfforts.length} efforts — ${formatTime(effort.elapsed_time)}`,
+        });
+      } else if (effort.elapsed_time < med) {
+        awards.push({
+          type: "beat_median",
+          segment: segment.name,
+          segment_id: segment.id,
+          time: effort.elapsed_time,
+          comparison: null,
+          delta: Math.round(med - effort.elapsed_time),
+          message: `Beat your median on ${segment.name}! ${formatTime(effort.elapsed_time)} — ${formatTime(Math.round(med - effort.elapsed_time))} under median (top ${100 - pctile}% of ${allEfforts.length} efforts)`,
         });
       }
     }
@@ -371,7 +380,6 @@ export async function computeAwards(activity) {
     // --- Best Month Ever (#27) ---
     // Fastest effort in this calendar month across ALL years
     if (allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
-      const actMonth = activityDate.getMonth();
       const sameMonthEfforts = allEfforts.filter(
         (e) => new Date(e.start_date_local).getMonth() === actMonth
       );

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -52,6 +52,7 @@ const AWARD_LABELS = {
   recent_best: { label: "Recent Best", color: "bg-blue-100 text-blue-800", icon: "↑" },
   beat_median: { label: "Beat Median", color: "bg-purple-100 text-purple-800", icon: "◆" },
   top_quartile: { label: "Top Quartile", color: "bg-indigo-100 text-indigo-800", icon: "▲" },
+  top_decile: { label: "Top 10%", color: "bg-red-100 text-red-800", icon: "⬆" },
   consistency: { label: "Metronome", color: "bg-teal-100 text-teal-800", icon: "≡" },
   monthly_best: { label: "Monthly Best", color: "bg-orange-100 text-orange-800", icon: "◎" },
   improvement_streak: { label: "On a Roll", color: "bg-emerald-100 text-emerald-800", icon: "⟫" },
@@ -72,6 +73,7 @@ const AWARD_COLORS = {
   recent_best:        { bg: "#DBEAFE", text: "#1E40AF", accent: "#3B82F6" },
   beat_median:        { bg: "#F3E8FF", text: "#6B21A8", accent: "#A855F7" },
   top_quartile:       { bg: "#E0E7FF", text: "#3730A3", accent: "#6366F1" },
+  top_decile:         { bg: "#FEE2E2", text: "#991B1B", accent: "#EF4444" },
   consistency:        { bg: "#CCFBF1", text: "#115E59", accent: "#14B8A6" },
   monthly_best:       { bg: "#FFEDD5", text: "#9A3412", accent: "#F97316" },
   improvement_streak: { bg: "#D1FAE5", text: "#065F46", accent: "#10B981" },
@@ -255,7 +257,7 @@ function renderShareCard(canvas, act, awardsList) {
   if (awardsList.length > 0) {
     // Summary pills
     const counts = {};
-    const order = ["season_first", "year_best", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "beat_median", "top_quartile", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
+    const order = ["season_first", "year_best", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
     for (const a of awardsList) counts[a.type] = (counts[a.type] || 0) + 1;
 
     let pillX = left;

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -62,6 +62,7 @@ const AWARD_LABELS = {
   recent_best: { label: "Recent Best", color: "bg-blue-100 text-blue-800" },
   beat_median: { label: "Beat Median", color: "bg-purple-100 text-purple-800" },
   top_quartile: { label: "Top Quartile", color: "bg-indigo-100 text-indigo-800" },
+  top_decile: { label: "Top 10%", color: "bg-red-100 text-red-800" },
   consistency: { label: "Metronome", color: "bg-teal-100 text-teal-800" },
   monthly_best: { label: "Monthly Best", color: "bg-orange-100 text-orange-800" },
   improvement_streak: { label: "On a Roll", color: "bg-emerald-100 text-emerald-800" },
@@ -287,7 +288,7 @@ export function Dashboard() {
               for (const a of awards) {
                 typeCounts.set(a.type, (typeCounts.get(a.type) || 0) + 1);
               }
-              const typeOrder = ["season_first", "year_best", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "beat_median", "top_quartile", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
+              const typeOrder = ["season_first", "year_best", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
               const summary = typeOrder
                 .filter((t) => typeCounts.has(t))
                 .map((t) => ({ type: t, count: typeCounts.get(t) }));
@@ -361,6 +362,10 @@ export function Dashboard() {
                   <div class="flex items-start gap-2">
                     <span class="text-xs px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-800 whitespace-nowrap mt-0.5">Top Quartile</span>
                     <span>In the top 25% of your own history on this segment.</span>
+                  </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-800 whitespace-nowrap mt-0.5">Top 10%</span>
+                    <span>In the top 10% of your own history. Supersedes Top Quartile and Beat Median.</span>
                   </div>
                   <div class="flex items-start gap-2">
                     <span class="text-xs px-2 py-0.5 rounded-full bg-teal-100 text-teal-800 whitespace-nowrap mt-0.5">Metronome</span>

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -174,6 +174,10 @@ export function Landing() {
                 <span>In the top 25% of your own history on this segment. A genuinely strong effort by your standards.</span>
               </div>
               <div class="flex items-start gap-2">
+                <span class="text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-800 whitespace-nowrap mt-0.5">Top 10%</span>
+                <span>In the top 10% of your history. Supersedes Top Quartile and Beat Median — only the highest tier is shown.</span>
+              </div>
+              <div class="flex items-start gap-2">
                 <span class="text-xs px-2 py-0.5 rounded-full bg-teal-100 text-teal-800 whitespace-nowrap mt-0.5">Metronome</span>
                 <span>Remarkably consistent — your last 5 efforts have very low variance. Not getting faster, but repeatable.</span>
               </div>


### PR DESCRIPTION
The awards module failed to load due to a duplicate `const actMonth`
declaration in the same block scope (Monthly Best and Best Month Ever
both declared it), causing a SyntaxError that broke all award computation.

Also adds a Top 10% (top_decile) award and implements superseding:
Top 10% > Top Quartile > Beat Median — only the highest tier is
awarded per segment, reducing badge noise.

https://claude.ai/code/session_01Kc4U5gtFoN7Q7j8htohXvG