### PR TITLE
feat: add user-defined reference points for custom "best since" awards

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -50,7 +50,7 @@
  *   - Recovered (at or better than pre-injury): normal awards + "You're Back!"
  */
 
-import { getSegment, getResetEvent, recordRecoveryMilestone } from "./db.js";
+import { getSegment, getResetEvent, recordRecoveryMilestone, getUserConfig } from "./db.js";
 import { formatTime, formatDistance } from "./units.js";
 
 /** Minimum total efforts on a segment before comparative awards apply */
@@ -224,6 +224,82 @@ function computeYtdComparison(currentValue, allEfforts, activityDate, field) {
 
 
 /**
+ * Resolve a reference point to a cutoff date or effort count.
+ * @param {Object} refPoint - Reference point config
+ * @returns {{ type: "date", date: Date, label: string } | { type: "count", count: number, label: string }}
+ */
+function resolveReferencePoint(refPoint) {
+  if (refPoint.type === "since_date") {
+    return { type: "date", date: new Date(refPoint.date), label: refPoint.label };
+  }
+  if (refPoint.type === "last_n") {
+    return { type: "count", count: refPoint.count, label: refPoint.label };
+  }
+  if (refPoint.type === "since_age") {
+    const birthday = new Date(refPoint.birthday);
+    const ageDate = new Date(birthday);
+    ageDate.setFullYear(ageDate.getFullYear() + refPoint.age);
+    return { type: "date", date: ageDate, label: refPoint.label };
+  }
+  return null;
+}
+
+/**
+ * Compute reference_best awards for a segment effort against user-defined reference points.
+ * @param {Object} effort - Current segment effort
+ * @param {Array} allEfforts - All efforts on this segment
+ * @param {Object} segment - Segment data
+ * @param {Array} referencePoints - User-defined reference points
+ * @returns {Array} - Awards for this effort
+ */
+function computeReferenceAwards(effort, allEfforts, segment, referencePoints) {
+  const awards = [];
+  for (const refPoint of referencePoints) {
+    const resolved = resolveReferencePoint(refPoint);
+    if (!resolved) continue;
+
+    let windowEfforts;
+    if (resolved.type === "date") {
+      windowEfforts = allEfforts.filter(
+        (e) => new Date(e.start_date_local) >= resolved.date
+      );
+    } else {
+      // Last N efforts by date (most recent N)
+      const sorted = [...allEfforts].sort(
+        (a, b) => b.start_date_local.localeCompare(a.start_date_local)
+      );
+      windowEfforts = sorted.slice(0, resolved.count);
+    }
+
+    // Need at least 2 efforts in the window to make comparison meaningful
+    if (windowEfforts.length < 2) continue;
+
+    const bestInWindow = Math.min(...windowEfforts.map((e) => e.elapsed_time));
+    if (effort.elapsed_time === bestInWindow) {
+      const others = windowEfforts
+        .filter((e) => e.effort_id !== effort.id)
+        .sort((a, b) => a.elapsed_time - b.elapsed_time);
+      const previousBest = others.length > 0 ? others[0] : null;
+
+      awards.push({
+        type: "reference_best",
+        segment: segment.name,
+        segment_id: segment.id,
+        time: effort.elapsed_time,
+        power: effort.average_watts || null,
+        comparison: previousBest,
+        delta: previousBest ? previousBest.elapsed_time - effort.elapsed_time : null,
+        reference_label: resolved.label,
+        message: previousBest
+          ? `Best ${resolved.label} on ${segment.name}! ${formatTime(effort.elapsed_time)} (previous: ${formatTime(previousBest.elapsed_time)})`
+          : `Best ${resolved.label} on ${segment.name}! ${formatTime(effort.elapsed_time)}`,
+      });
+    }
+  }
+  return awards;
+}
+
+/**
  * Compute comeback context for a segment effort given an active reset event.
  * @param {Object} effort - Current segment effort
  * @param {Array} allEfforts - All efforts on this segment
@@ -259,7 +335,7 @@ function computeComebackContext(effort, allEfforts, resetEvent) {
  * @param {Object|null} resetEvent — Active reset event, if any
  * @returns {Array} — Array of award objects
  */
-export async function computeAwards(activity, resetEvent = null) {
+export async function computeAwards(activity, resetEvent = null, referencePoints = []) {
   if (!activity.segment_efforts || activity.segment_efforts.length === 0) {
     return [];
   }
@@ -666,6 +742,12 @@ export async function computeAwards(activity, resetEvent = null) {
       }
     }
 
+    // --- Reference Point Awards (user-defined "best since" comparisons) ---
+    if (referencePoints.length > 0 && !isHighVariance && allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
+      const refAwards = computeReferenceAwards(effort, allEfforts, segment, referencePoints);
+      awards.push(...refAwards);
+    }
+
     // --- Comeback Awards (#60) ---
     if (comebackCtx && comebackCtx.preInjuryBest != null) {
       const { preInjuryBest, recoveryRatio, postResetEfforts } = comebackCtx;
@@ -940,9 +1022,11 @@ export function computeRideLevelAwards(activity, allActivities, resetEvent = nul
  */
 export async function computeAwardsForActivities(activities) {
   const resetEvent = await getResetEvent();
+  const userConfig = await getUserConfig();
+  const referencePoints = userConfig.referencePoints || [];
   const result = new Map();
   for (const activity of activities) {
-    const segmentAwards = await computeAwards(activity, resetEvent);
+    const segmentAwards = await computeAwards(activity, resetEvent, referencePoints);
     const rideAwards = computeRideLevelAwards(activity, activities, resetEvent);
     const allAwards = [...segmentAwards, ...rideAwards];
 

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -7,7 +7,7 @@
 import { html } from "htm/preact";
 import { signal } from "@preact/signals";
 import { useEffect, useRef } from "preact/hooks";
-import { getActivity, getSegment, getAllActivities, getResetEvent } from "../db.js";
+import { getActivity, getSegment, getAllActivities, getResetEvent, getUserConfig } from "../db.js";
 import { computeAwards, computeRideLevelAwards } from "../awards.js";
 import { navigate } from "../app.js";
 import {
@@ -62,6 +62,7 @@ const AWARD_LABELS = {
   comeback_distance: { label: "Comeback Distance", color: "bg-rose-100 text-rose-800", icon: "→" },
   comeback_elevation: { label: "Comeback Climbing", color: "bg-rose-100 text-rose-800", icon: "⛰" },
   comeback_endurance: { label: "Comeback Endurance", color: "bg-rose-100 text-rose-800", icon: "⏱" },
+  reference_best: { label: "Reference Best", color: "bg-teal-200 text-teal-900", icon: "⊕" },
 };
 
 const AWARD_COLORS = {
@@ -92,6 +93,7 @@ const AWARD_COLORS = {
   comeback_distance:  { bg: "#FFE4E6", text: "#9F1239", accent: "#F43F5E" },
   comeback_elevation: { bg: "#FFE4E6", text: "#9F1239", accent: "#F43F5E" },
   comeback_endurance: { bg: "#FFE4E6", text: "#9F1239", accent: "#F43F5E" },
+  reference_best:     { bg: "#99F6E4", text: "#134E4A", accent: "#14B8A6" },
 };
 
 async function loadActivity(id) {
@@ -104,7 +106,9 @@ async function loadActivity(id) {
 
     if (act.has_efforts) {
       const resetEvent = await getResetEvent();
-      const segmentAwards = await computeAwards(act, resetEvent);
+      const userConfig = await getUserConfig();
+      const refPoints = userConfig.referencePoints || [];
+      const segmentAwards = await computeAwards(act, resetEvent, refPoints);
       const allActivities = await getAllActivities();
       const rideAwards = computeRideLevelAwards(act, allActivities, resetEvent);
       const awardsList = [...segmentAwards, ...rideAwards];

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -28,6 +28,8 @@ import {
   getResetEvent,
   setResetEvent,
   clearResetEvent,
+  getUserConfig,
+  setUserConfig,
 } from "../db.js";
 import { navigate } from "../app.js";
 import {
@@ -53,6 +55,14 @@ const activeResetEvent = signal(null);
 const showResetForm = signal(false);
 const resetName = signal("");
 const resetDate = signal("");
+const referencePoints = signal([]);
+const showRefForm = signal(false);
+const refType = signal("since_date");
+const refLabel = signal("");
+const refDate = signal("");
+const refCount = signal(10);
+const refBirthday = signal("");
+const refAge = signal(40);
 
 const AWARD_LABELS = {
   year_best: { label: "Year Best", color: "bg-yellow-100 text-yellow-800" },
@@ -82,6 +92,7 @@ const AWARD_LABELS = {
   comeback_distance: { label: "Comeback Distance", color: "bg-rose-100 text-rose-800" },
   comeback_elevation: { label: "Comeback Climbing", color: "bg-rose-100 text-rose-800" },
   comeback_endurance: { label: "Comeback Endurance", color: "bg-rose-100 text-rose-800" },
+  reference_best: { label: "Reference Best", color: "bg-teal-200 text-teal-900" },
 };
 
 async function loadDashboard() {
@@ -89,6 +100,8 @@ async function loadDashboard() {
   try {
     await loadUnitPreference();
     activeResetEvent.value = await getResetEvent();
+    const userConfig = await getUserConfig();
+    referencePoints.value = userConfig.referencePoints || [];
     const activities = await getAllActivities();
     // Sort by date descending, take recent 20
     activities.sort((a, b) => b.start_date_local.localeCompare(a.start_date_local));
@@ -349,7 +362,7 @@ export function Dashboard() {
               for (const a of awards) {
                 typeCounts.set(a.type, (typeCounts.get(a.type) || 0) + 1);
               }
-              const typeOrder = ["season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
+              const typeOrder = ["season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "reference_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
               const summary = typeOrder
                 .filter((t) => typeCounts.has(t))
                 .map((t) => ({ type: t, count: typeCounts.get(t) }));
@@ -491,6 +504,10 @@ export function Dashboard() {
                     <span class="text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-800 whitespace-nowrap mt-0.5">Longest by Time</span>
                     <span>Longest ride by moving time this year — your biggest endurance effort.</span>
                   </div>
+                  <div class="flex items-start gap-2">
+                    <span class="text-xs px-2 py-0.5 rounded-full bg-teal-200 text-teal-900 whitespace-nowrap mt-0.5">Reference Best</span>
+                    <span>Best effort within a user-defined window — since a date, in last N rides, or since turning an age. Configure in settings below.</span>
+                  </div>
                 </div>
               </details>
 
@@ -620,6 +637,167 @@ export function Dashboard() {
                     </button>
                     <p class="text-xs text-gray-300 mt-1">Awards will adjust to celebrate your recovery progress instead of comparing to pre-injury bests.</p>
                   `}
+                `}
+              </div>
+            </div>
+
+            <div class="mt-4 pt-4 border-t border-gray-100 space-y-3">
+              <!-- Reference Points Settings -->
+              <div>
+                <p class="text-xs font-medium text-gray-600 mb-1.5">Reference Points</p>
+                <p class="text-xs text-gray-400 mb-2">Custom "best since" awards — compare your efforts within a personal time window.</p>
+
+                ${referencePoints.value.length > 0 && html`
+                  <div class="space-y-1.5 mb-2">
+                    ${referencePoints.value.map((rp) => html`
+                      <div key=${rp.id} class="flex items-center justify-between bg-teal-50 rounded-lg px-3 py-2">
+                        <div>
+                          <p class="text-xs font-medium text-teal-800">${rp.label}</p>
+                          <p class="text-xs text-teal-600">
+                            ${rp.type === "since_date" ? `Since ${new Date(rp.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}` : ""}
+                            ${rp.type === "last_n" ? `Last ${rp.count} rides` : ""}
+                            ${rp.type === "since_age" ? `Since turning ${rp.age} (${new Date(rp.birthday).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })})` : ""}
+                          </p>
+                        </div>
+                        <button
+                          onClick=${async () => {
+                            const updated = referencePoints.value.filter((r) => r.id !== rp.id);
+                            referencePoints.value = updated;
+                            await setUserConfig({ referencePoints: updated });
+                            await loadDashboard();
+                          }}
+                          class="text-xs text-teal-400 hover:text-teal-600 px-2 py-1 rounded transition-colors"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    `)}
+                  </div>
+                `}
+
+                ${showRefForm.value ? html`
+                  <div class="bg-gray-50 rounded-lg p-3 space-y-2">
+                    <select
+                      value=${refType.value}
+                      onChange=${(e) => {
+                        refType.value = e.target.value;
+                        // Set default labels
+                        if (e.target.value === "since_date") refLabel.value = "";
+                        if (e.target.value === "last_n") refLabel.value = "last " + refCount.value + " rides";
+                        if (e.target.value === "since_age") refLabel.value = "";
+                      }}
+                      class="w-full text-xs border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-teal-400 bg-white"
+                    >
+                      <option value="since_date">Best since date</option>
+                      <option value="last_n">Best in last N rides</option>
+                      <option value="since_age">Best since turning age</option>
+                    </select>
+
+                    <input
+                      type="text"
+                      placeholder=${refType.value === "since_date" ? "Label (e.g. Since new bike)" : refType.value === "last_n" ? "Label (e.g. Last 10 rides)" : "Label (e.g. Since turning 40)"}
+                      value=${refLabel.value}
+                      onInput=${(e) => { refLabel.value = e.target.value; }}
+                      class="w-full text-xs border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-teal-400"
+                    />
+
+                    ${refType.value === "since_date" && html`
+                      <input
+                        type="date"
+                        value=${refDate.value}
+                        onInput=${(e) => { refDate.value = e.target.value; }}
+                        class="w-full text-xs border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-teal-400"
+                      />
+                    `}
+
+                    ${refType.value === "last_n" && html`
+                      <div class="flex items-center gap-2">
+                        <input
+                          type="number"
+                          min="2"
+                          max="100"
+                          value=${refCount.value}
+                          onInput=${(e) => { refCount.value = parseInt(e.target.value) || 10; }}
+                          class="w-20 text-xs border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-teal-400"
+                        />
+                        <span class="text-xs text-gray-500">rides per segment</span>
+                      </div>
+                    `}
+
+                    ${refType.value === "since_age" && html`
+                      <div class="space-y-2">
+                        <div>
+                          <label class="text-xs text-gray-500 block mb-0.5">Birthday</label>
+                          <input
+                            type="date"
+                            value=${refBirthday.value}
+                            onInput=${(e) => { refBirthday.value = e.target.value; }}
+                            class="w-full text-xs border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-teal-400"
+                          />
+                        </div>
+                        <div class="flex items-center gap-2">
+                          <label class="text-xs text-gray-500">Age</label>
+                          <input
+                            type="number"
+                            min="1"
+                            max="120"
+                            value=${refAge.value}
+                            onInput=${(e) => { refAge.value = parseInt(e.target.value) || 40; }}
+                            class="w-20 text-xs border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-teal-400"
+                          />
+                        </div>
+                      </div>
+                    `}
+
+                    <div class="flex gap-2">
+                      <button
+                        onClick=${async () => {
+                          const label = refLabel.value.trim();
+                          if (!label) return;
+                          const rp = { id: Date.now().toString(), type: refType.value, label };
+                          if (refType.value === "since_date") {
+                            if (!refDate.value) return;
+                            rp.date = refDate.value;
+                          } else if (refType.value === "last_n") {
+                            rp.count = refCount.value;
+                          } else if (refType.value === "since_age") {
+                            if (!refBirthday.value || !refAge.value) return;
+                            rp.birthday = refBirthday.value;
+                            rp.age = refAge.value;
+                          }
+                          const updated = [...referencePoints.value, rp];
+                          referencePoints.value = updated;
+                          await setUserConfig({ referencePoints: updated });
+                          showRefForm.value = false;
+                          refLabel.value = "";
+                          refDate.value = "";
+                          refType.value = "since_date";
+                          await loadDashboard();
+                        }}
+                        disabled=${!refLabel.value.trim() || (refType.value === "since_date" && !refDate.value) || (refType.value === "since_age" && (!refBirthday.value || !refAge.value))}
+                        class="text-xs px-3 py-1.5 rounded font-medium transition-colors ${
+                          refLabel.value.trim() && (refType.value !== "since_date" || refDate.value) && (refType.value !== "since_age" || (refBirthday.value && refAge.value))
+                            ? "bg-teal-600 text-white hover:bg-teal-700"
+                            : "bg-gray-200 text-gray-400 cursor-not-allowed"
+                        }"
+                      >
+                        Add reference point
+                      </button>
+                      <button
+                        onClick=${() => { showRefForm.value = false; refLabel.value = ""; refDate.value = ""; refType.value = "since_date"; }}
+                        class="text-xs px-3 py-1.5 rounded text-gray-500 hover:text-gray-700 transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ` : html`
+                  <button
+                    onClick=${() => { showRefForm.value = true; }}
+                    class="text-xs text-gray-400 hover:text-teal-500 transition-colors"
+                  >
+                    Add a reference point
+                  </button>
                 `}
               </div>
             </div>

--- a/src/db.js
+++ b/src/db.js
@@ -274,6 +274,33 @@ export async function recordRecoveryMilestone(segmentId, threshold) {
   }
 }
 
+// --- User Config (Reference Points) ---
+
+/**
+ * Get user configuration (reference points for custom awards).
+ * Stored in sync_state under "user_config" key.
+ * Shape: { referencePoints: Array<{ id, type, label, date?, count?, birthday?, age? }> }
+ */
+export async function getUserConfig() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("sync_state", "readonly");
+    const req = tx.objectStore("sync_state").get("user_config");
+    req.onsuccess = () => resolve(req.result || { referencePoints: [] });
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function setUserConfig(config) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("sync_state", "readwrite");
+    tx.objectStore("sync_state").put(config, "user_config");
+    tx.oncomplete = () => resolve(config);
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
 // --- Sync State ---
 
 const DEFAULT_SYNC_STATE = {


### PR DESCRIPTION
Add settings UI for configuring personal reference points that generate
custom awards: "Best since [date]", "Best in last N rides", and
"Best since turning [age]". Reference points are stored in IndexedDB
and integrated into the awards engine as `reference_best` award type.

Closes #27 (user configuration requirement)

https://claude.ai/code/session_01AUb2jfR9ni9av7QS2MwqpM