### PR TITLE
Add resync button to re-fetch individual activities from Strava (#57)

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -9,6 +9,8 @@ import { signal } from "@preact/signals";
 import { useEffect, useRef } from "preact/hooks";
 import { getActivity, getSegment, getAllActivities, getResetEvent, getUserConfig } from "../db.js";
 import { computeAwards, computeRideLevelAwards } from "../awards.js";
+import { resyncActivity } from "../sync.js";
+import { isDemo } from "../demo.js";
 import { navigate } from "../app.js";
 import {
   formatDistance,
@@ -25,6 +27,8 @@ const segmentHistory = signal(new Map());
 const loading = signal(true);
 const copied = signal(false);
 const cardGenerated = signal(false);
+const resyncing = signal(false);
+const resyncError = signal(null);
 
 function formatDateShort(isoString) {
   return new Date(isoString).toLocaleDateString("en-US", {
@@ -493,6 +497,20 @@ export function ActivityDetail({ id }) {
     URL.revokeObjectURL(url);
   }
 
+  async function handleResync() {
+    if (resyncing.value) return;
+    resyncing.value = true;
+    resyncError.value = null;
+    try {
+      await resyncActivity(Number(id));
+      await loadActivity(id);
+    } catch (err) {
+      resyncError.value = err.message || "Resync failed";
+    } finally {
+      resyncing.value = false;
+    }
+  }
+
   // Ride-level power display
   const ridePower = act.device_watts && act.average_watts ? formatPower(act.average_watts) : null;
 
@@ -503,7 +521,25 @@ export function ActivityDetail({ id }) {
           <button onClick=${() => navigate("dashboard")} class="text-sm text-blue-600 hover:underline mb-2 block">
             ← Back to dashboard
           </button>
-          <h1 class="text-xl font-bold text-gray-800">${act.name}</h1>
+          <div class="flex items-center justify-between gap-3">
+            <h1 class="text-xl font-bold text-gray-800">${act.name}</h1>
+            ${!isDemo.value && html`
+              <button
+                onClick=${handleResync}
+                disabled=${resyncing.value}
+                class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg border border-gray-200 text-gray-500 hover:bg-gray-50 hover:text-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                title="Re-fetch this activity from Strava"
+              >
+                <svg class="w-3.5 h-3.5 ${resyncing.value ? 'animate-spin' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+                </svg>
+                ${resyncing.value ? "Resyncing…" : "Resync"}
+              </button>
+            `}
+          </div>
+          ${resyncError.value && html`
+            <div class="mt-1 text-xs text-red-600">${resyncError.value}</div>
+          `}
           <p class="text-sm text-gray-500">
             ${formatDateFull(act.start_date_local)}
             · ${formatDistance(act.distance)}

--- a/src/db.js
+++ b/src/db.js
@@ -254,6 +254,37 @@ export async function appendEffort(segmentId, segmentData, effort) {
   });
 }
 
+/**
+ * Remove all efforts for a given activity from the segments store.
+ * Used before re-appending updated efforts during activity resync.
+ */
+export async function removeEffortsForActivity(activityId) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("segments", "readwrite");
+    const store = tx.objectStore("segments");
+    const req = store.openCursor();
+
+    req.onsuccess = () => {
+      const cursor = req.result;
+      if (cursor) {
+        const segment = cursor.value;
+        const before = segment.efforts.length;
+        segment.efforts = segment.efforts.filter(
+          (e) => e.activity_id !== activityId
+        );
+        if (segment.efforts.length !== before) {
+          cursor.update(segment);
+        }
+        cursor.continue();
+      }
+    };
+
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
 // --- Reset Event (Comeback Mode) ---
 
 /**

--- a/src/sync.js
+++ b/src/sync.js
@@ -9,11 +9,13 @@ import { getValidToken } from "./auth.js";
 import {
   putActivities,
   putActivity,
+  getActivity,
   getActivitiesWithoutEfforts,
   getActivitiesWithoutPower,
   getSyncState,
   updateSyncState,
   appendEffort,
+  removeEffortsForActivity,
 } from "./db.js";
 
 // --- Signals ---
@@ -456,4 +458,79 @@ export async function incrementalSync() {
   } finally {
     isSyncing.value = false;
   }
+}
+
+/**
+ * Resync a single activity from Strava.
+ * Re-fetches detail, updates IndexedDB, replaces segment efforts, returns updated activity.
+ */
+export async function resyncActivity(activityId) {
+  const existing = await getActivity(activityId);
+  if (!existing) throw new Error("Activity not found in local database");
+
+  const full = await stravaFetch(
+    `/activities/${activityId}?include_all_efforts=true`
+  );
+
+  const efforts = (full.segment_efforts || []).map((e) => ({
+    id: e.id,
+    name: e.name,
+    segment: {
+      id: e.segment.id,
+      name: e.segment.name,
+      distance: e.segment.distance,
+      average_grade: e.segment.average_grade,
+      elevation_high: e.segment.elevation_high,
+      elevation_low: e.segment.elevation_low,
+      climb_category: e.segment.climb_category,
+    },
+    elapsed_time: e.elapsed_time,
+    moving_time: e.moving_time,
+    start_date: e.start_date,
+    start_date_local: e.start_date_local,
+    pr_rank: e.pr_rank || null,
+    achievements: e.achievements || [],
+    average_watts: e.average_watts || null,
+    device_watts: e.device_watts || false,
+  }));
+
+  const updated = {
+    ...existing,
+    name: full.name,
+    sport_type: full.sport_type,
+    distance: full.distance,
+    moving_time: full.moving_time,
+    elapsed_time: full.elapsed_time,
+    total_elevation_gain: full.total_elevation_gain,
+    average_speed: full.average_speed,
+    max_speed: full.max_speed,
+    average_watts: full.average_watts || null,
+    max_watts: full.max_watts || null,
+    weighted_average_watts: full.weighted_average_watts || null,
+    device_watts: full.device_watts || false,
+    kilojoules: full.kilojoules || null,
+    trainer: full.trainer || false,
+    has_efforts: true,
+    segment_efforts: efforts,
+  };
+
+  await putActivity(updated);
+
+  // Remove old efforts from segments store, then re-append
+  await removeEffortsForActivity(activityId);
+  for (const effort of efforts) {
+    await appendEffort(effort.segment.id, effort.segment, {
+      effort_id: effort.id,
+      activity_id: activityId,
+      elapsed_time: effort.elapsed_time,
+      moving_time: effort.moving_time,
+      start_date: effort.start_date,
+      start_date_local: effort.start_date_local,
+      pr_rank: effort.pr_rank,
+      average_watts: effort.average_watts,
+      device_watts: effort.device_watts,
+    });
+  }
+
+  return updated;
 }


### PR DESCRIPTION
When an activity is updated in Strava after initial sync (renamed, segments
added/removed, gear changed), users can now click "Resync" on the activity
detail page to re-fetch it. This adds:

- db.js: removeEffortsForActivity() to clean old segment efforts before re-append
- sync.js: resyncActivity() to fetch detail, update activity, replace efforts
- ActivityDetail.js: Resync button with spinner state, error display, hidden in demo

Closes #57

https://claude.ai/code/session_01LNtMkA4efiHqUJdQzwp8Jg