### PR TITLE
feat: add activity-level power awards engine (#45)

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -33,6 +33,15 @@
  *   - Endurance Record: Longest moving time this year (#31)
  *   - Comeback Distance/Elevation/Endurance: Post-reset records (#60)
  *
+ * Activity-level power awards (Phase 1, #45):
+ *   - Season First Power: First power-metered ride of the year
+ *   - NP Year Best: Year's highest normalized power (weighted avg watts)
+ *   - NP Recent Best: Best NP among last 5 powered rides
+ *   - Work Year Best: Highest kilojoules in a single ride this year
+ *   - Work Recent Best: Best work output among last 5 powered rides
+ *   - Peak Power: Highest max watts recorded this year
+ *   - Peak Power Recent: Best peak power among last 5 powered rides
+ *
  * Data quality rules:
  *   - Minimum effort threshold: comparative awards (Year Best, Recent Best,
  *     Beat Median, Top Quartile, Monthly Best, YTD Best) require ≥3 total efforts.
@@ -863,6 +872,35 @@ export function computeRideLevelAwards(activity, allActivities, resetEvent = nul
       a.id !== activity.id
   );
 
+  // --- Season First Power (exempt from min-activity gate, like season_first) ---
+  if (activity.device_watts && activity.weighted_average_watts > 0) {
+    const poweredSameTypeThisYear = sameTypeThisYear.filter(
+      (a) => a.device_watts && a.weighted_average_watts > 0
+    );
+    if (poweredSameTypeThisYear.length === 0) {
+      const priorYearsPowered = allActivities.filter(
+        (a) =>
+          a.sport_type === activity.sport_type &&
+          a.device_watts &&
+          a.weighted_average_watts > 0 &&
+          new Date(a.start_date_local).getFullYear() < currentYear
+      );
+      const label = activity.sport_type === "Ride" ? "ride" : "activity";
+      awards.push({
+        type: "season_first_power",
+        segment: null,
+        segment_id: null,
+        time: null,
+        power: activity.weighted_average_watts,
+        comparison: null,
+        delta: null,
+        message: priorYearsPowered.length > 0
+          ? `First power-metered ${label} of the year! Welcome back to the pain cave — ${Math.round(activity.weighted_average_watts)}W NP`
+          : `First power-metered ${label} of the year! ${Math.round(activity.weighted_average_watts)}W NP`,
+      });
+    }
+  }
+
   // Need at least 5 prior activities this year to make records meaningful
   if (sameTypeThisYear.length < 5) return awards;
 
@@ -937,6 +975,157 @@ export function computeRideLevelAwards(activity, allActivities, resetEvent = nul
         delta: null,
         message: `Longest ${label} by time this year! ${formatTime(activity.moving_time)} moving time`,
       });
+    }
+  }
+
+  // ── Activity-Level Power Awards (Phase 1, #45) ──────────────────
+  // All require device_watts === true (measured power, not estimated).
+  // Compared within same sport_type to respect different power profiles.
+  // (Season First Power is computed above, before the min-activity gate.)
+  if (activity.device_watts && activity.weighted_average_watts > 0) {
+    const poweredSameTypeThisYear = sameTypeThisYear.filter(
+      (a) => a.device_watts && a.weighted_average_watts > 0
+    );
+
+    // Power awards require 5+ prior powered activities (same threshold as other ride-level)
+    if (poweredSameTypeThisYear.length >= 5) {
+      const activityDate = new Date(activity.start_date_local);
+      const afterCalendarGate = (activityDate.getMonth() + 1) >= YEAR_BEST_CALENDAR_GATE_MONTH;
+
+      // --- NP Year Best ---
+      // Year's highest weighted average watts (normalized power)
+      if (afterCalendarGate) {
+        const maxPriorNP = Math.max(
+          ...poweredSameTypeThisYear.map((a) => a.weighted_average_watts)
+        );
+        if (activity.weighted_average_watts > maxPriorNP) {
+          awards.push({
+            type: "np_year_best",
+            segment: null,
+            segment_id: null,
+            time: null,
+            power: activity.weighted_average_watts,
+            comparison: null,
+            delta: Math.round(activity.weighted_average_watts - maxPriorNP),
+            message: `Year's best Normalized Power! ${Math.round(activity.weighted_average_watts)}W NP — ${Math.round(activity.weighted_average_watts - maxPriorNP)}W above previous best`,
+          });
+        }
+      }
+
+      // --- Work/Energy Year Best ---
+      // Highest kilojoules in a single ride this year
+      if (afterCalendarGate && activity.kilojoules > 0) {
+        const poweredWithKJ = poweredSameTypeThisYear.filter((a) => a.kilojoules > 0);
+        if (poweredWithKJ.length >= 5) {
+          const maxPriorKJ = Math.max(...poweredWithKJ.map((a) => a.kilojoules));
+          if (activity.kilojoules > maxPriorKJ) {
+            awards.push({
+              type: "work_year_best",
+              segment: null,
+              segment_id: null,
+              time: null,
+              power: activity.weighted_average_watts,
+              comparison: null,
+              delta: Math.round(activity.kilojoules - maxPriorKJ),
+              message: `Year's highest work output! ${Math.round(activity.kilojoules)} kJ — ${Math.round(activity.kilojoules - maxPriorKJ)} kJ above previous best`,
+            });
+          }
+        }
+      }
+
+      // --- Peak Power Year Best ---
+      // Highest max watts recorded this year
+      if (afterCalendarGate && activity.max_watts > 0) {
+        const poweredWithMax = poweredSameTypeThisYear.filter((a) => a.max_watts > 0);
+        if (poweredWithMax.length >= 5) {
+          const maxPriorPeak = Math.max(...poweredWithMax.map((a) => a.max_watts));
+          if (activity.max_watts > maxPriorPeak) {
+            awards.push({
+              type: "peak_power",
+              segment: null,
+              segment_id: null,
+              time: null,
+              power: activity.max_watts,
+              comparison: null,
+              delta: activity.max_watts - maxPriorPeak,
+              message: `Year's highest peak power! ${activity.max_watts}W — ${activity.max_watts - maxPriorPeak}W above previous best`,
+            });
+          }
+        }
+      }
+    }
+
+    // --- NP Recent Best ---
+    // Best normalized power among last 5 powered rides (same sport type)
+    const allPoweredSameType = allActivities
+      .filter(
+        (a) =>
+          a.sport_type === activity.sport_type &&
+          a.device_watts &&
+          a.weighted_average_watts > 0 &&
+          a.id !== activity.id
+      )
+      .sort((a, b) => b.start_date_local.localeCompare(a.start_date_local));
+    const recentPowered = allPoweredSameType.slice(0, 4); // last 4 others + this = 5
+
+    if (recentPowered.length >= 3) {
+      const bestRecentNP = Math.max(...recentPowered.map((a) => a.weighted_average_watts));
+      if (activity.weighted_average_watts > bestRecentNP) {
+        awards.push({
+          type: "np_recent_best",
+          segment: null,
+          segment_id: null,
+          time: null,
+          power: activity.weighted_average_watts,
+          comparison: null,
+          delta: Math.round(activity.weighted_average_watts - bestRecentNP),
+          message: `Best NP of your last ${recentPowered.length + 1} powered ${activity.sport_type === "Ride" ? "rides" : "activities"}! ${Math.round(activity.weighted_average_watts)}W`,
+        });
+      }
+    }
+
+    // --- Work/Energy Recent Best ---
+    if (activity.kilojoules > 0) {
+      const recentWithKJ = allPoweredSameType
+        .filter((a) => a.kilojoules > 0)
+        .slice(0, 4);
+      if (recentWithKJ.length >= 3) {
+        const bestRecentKJ = Math.max(...recentWithKJ.map((a) => a.kilojoules));
+        if (activity.kilojoules > bestRecentKJ) {
+          awards.push({
+            type: "work_recent_best",
+            segment: null,
+            segment_id: null,
+            time: null,
+            power: activity.weighted_average_watts,
+            comparison: null,
+            delta: Math.round(activity.kilojoules - bestRecentKJ),
+            message: `Best work output of your last ${recentWithKJ.length + 1} powered ${activity.sport_type === "Ride" ? "rides" : "activities"}! ${Math.round(activity.kilojoules)} kJ`,
+          });
+        }
+      }
+    }
+
+    // --- Peak Power Recent Best ---
+    if (activity.max_watts > 0) {
+      const recentWithMax = allPoweredSameType
+        .filter((a) => a.max_watts > 0)
+        .slice(0, 4);
+      if (recentWithMax.length >= 3) {
+        const bestRecentPeak = Math.max(...recentWithMax.map((a) => a.max_watts));
+        if (activity.max_watts > bestRecentPeak) {
+          awards.push({
+            type: "peak_power_recent",
+            segment: null,
+            segment_id: null,
+            time: null,
+            power: activity.max_watts,
+            comparison: null,
+            delta: activity.max_watts - bestRecentPeak,
+            message: `Best peak power of your last ${recentWithMax.length + 1} powered ${activity.sport_type === "Ride" ? "rides" : "activities"}! ${activity.max_watts}W`,
+          });
+        }
+      }
     }
   }
 

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -63,6 +63,14 @@ const AWARD_LABELS = {
   comeback_elevation: { label: "Comeback Climbing", color: "bg-rose-100 text-rose-800", icon: "⛰" },
   comeback_endurance: { label: "Comeback Endurance", color: "bg-rose-100 text-rose-800", icon: "⏱" },
   reference_best: { label: "Reference Best", color: "bg-teal-200 text-teal-900", icon: "⊕" },
+  // Activity-level power awards (#45)
+  season_first_power: { label: "First Power Ride", color: "bg-green-200 text-green-900", icon: "⚡" },
+  np_year_best: { label: "NP Year Best", color: "bg-red-200 text-red-900", icon: "⚡" },
+  np_recent_best: { label: "NP Recent Best", color: "bg-red-100 text-red-800", icon: "⚡" },
+  work_year_best: { label: "Work Year Best", color: "bg-orange-200 text-orange-900", icon: "⊙" },
+  work_recent_best: { label: "Work Recent Best", color: "bg-orange-100 text-orange-800", icon: "⊙" },
+  peak_power: { label: "Peak Power", color: "bg-yellow-200 text-yellow-900", icon: "⚡" },
+  peak_power_recent: { label: "Peak Recent", color: "bg-yellow-100 text-yellow-800", icon: "⚡" },
 };
 
 const AWARD_COLORS = {
@@ -94,6 +102,14 @@ const AWARD_COLORS = {
   comeback_elevation: { bg: "#FFE4E6", text: "#9F1239", accent: "#F43F5E" },
   comeback_endurance: { bg: "#FFE4E6", text: "#9F1239", accent: "#F43F5E" },
   reference_best:     { bg: "#99F6E4", text: "#134E4A", accent: "#14B8A6" },
+  // Activity-level power awards (#45)
+  season_first_power: { bg: "#BBF7D0", text: "#14532D", accent: "#16A34A" },
+  np_year_best:       { bg: "#FECACA", text: "#7F1D1D", accent: "#DC2626" },
+  np_recent_best:     { bg: "#FEE2E2", text: "#991B1B", accent: "#EF4444" },
+  work_year_best:     { bg: "#FED7AA", text: "#7C2D12", accent: "#EA580C" },
+  work_recent_best:   { bg: "#FFEDD5", text: "#9A3412", accent: "#F97316" },
+  peak_power:         { bg: "#FDE68A", text: "#78350F", accent: "#D97706" },
+  peak_power_recent:  { bg: "#FEF9C3", text: "#854D0E", accent: "#EAB308" },
 };
 
 async function loadActivity(id) {

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -93,6 +93,14 @@ const AWARD_LABELS = {
   comeback_elevation: { label: "Comeback Climbing", color: "bg-rose-100 text-rose-800" },
   comeback_endurance: { label: "Comeback Endurance", color: "bg-rose-100 text-rose-800" },
   reference_best: { label: "Reference Best", color: "bg-teal-200 text-teal-900" },
+  // Activity-level power awards (#45)
+  season_first_power: { label: "First Power Ride", color: "bg-green-200 text-green-900" },
+  np_year_best: { label: "NP Year Best", color: "bg-red-200 text-red-900" },
+  np_recent_best: { label: "NP Recent Best", color: "bg-red-100 text-red-800" },
+  work_year_best: { label: "Work Year Best", color: "bg-orange-200 text-orange-900" },
+  work_recent_best: { label: "Work Recent Best", color: "bg-orange-100 text-orange-800" },
+  peak_power: { label: "Peak Power", color: "bg-yellow-200 text-yellow-900" },
+  peak_power_recent: { label: "Peak Recent", color: "bg-yellow-100 text-yellow-800" },
 };
 
 async function loadDashboard() {

--- a/src/icons.js
+++ b/src/icons.js
@@ -280,6 +280,28 @@ const ICON_DEFS = {
     { type: "polygon", points: [[4,20],[3,22],[5,22]] },                  // small bolt at origin
   ],
 
+  // 🌱⚡ Season First Power — sprouting seedling with bolt
+  season_first_power: [
+    { type: "path", d: "M12 22V12" },
+    { type: "path", d: "M8 8c0-3 4-6 4-6s4 3 4 6c0 2.5-1.8 4-4 4S8 10.5 8 8z" },
+    { type: "polygon", points: [[19,3],[16,8],[18,8],[17,11],[20,6],[18,6]], strokeWidth: 0.8 },
+  ],
+
+  // ↗⊙ Work Recent Best — gauge with trend arrow
+  work_recent_best: [
+    { type: "circle", cx: 12, cy: 13, r: 9 },
+    { type: "path", d: "M12 13L16 8" },                                   // needle
+    { type: "circle", cx: 12, cy: 13, r: 1.5 },
+    { type: "polyline", points: [[16,5],[22,5],[22,11]] },                 // trend corner
+  ],
+
+  // ⚡↗ Peak Power Recent — bolt with trend
+  peak_power_recent: [
+    { type: "polygon", points: [[11,2],[3,12],[10,12],[9,19],[17,9],[10,9]] },  // bolt
+    { type: "polyline", points: [[17,4],[22,4],[22,9]] },                        // trend corner
+    { type: "line", x1: 22, y1: 4, x2: 17, y2: 9 },                           // trend diagonal
+  ],
+
   // ≡W Power Consistency — steady watt lines (low variance)
   power_consistency: [
     { type: "path", d: "M2 10c2-1 4-1 6 0s4 1 6 0 4-1 6 0" },           // gentle wave

--- a/test/harness.py
+++ b/test/harness.py
@@ -6,7 +6,7 @@ Generates realistic Strava mock data with deterministic scenarios that
 guarantee every award type fires. Serves the app locally, injects data
 into IndexedDB via Playwright, runs an awards audit, and takes screenshots.
 
-Award coverage (26 types):
+Award coverage (33 types):
   Segment-level: year_best, season_first, recent_best, beat_median,
     top_quartile, top_decile, consistency, monthly_best, improvement_streak,
     comeback, milestone, best_month_ever, closing_in, anniversary,
@@ -14,6 +14,8 @@ Award coverage (26 types):
   Comeback: comeback_pb, recovery_milestone, comeback_full
   Ride-level: distance_record, elevation_record, segment_count,
     endurance_record, comeback_distance, comeback_elevation, comeback_endurance
+  Power (#45): season_first_power, np_year_best, np_recent_best,
+    work_year_best, work_recent_best, peak_power, peak_power_recent
 
 Data quality rules tested:
   - Min 3 efforts gate
@@ -179,6 +181,19 @@ def make_ride(dt, efforts_data, seg_efforts_store, name=None, extra_dist=0,
         act["average_watts"] = avg_watts or int(sum(
             e.get("average_watts", 0) for e in efforts if e.get("average_watts")
         ) / max(1, sum(1 for e in efforts if e.get("average_watts"))))
+        # Normalized Power is typically ~5-10% above average watts
+        act["weighted_average_watts"] = int(act["average_watts"] * random.uniform(1.04, 1.12))
+        # Max watts: sprint peaks, typically 2-4x average
+        act["max_watts"] = int(act["average_watts"] * random.uniform(2.0, 3.5))
+        # Kilojoules ≈ average_watts * moving_time_hours * 3.6
+        act["kilojoules"] = round(act["average_watts"] * act["moving_time"] / 1000 * random.uniform(0.95, 1.05), 1)
+    else:
+        act["device_watts"] = False
+        act["average_watts"] = None
+        act["weighted_average_watts"] = None
+        act["max_watts"] = None
+        act["kilojoules"] = None
+    act["trainer"] = False
     return act, aid
 
 
@@ -340,6 +355,57 @@ def generate_mock_data(seed=42):
                            device_watts=True, avg_watts=watts)
         activities.append(act)
 
+    # --- Scenario E: Power Awards (#45) ---
+    # Need 5+ powered activities same sport/year for year-best awards.
+    # Random history already provides many powered rides; add explicit
+    # March 2026 powered rides with escalating NP/kJ/peak to guarantee awards.
+    # First, ensure a strong recent-best baseline via 4 powered rides.
+    power_baseline = [
+        (datetime(2026, 3, 1, 8, 0),  200, 500, 350),   # NP, kJ, peak
+        (datetime(2026, 3, 2, 8, 0),  210, 520, 360),
+        (datetime(2026, 3, 3, 8, 0),  205, 510, 355),
+        (datetime(2026, 3, 4, 8, 0),  215, 530, 365),
+    ]
+    for dt, np_w, kj, peak in power_baseline:
+        avg_w = int(np_w / 1.08)
+        act, _ = make_ride(dt,
+            [(seg_by_id(100002), 88, True, avg_w), (seg_by_id(100006), 63, True, avg_w)],
+            seg_efforts, name="Power Baseline",
+            device_watts=True, avg_watts=avg_w)
+        # Override computed power fields with deterministic values
+        act["weighted_average_watts"] = np_w
+        act["kilojoules"] = kj
+        act["max_watts"] = peak
+        activities.append(act)
+
+    # Season First Power: first powered GravelRide of 2026
+    # (Random history only generates "Ride" sport_type, so GravelRide is clean)
+    dt_sfp = datetime(2026, 3, 5, 9, 0)
+    act_sfp, _ = make_ride(dt_sfp,
+        [(seg_by_id(100004), 370, True, 195)],
+        seg_efforts, name="Gravel Opener",
+        device_watts=True, avg_watts=195)
+    act_sfp["sport_type"] = "GravelRide"
+    act_sfp["weighted_average_watts"] = 210
+    act_sfp["kilojoules"] = 450
+    act_sfp["max_watts"] = 550
+    activities.append(act_sfp)
+
+    # The killer ride: beats all baselines + all random history
+    dt_power = datetime(2026, 3, 9, 7, 30)
+    act_power, _ = make_ride(dt_power,
+        [(seg_by_id(100001), int(seg_by_id(100001)["base_time"] * 0.88), True, 260),
+         (seg_by_id(100003), int(seg_by_id(100003)["base_time"] * 0.90), True, 255),
+         (seg_by_id(100005), int(seg_by_id(100005)["base_time"] * 0.87), True, 270)],
+        seg_efforts, name="Power PR Day",
+        extra_dist=35000, extra_time=5400, extra_elev=800,
+        device_watts=True, avg_watts=250)
+    # Set extreme power values to guarantee Year Best on all power categories
+    act_power["weighted_average_watts"] = 310  # above any baseline or random
+    act_power["kilojoules"] = 1800             # massive work output
+    act_power["max_watts"] = 900               # sprint peak
+    activities.append(act_power)
+
     # --- Scenario F: Closing In on PR (River Road 100001) ---
     rr_efforts = seg_efforts.get(100001, [])
     if rr_efforts:
@@ -487,7 +553,7 @@ INJECT_JS = """(async () => {
     const DB = "participation-awards";
     await new Promise(r => { const q = indexedDB.deleteDatabase(DB); q.onsuccess = r; q.onerror = r; });
     const db = await new Promise((res, rej) => {
-        const q = indexedDB.open(DB, 1);
+        const q = indexedDB.open(DB, 2);
         q.onupgradeneeded = e => {
             const d = e.target.result;
             if (!d.objectStoreNames.contains("auth")) d.createObjectStore("auth");
@@ -495,6 +561,8 @@ INJECT_JS = """(async () => {
                 const s = d.createObjectStore("activities", { keyPath: "id" });
                 s.createIndex("start_date_local", "start_date_local");
                 s.createIndex("sport_type", "sport_type");
+                s.createIndex("device_watts", "device_watts");
+                s.createIndex("trainer", "trainer");
             }
             if (!d.objectStoreNames.contains("segments")) {
                 const s = d.createObjectStore("segments", { keyPath: "id" });
@@ -572,6 +640,8 @@ AUDIT_JS = """(async () => {
         "distance_record", "elevation_record", "segment_count",
         "endurance_record",
         "comeback_distance", "comeback_elevation", "comeback_endurance",
+        "season_first_power", "np_year_best", "np_recent_best",
+        "work_year_best", "work_recent_best", "peak_power", "peak_power_recent",
     ];
 
     const found = Object.keys(typeCounts);


### PR DESCRIPTION
Implement Phase 1 power awards that recognize cycling achievements
based on power meter data from activity summaries. No additional
API calls required — uses existing weighted_average_watts, max_watts,
and kilojoules fields.

New award types (7):
- Season First Power: first power-metered ride of the year
- NP Year Best: year's highest normalized power
- NP Recent Best: best NP among last 5 powered rides
- Work Year Best: highest kilojoules in a ride this year
- Work Recent Best: best work output in last 5 powered rides
- Peak Power: highest max watts this year
- Peak Power Recent: best peak power in last 5 powered rides

All awards require device_watts === true (measured, not estimated)
and compare within same sport_type to respect different power
profiles (road vs gravel vs MTB).

Test harness updated with deterministic power scenarios and
realistic power fields (weighted_average_watts, max_watts, kilojoules)
on all powered activities. Audit validates 27/27 non-comeback award
types fire including all 7 new power awards.

https://claude.ai/code/session_01PnmQi7fsVMtsJ6VDbXE8zR