### PR TITLE
Fix activity refresh showing Loading screen instead of staying on activity

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -131,7 +131,10 @@ const AWARD_COLORS = {
 };
 
 async function loadActivity(id) {
-  loading.value = true;
+  // Only show full loading screen on initial load, not on refresh/resync
+  if (!activity.value || activity.value.id !== Number(id)) {
+    loading.value = true;
+  }
   cardGenerated.value = false;
   try {
     const act = await getActivity(Number(id));


### PR DESCRIPTION
When resyncing an activity, loadActivity() was unconditionally setting
loading=true, which replaced the entire activity view with the
"Loading activity..." screen. Now only shows the loading screen on
initial load (when no activity is displayed yet), so resyncs keep
the activity visible with the spinner on the resync button.

https://claude.ai/code/session_01NQ6CRESFykECrKmGmxKDqE