### PR TITLE
feat: migrate power backfill to reset-and-refetch strategy (#53)

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -344,6 +344,7 @@ const DEFAULT_SYNC_STATE = {
   detailed_activities: 0,
   last_sync: null,
   power_backfill_complete: false,
+  schema_version: 0,
 };
 
 export async function getSyncState() {

--- a/src/sync.js
+++ b/src/sync.js
@@ -320,82 +320,39 @@ async function fetchActivityDetails() {
   return detailed;
 }
 
-// --- Phase 3: Power Fields Backfill ---
+// --- Phase 3: Power Fields Migration ---
 
 /**
- * Backfill power fields for activities stored before power tracking.
- * Re-fetches the activity list (200/page) which includes power fields,
- * then merges them into existing records. Only runs once.
+ * One-time migration for activities stored before power tracking (pre-486be78).
+ * Instead of re-fetching from the list API, resets has_efforts on legacy
+ * activities so the detail fetch pipeline re-processes them — capturing
+ * both activity-level AND segment-effort-level power fields.
+ * Triggered when schema_version is missing or below 2.
  */
-async function backfillPowerFields() {
+async function runPowerMigration() {
   const state = await getSyncState();
-  if (state.power_backfill_complete) return;
+  if (state.schema_version >= 2) return;
 
   const legacy = await getActivitiesWithoutPower();
-  if (legacy.length === 0) {
-    await updateSyncState({ power_backfill_complete: true });
+  // Only consider activities that already had details fetched
+  const needsRefetch = legacy.filter((a) => a.has_efforts);
+
+  if (needsRefetch.length === 0) {
+    await updateSyncState({ schema_version: 2, power_backfill_complete: true });
     return;
   }
 
   syncProgress.value = {
     ...syncProgress.value,
-    phase: "list",
-    message: `Backfilling power data for ${legacy.length} activities...`,
+    phase: "detail",
+    message: `Migrating ${needsRefetch.length} activities for power data...`,
   };
 
-  // Build a lookup of legacy activity IDs for fast matching
-  const legacyIds = new Set(legacy.map((a) => a.id));
-  let page = 1;
-  let updated = 0;
+  // Reset has_efforts so fetchActivityDetails() will re-fetch them
+  const reset = needsRefetch.map((a) => ({ ...a, has_efforts: false }));
+  await putActivities(reset);
 
-  while (true) {
-    if (isRateLimited()) break;
-
-    const params = new URLSearchParams({
-      per_page: String(PAGE_SIZE),
-      page: String(page),
-      after: "0",
-    });
-
-    const activities = await stravaFetch(`/athlete/activities?${params}`);
-    if (activities.length === 0) break;
-
-    const patches = [];
-    for (const a of activities) {
-      if (legacyIds.has(a.id)) {
-        // Find existing record and merge power fields
-        const existing = legacy.find((l) => l.id === a.id);
-        patches.push({
-          ...existing,
-          average_watts: a.average_watts || null,
-          max_watts: a.max_watts || null,
-          weighted_average_watts: a.weighted_average_watts || null,
-          device_watts: a.device_watts || false,
-          kilojoules: a.kilojoules || null,
-          trainer: a.trainer || false,
-        });
-        legacyIds.delete(a.id);
-      }
-    }
-
-    if (patches.length > 0) {
-      await putActivities(patches);
-      updated += patches.length;
-    }
-
-    syncProgress.value = {
-      ...syncProgress.value,
-      message: `Backfilling power data: ${updated}/${legacy.length}...`,
-    };
-
-    page++;
-    if (activities.length < PAGE_SIZE) break;
-    if (legacyIds.size === 0) break;
-  }
-
-  if (legacyIds.size === 0) {
-    await updateSyncState({ power_backfill_complete: true });
-  }
+  await updateSyncState({ schema_version: 2, power_backfill_complete: true });
 }
 
 // --- Public API ---
@@ -419,7 +376,7 @@ export async function startBackfill() {
     };
 
     await fetchActivityList();
-    await backfillPowerFields();
+    await runPowerMigration();
     const detailed = await fetchActivityDetails();
 
     const remaining = await getActivitiesWithoutEfforts();


### PR DESCRIPTION
Replace the list-API-based power backfill with a one-time migration that
resets has_efforts on legacy activities (pre-486be78) so the existing
detail fetch pipeline re-processes them — capturing both activity-level
AND segment-effort-level power fields. Uses schema_version in sync_state
to ensure the migration runs only once.

https://claude.ai/code/session_01MwSgazKKgVXiFCBhrd3b6H