### PR TITLE
feat: add power fields to IndexedDB schema + sync engine (#44)

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -5,7 +5,7 @@
  */
 
 const DB_NAME = "participation-awards";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 let dbPromise = null;
 
@@ -16,6 +16,7 @@ export function openDB() {
 
     request.onupgradeneeded = (event) => {
       const db = event.target.result;
+      const oldVersion = event.oldVersion;
 
       if (!db.objectStoreNames.contains("auth")) {
         db.createObjectStore("auth");
@@ -25,6 +26,8 @@ export function openDB() {
         const activities = db.createObjectStore("activities", { keyPath: "id" });
         activities.createIndex("start_date_local", "start_date_local");
         activities.createIndex("sport_type", "sport_type");
+        activities.createIndex("device_watts", "device_watts");
+        activities.createIndex("trainer", "trainer");
       }
 
       if (!db.objectStoreNames.contains("segments")) {
@@ -34,6 +37,18 @@ export function openDB() {
 
       if (!db.objectStoreNames.contains("sync_state")) {
         db.createObjectStore("sync_state");
+      }
+
+      // Migration from v1 → v2: add power indexes to existing activities store
+      if (oldVersion < 2 && db.objectStoreNames.contains("activities")) {
+        const activitiesTx = event.target.transaction;
+        const activities = activitiesTx.objectStore("activities");
+        if (!activities.indexNames.contains("device_watts")) {
+          activities.createIndex("device_watts", "device_watts");
+        }
+        if (!activities.indexNames.contains("trainer")) {
+          activities.createIndex("trainer", "trainer");
+        }
       }
     };
 
@@ -133,6 +148,23 @@ export async function getActivitiesWithoutEfforts() {
       const results = req.result.filter((a) => !a.has_efforts);
       // Sort by start_date descending (newest first)
       results.sort((a, b) => b.start_date_local.localeCompare(a.start_date_local));
+      resolve(results);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Get activities that were stored before power fields were tracked.
+ * These lack the device_watts property entirely (not just false).
+ */
+export async function getActivitiesWithoutPower() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("activities", "readonly");
+    const req = tx.objectStore("activities").getAll();
+    req.onsuccess = () => {
+      const results = req.result.filter((a) => !("device_watts" in a));
       resolve(results);
     };
     req.onerror = () => reject(req.error);
@@ -284,6 +316,7 @@ const DEFAULT_SYNC_STATE = {
   fetched_activities: 0,
   detailed_activities: 0,
   last_sync: null,
+  power_backfill_complete: false,
 };
 
 export async function getSyncState() {

--- a/src/sync.js
+++ b/src/sync.js
@@ -10,6 +10,7 @@ import {
   putActivities,
   putActivity,
   getActivitiesWithoutEfforts,
+  getActivitiesWithoutPower,
   getSyncState,
   updateSyncState,
   appendEffort,
@@ -149,6 +150,7 @@ async function fetchActivityList() {
       weighted_average_watts: a.weighted_average_watts || null,
       device_watts: a.device_watts || false,
       kilojoules: a.kilojoules || null,
+      trainer: a.trainer || false,
       has_efforts: false,
       segment_efforts: [],
     }));
@@ -249,6 +251,7 @@ async function fetchActivityDetails() {
         weighted_average_watts: full.weighted_average_watts || activity.weighted_average_watts || null,
         device_watts: full.device_watts || activity.device_watts || false,
         kilojoules: full.kilojoules || activity.kilojoules || null,
+        trainer: full.trainer || activity.trainer || false,
       };
 
       await putActivity(updated);
@@ -317,6 +320,84 @@ async function fetchActivityDetails() {
   return detailed;
 }
 
+// --- Phase 3: Power Fields Backfill ---
+
+/**
+ * Backfill power fields for activities stored before power tracking.
+ * Re-fetches the activity list (200/page) which includes power fields,
+ * then merges them into existing records. Only runs once.
+ */
+async function backfillPowerFields() {
+  const state = await getSyncState();
+  if (state.power_backfill_complete) return;
+
+  const legacy = await getActivitiesWithoutPower();
+  if (legacy.length === 0) {
+    await updateSyncState({ power_backfill_complete: true });
+    return;
+  }
+
+  syncProgress.value = {
+    ...syncProgress.value,
+    phase: "list",
+    message: `Backfilling power data for ${legacy.length} activities...`,
+  };
+
+  // Build a lookup of legacy activity IDs for fast matching
+  const legacyIds = new Set(legacy.map((a) => a.id));
+  let page = 1;
+  let updated = 0;
+
+  while (true) {
+    if (isRateLimited()) break;
+
+    const params = new URLSearchParams({
+      per_page: String(PAGE_SIZE),
+      page: String(page),
+      after: "0",
+    });
+
+    const activities = await stravaFetch(`/athlete/activities?${params}`);
+    if (activities.length === 0) break;
+
+    const patches = [];
+    for (const a of activities) {
+      if (legacyIds.has(a.id)) {
+        // Find existing record and merge power fields
+        const existing = legacy.find((l) => l.id === a.id);
+        patches.push({
+          ...existing,
+          average_watts: a.average_watts || null,
+          max_watts: a.max_watts || null,
+          weighted_average_watts: a.weighted_average_watts || null,
+          device_watts: a.device_watts || false,
+          kilojoules: a.kilojoules || null,
+          trainer: a.trainer || false,
+        });
+        legacyIds.delete(a.id);
+      }
+    }
+
+    if (patches.length > 0) {
+      await putActivities(patches);
+      updated += patches.length;
+    }
+
+    syncProgress.value = {
+      ...syncProgress.value,
+      message: `Backfilling power data: ${updated}/${legacy.length}...`,
+    };
+
+    page++;
+    if (activities.length < PAGE_SIZE) break;
+    if (legacyIds.size === 0) break;
+  }
+
+  if (legacyIds.size === 0) {
+    await updateSyncState({ power_backfill_complete: true });
+  }
+}
+
 // --- Public API ---
 
 /**
@@ -338,6 +419,7 @@ export async function startBackfill() {
     };
 
     await fetchActivityList();
+    await backfillPowerFields();
     const detailed = await fetchActivityDetails();
 
     const remaining = await getActivitiesWithoutEfforts();


### PR DESCRIPTION
- Bump DB to v2 with device_watts and trainer indexes on activities store
- Migrate v1→v2: add indexes to existing activities store
- Capture all 6 power fields in activity list sync: average_watts,
  max_watts, weighted_average_watts, device_watts, kilojoules, trainer
- Update detail fetch to merge trainer field alongside other power fields
- Add backfillPowerFields() for existing activities missing power data
- Add getActivitiesWithoutPower() query for migration detection
- Track power_backfill_complete in sync_state

https://claude.ai/code/session_01PzuoAw585Jdn7c51AQTHYg