### PR TITLE
Fix missing getActivitiesWithoutEfforts import and simplify auto-trigger

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -22,6 +22,7 @@ import { computeAwardsForActivities } from "../awards.js";
 import {
   getAllActivities,
   getAllSegments,
+  getActivitiesWithoutEfforts,
   getSyncState,
   clearAllData,
   getResetEvent,
@@ -136,8 +137,7 @@ export function Dashboard() {
 
       // Auto-trigger backfill if initial list sync isn't done
       const state = await getSyncState();
-      const pending = await getActivitiesWithoutEfforts();
-      if (!state.backfill_complete || pending.length > 0) {
+      if (!state.backfill_complete) {
         try {
           await startBackfill();
         } catch (err) {


### PR DESCRIPTION
The #60/#61 comeback mode merge removed getActivitiesWithoutEfforts from
imports but left two call sites, causing a ReferenceError at runtime.

- Re-import getActivitiesWithoutEfforts (still needed by handleSync to
  resume pending detail fetches on manual sync)
- Simplify init() auto-trigger to only check !state.backfill_complete,
  so activities permanently missing details don't trigger backfill on
  every page load (aligned with PR #63's intent)

https://claude.ai/code/session_01Q7Nzs3zFHxfCe9tE3u1rja