### PR TITLE
feat: consolidate AWARD_LABELS (#74) and add segment award ranking (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,8 @@ Loads `demo-data.json` into IndexedDB with a fake auth session (athlete ID 99999
 
 **Add a new award type:**
 1. Add computation logic in `awards.js` (in `computeAwards` for segment-level, `computeRideLevelAwards` for ride-level)
-2. Add label/color in `AWARD_LABELS` in both `Dashboard.js` and `ActivityDetail.js`
-3. Add color config in `AWARD_COLORS` in `ActivityDetail.js` (for share cards)
+2. Add label/color in `AWARD_LABELS` in `src/award-config.js` (single source of truth for both Dashboard and ActivityDetail)
+3. Add tier ranking in `AWARD_TIER` in `awards.js` (for segment award ranking)
 4. Add FAQ entry in Dashboard.js FAQ section
 5. Add to test harness scenario in `test/harness.py`
 
@@ -104,7 +104,6 @@ Push to `main` → GitHub Pages auto-deploys. Worker changes need `wrangler depl
 
 - **No `gh` CLI available.** Use the GitHub REST API directly (curl or urllib). Don't attempt `gh issue`, `gh pr`, etc.
 
-- `AWARD_LABELS` is duplicated in Dashboard.js and ActivityDetail.js — keep them in sync (consolidation tracked in #74)
 - Segment efforts are stored in TWO places: embedded in activities AND in the segments store. Both must be populated.
 - The `has_efforts` flag on activities distinguishes summary-only (from list endpoint) from detail-fetched activities
 - Power awards require `device_watts: true` — estimated power is excluded

--- a/src/_MAP.md
+++ b/src/_MAP.md
@@ -1,11 +1,15 @@
 # src/
-*Files: 9 | Subdirectories: 1*
+*Files: 10 | Subdirectories: 1*
 
 ## Subdirectories
 
 - [components/](./components/_MAP.md)
 
 ## Files
+
+### award-config.js
+- **AWARD_LABELS** (variable) :9
+- **AWARD_COLORS** (variable) :56
 
 ### app.js
 > Imports: `preact, preact, signals, auth.js, demo.js`...
@@ -24,9 +28,10 @@
 
 ### awards.js
 > Imports: `db.js, units.js`
-- **computeAwards** (f) `(activity, resetEvent = null, referencePoints = [])` :338
-- **computeRideLevelAwards** (f) `(activity, allActivities, resetEvent = null)` :854
-- **computeAwardsForActivities** (f) `(activities)` :1023
+- **rankSegmentAwards** (f) `(awards)` :174
+- **computeAwards** (f) `(activity, resetEvent = null, referencePoints = [])` :472
+- **computeRideLevelAwards** (f) `(activity, allActivities, resetEvent = null)` :988
+- **computeAwardsForActivities** (f) `(activities)` :1484
 
 ### config.js
 - **STRAVA_CLIENT_ID** (variable) :6

--- a/src/award-config.js
+++ b/src/award-config.js
@@ -1,0 +1,58 @@
+/**
+ * Award Labels and Colors — Single source of truth
+ * Extracted from Dashboard.js and ActivityDetail.js (#74).
+ *
+ * Each entry has: label (display name), dot (accent color), bg, text, border.
+ * AWARD_COLORS is derived from AWARD_LABELS for share card rendering.
+ */
+
+export const AWARD_LABELS = {
+  season_first:       { label: "Season First",      dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
+  year_best:          { label: "Year Best",          dot: "#B8862E", bg: "#FBF0D8", text: "#6E5010", border: "#E8D4A0" },
+  recent_best:        { label: "Recent Best",        dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
+  beat_median:        { label: "Beat Median",        dot: "#7A5C8A", bg: "#ECE4F0", text: "#4A3060", border: "#CCC0D8" },
+  top_quartile:       { label: "Top Quartile",       dot: "#5B6CA0", bg: "#E4E8F2", text: "#34406A", border: "#BCC4DC" },
+  top_decile:         { label: "Top 10%",            dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
+  consistency:        { label: "Metronome",          dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
+  monthly_best:       { label: "Monthly Best",       dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
+  improvement_streak: { label: "On a Roll",          dot: "#3D7A4A", bg: "#E4F0E4", text: "#204E28", border: "#B8D4B0" },
+  comeback:           { label: "Comeback",           dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
+  milestone:          { label: "Milestone",          dot: "#8C7A30", bg: "#F4EEDA", text: "#5C5018", border: "#DCD4A8" },
+  best_month_ever:    { label: "Best Month Ever",    dot: "#8C7A30", bg: "#F4EEDA", text: "#5C5018", border: "#DCD4A8" },
+  closing_in:         { label: "Closing In",         dot: "#A04880", bg: "#F2E0EC", text: "#6A2858", border: "#D8B8D0" },
+  anniversary:        { label: "Anniversary",        dot: "#6B5CA0", bg: "#E8E4F4", text: "#3E3070", border: "#C4BCD8" },
+  distance_record:    { label: "Longest Ride",       dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
+  elevation_record:   { label: "Most Climbing",      dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
+  segment_count:      { label: "Most Segments",      dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
+  endurance_record:   { label: "Longest by Time",    dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
+  ytd_best_time:      { label: "YTD Best",           dot: "#9C6E18", bg: "#F8ECD0", text: "#5E4010", border: "#E0CCA0" },
+  ytd_best_power:     { label: "YTD Power",          dot: "#B85030", bg: "#F6DED4", text: "#7A2E18", border: "#E4B8A4" },
+  // Comeback mode (#60)
+  comeback_pb:        { label: "Comeback PB",        dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
+  recovery_milestone: { label: "Recovery",           dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
+  comeback_full:      { label: "You're Back!",       dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
+  comeback_distance:  { label: "Comeback Distance",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
+  comeback_elevation: { label: "Comeback Climbing",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
+  comeback_endurance: { label: "Comeback Endurance",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
+  reference_best:     { label: "Reference Best",     dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
+  // Route-level Season First (#59)
+  route_season_first: { label: "Route Season First", dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
+  // Activity-level power awards (#45)
+  season_first_power: { label: "First Power Ride",   dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
+  np_year_best:       { label: "NP Year Best",       dot: "#B8862E", bg: "#FBF0D8", text: "#6E5010", border: "#E8D4A0" },
+  np_recent_best:     { label: "NP Recent Best",     dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
+  work_year_best:     { label: "Work Year Best",     dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
+  work_recent_best:   { label: "Work Recent Best",   dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
+  peak_power:         { label: "Peak Power",         dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
+  peak_power_recent:  { label: "Peak Recent",        dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
+  // Indoor training awards (#46)
+  indoor_np_year_best:  { label: "Indoor NP Best",   dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
+  indoor_work_year_best:{ label: "Indoor Work Best",  dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
+  trainer_streak:       { label: "Trainer Streak",    dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
+  indoor_vs_outdoor:    { label: "Indoor vs Outdoor", dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
+};
+
+// Share card colors derived from AWARD_LABELS
+export const AWARD_COLORS = Object.fromEntries(
+  Object.entries(AWARD_LABELS).map(([k, v]) => [k, { bg: v.bg, text: v.text, accent: v.dot, border: v.border }])
+);

--- a/src/awards.js
+++ b/src/awards.js
@@ -122,6 +122,103 @@ const SUPPRESSED_IN_RECOVERY = new Set([
   "closing_in",
 ]);
 
+// ── Award Ranking (#80) ─────────────────────────────────────────────
+// Caps per-segment awards to reduce noise when a single segment earns many.
+
+/** Maximum regular awards per segment */
+const MAX_AWARDS_PER_SEGMENT = 3;
+
+/** Award types that get a bonus slot (not counted against the cap) */
+const COMEBACK_MODE_TYPES = new Set(["comeback_pb", "comeback_full", "recovery_milestone"]);
+
+/** Subsumption rules: higher award removes lower ones on the same segment */
+const SUBSUMES = {
+  year_best: ["recent_best", "monthly_best"],
+  comeback_full: ["comeback_pb", "recovery_milestone", "comeback"],
+  comeback_pb: ["comeback"],
+};
+
+/** Tier ranking (5=highest → 1=lowest) for award priority */
+const AWARD_TIER = {
+  comeback_full:      5,
+  year_best:          4,
+  top_decile:         4,
+  comeback_pb:        4,
+  closing_in:         4,
+  ytd_best_time:      3,
+  ytd_best_power:     3,
+  best_month_ever:    3,
+  improvement_streak: 3,
+  reference_best:     3,
+  consistency:        3,
+  recent_best:        2,
+  monthly_best:       2,
+  top_quartile:       2,
+  comeback:           2,
+  beat_median:        1,
+  anniversary:        1,
+  milestone:          1,
+  recovery_milestone: 1,
+  season_first:       1,
+};
+
+/**
+ * Rank and cap per-segment awards to reduce noise.
+ * Applies subsumption rules, then caps to MAX_AWARDS_PER_SEGMENT regular awards
+ * plus one bonus slot for comeback-mode awards.
+ * Ride-level awards (segment_id === null) pass through unaffected.
+ *
+ * @param {Array} awards — Array of award objects from computeAwards
+ * @returns {Array} — Filtered/ranked awards
+ */
+export function rankSegmentAwards(awards) {
+  // Separate ride-level awards (no segment) from segment awards
+  const rideLevelAwards = awards.filter((a) => !a.segment_id);
+  const segmentAwards = awards.filter((a) => a.segment_id);
+
+  if (segmentAwards.length === 0) return awards;
+
+  // Group by segment_id
+  const bySegment = new Map();
+  for (const award of segmentAwards) {
+    if (!bySegment.has(award.segment_id)) {
+      bySegment.set(award.segment_id, []);
+    }
+    bySegment.get(award.segment_id).push(award);
+  }
+
+  const ranked = [];
+  for (const [, segAwards] of bySegment) {
+    // 1. Apply subsumption: remove lower awards that are subsumed by higher ones
+    const presentTypes = new Set(segAwards.map((a) => a.type));
+    const subsumed = new Set();
+    for (const [higher, lowerList] of Object.entries(SUBSUMES)) {
+      if (presentTypes.has(higher)) {
+        for (const lower of lowerList) {
+          subsumed.add(lower);
+        }
+      }
+    }
+    const afterSubsumption = segAwards.filter((a) => !subsumed.has(a.type));
+
+    // 2. Separate comeback-mode bonus awards from regular awards
+    const comebackAwards = afterSubsumption.filter((a) => COMEBACK_MODE_TYPES.has(a.type));
+    const regularAwards = afterSubsumption.filter((a) => !COMEBACK_MODE_TYPES.has(a.type));
+
+    // 3. Sort regular awards by tier (highest first), then cap
+    regularAwards.sort((a, b) => (AWARD_TIER[b.type] || 0) - (AWARD_TIER[a.type] || 0));
+    const cappedRegular = regularAwards.slice(0, MAX_AWARDS_PER_SEGMENT);
+
+    // 4. Allow at most 1 comeback-mode bonus award (highest tier)
+    comebackAwards.sort((a, b) => (AWARD_TIER[b.type] || 0) - (AWARD_TIER[a.type] || 0));
+    const bonusComeback = comebackAwards.slice(0, 1);
+
+    ranked.push(...cappedRegular, ...bonusComeback);
+  }
+
+  return [...ranked, ...rideLevelAwards];
+}
+
 function formatDate(isoString) {
   return new Date(isoString).toLocaleDateString("en-US", {
     month: "short",
@@ -854,7 +951,7 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
       if (hasRecoveryZone) {
         // Only suppress if the athlete is still recovering on at least one segment
         // Keep awards for segments where they're fully recovered
-        return awards.filter((a) => {
+        return rankSegmentAwards(awards.filter((a) => {
           if (!SUPPRESSED_IN_RECOVERY.has(a.type)) return true;
           // Check this specific segment's recovery status
           if (!a.segment_id) return true; // ride-level awards pass through
@@ -871,12 +968,12 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
           if (isFullyRecovered) return true;
           // Suppress comparative awards for segments still in recovery
           return !hasRecoveryAward;
-        });
+        }));
       }
     }
   }
 
-  return awards;
+  return rankSegmentAwards(awards);
 }
 
 /**

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -21,6 +21,7 @@ import {
   formatPower,
 } from "../units.js";
 import { renderIconSVG, drawIcon } from "../icons.js";
+import { AWARD_LABELS, AWARD_COLORS } from "../award-config.js";
 
 const activity = signal(null);
 const awards = signal([]);
@@ -38,53 +39,6 @@ function formatDateShort(isoString) {
     year: "numeric",
   });
 }
-
-const AWARD_LABELS = {
-  season_first:       { label: "Season First",      dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
-  year_best:          { label: "Year Best",          dot: "#B8862E", bg: "#FBF0D8", text: "#6E5010", border: "#E8D4A0" },
-  recent_best:        { label: "Recent Best",        dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
-  beat_median:        { label: "Beat Median",        dot: "#7A5C8A", bg: "#ECE4F0", text: "#4A3060", border: "#CCC0D8" },
-  top_quartile:       { label: "Top Quartile",       dot: "#5B6CA0", bg: "#E4E8F2", text: "#34406A", border: "#BCC4DC" },
-  top_decile:         { label: "Top 10%",            dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
-  consistency:        { label: "Metronome",          dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  monthly_best:       { label: "Monthly Best",       dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
-  improvement_streak: { label: "On a Roll",          dot: "#3D7A4A", bg: "#E4F0E4", text: "#204E28", border: "#B8D4B0" },
-  comeback:           { label: "Comeback",           dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  milestone:          { label: "Milestone",          dot: "#8C7A30", bg: "#F4EEDA", text: "#5C5018", border: "#DCD4A8" },
-  best_month_ever:    { label: "Best Month Ever",    dot: "#8C7A30", bg: "#F4EEDA", text: "#5C5018", border: "#DCD4A8" },
-  closing_in:         { label: "Closing In",         dot: "#A04880", bg: "#F2E0EC", text: "#6A2858", border: "#D8B8D0" },
-  anniversary:        { label: "Anniversary",        dot: "#6B5CA0", bg: "#E8E4F4", text: "#3E3070", border: "#C4BCD8" },
-  distance_record:    { label: "Longest Ride",       dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
-  elevation_record:   { label: "Most Climbing",      dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  segment_count:      { label: "Most Segments",      dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  endurance_record:   { label: "Longest by Time",    dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  ytd_best_time:      { label: "YTD Best",           dot: "#9C6E18", bg: "#F8ECD0", text: "#5E4010", border: "#E0CCA0" },
-  ytd_best_power:     { label: "YTD Power",          dot: "#B85030", bg: "#F6DED4", text: "#7A2E18", border: "#E4B8A4" },
-  comeback_pb:        { label: "Comeback PB",        dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  recovery_milestone: { label: "Recovery",           dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  comeback_full:      { label: "You're Back!",       dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
-  comeback_distance:  { label: "Comeback Distance",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  comeback_elevation: { label: "Comeback Climbing",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  comeback_endurance: { label: "Comeback Endurance",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  reference_best:     { label: "Reference Best",     dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  route_season_first: { label: "Route Season First", dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
-  season_first_power: { label: "First Power Ride",   dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
-  np_year_best:       { label: "NP Year Best",       dot: "#B8862E", bg: "#FBF0D8", text: "#6E5010", border: "#E8D4A0" },
-  np_recent_best:     { label: "NP Recent Best",     dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
-  work_year_best:     { label: "Work Year Best",     dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
-  work_recent_best:   { label: "Work Recent Best",   dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
-  peak_power:         { label: "Peak Power",         dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
-  peak_power_recent:  { label: "Peak Recent",        dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
-  indoor_np_year_best:  { label: "Indoor NP Best",   dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
-  indoor_work_year_best:{ label: "Indoor Work Best",  dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
-  trainer_streak:       { label: "Trainer Streak",    dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
-  indoor_vs_outdoor:    { label: "Indoor vs Outdoor", dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
-};
-
-// AWARD_COLORS now uses same structure as AWARD_LABELS for share card rendering
-const AWARD_COLORS = Object.fromEntries(
-  Object.entries(AWARD_LABELS).map(([k, v]) => [k, { bg: v.bg, text: v.text, accent: v.dot, border: v.border }])
-);
 
 async function loadActivity(id) {
   // Only show full loading screen on initial load, not on refresh/resync

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -44,6 +44,7 @@ import {
 } from "../units.js";
 import { isDemo, exitDemo } from "../demo.js";
 import { renderIconSVG } from "../icons.js";
+import { AWARD_LABELS } from "../award-config.js";
 
 const recentActivities = signal([]);
 const activityAwards = signal(new Map());
@@ -66,52 +67,6 @@ const refDate = signal("");
 const refCount = signal("10");
 const refBirthday = signal("");
 const refAge = signal("40");
-
-const AWARD_LABELS = {
-  season_first:       { label: "Season First",      dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
-  year_best:          { label: "Year Best",          dot: "#B8862E", bg: "#FBF0D8", text: "#6E5010", border: "#E8D4A0" },
-  recent_best:        { label: "Recent Best",        dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
-  beat_median:        { label: "Beat Median",        dot: "#7A5C8A", bg: "#ECE4F0", text: "#4A3060", border: "#CCC0D8" },
-  top_quartile:       { label: "Top Quartile",       dot: "#5B6CA0", bg: "#E4E8F2", text: "#34406A", border: "#BCC4DC" },
-  top_decile:         { label: "Top 10%",            dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
-  consistency:        { label: "Metronome",          dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  monthly_best:       { label: "Monthly Best",       dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
-  improvement_streak: { label: "On a Roll",          dot: "#3D7A4A", bg: "#E4F0E4", text: "#204E28", border: "#B8D4B0" },
-  comeback:           { label: "Comeback",           dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  milestone:          { label: "Milestone",          dot: "#8C7A30", bg: "#F4EEDA", text: "#5C5018", border: "#DCD4A8" },
-  best_month_ever:    { label: "Best Month Ever",    dot: "#8C7A30", bg: "#F4EEDA", text: "#5C5018", border: "#DCD4A8" },
-  closing_in:         { label: "Closing In",         dot: "#A04880", bg: "#F2E0EC", text: "#6A2858", border: "#D8B8D0" },
-  anniversary:        { label: "Anniversary",        dot: "#6B5CA0", bg: "#E8E4F4", text: "#3E3070", border: "#C4BCD8" },
-  distance_record:    { label: "Longest Ride",       dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
-  elevation_record:   { label: "Most Climbing",      dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  segment_count:      { label: "Most Segments",      dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  endurance_record:   { label: "Longest by Time",    dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  ytd_best_time:      { label: "YTD Best",           dot: "#9C6E18", bg: "#F8ECD0", text: "#5E4010", border: "#E0CCA0" },
-  ytd_best_power:     { label: "YTD Power",          dot: "#B85030", bg: "#F6DED4", text: "#7A2E18", border: "#E4B8A4" },
-  // Comeback mode (#60)
-  comeback_pb:        { label: "Comeback PB",        dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  recovery_milestone: { label: "Recovery",           dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  comeback_full:      { label: "You're Back!",       dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
-  comeback_distance:  { label: "Comeback Distance",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  comeback_elevation: { label: "Comeback Climbing",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  comeback_endurance: { label: "Comeback Endurance",  dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
-  reference_best:     { label: "Reference Best",     dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
-  // Route-level Season First (#59)
-  route_season_first: { label: "Route Season First", dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
-  // Activity-level power awards (#45)
-  season_first_power: { label: "First Power Ride",   dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
-  np_year_best:       { label: "NP Year Best",       dot: "#B8862E", bg: "#FBF0D8", text: "#6E5010", border: "#E8D4A0" },
-  np_recent_best:     { label: "NP Recent Best",     dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
-  work_year_best:     { label: "Work Year Best",     dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
-  work_recent_best:   { label: "Work Recent Best",   dot: "#C08020", bg: "#FAF0D8", text: "#785010", border: "#E8D8A8" },
-  peak_power:         { label: "Peak Power",         dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
-  peak_power_recent:  { label: "Peak Recent",        dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
-  // Indoor training awards (#46)
-  indoor_np_year_best:  { label: "Indoor NP Best",   dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
-  indoor_work_year_best:{ label: "Indoor Work Best",  dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
-  trainer_streak:       { label: "Trainer Streak",    dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
-  indoor_vs_outdoor:    { label: "Indoor vs Outdoor", dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
-};
 
 async function loadDashboard() {
   loading.value = true;

--- a/src/components/_MAP.md
+++ b/src/components/_MAP.md
@@ -4,12 +4,12 @@
 ## Files
 
 ### ActivityDetail.js
-> Imports: `preact, signals, hooks, db.js, awards.js`...
-- **ActivityDetail** (f) `({ id })` :386
+> Imports: `preact, signals, hooks, db.js, awards.js, award-config.js`...
+- **ActivityDetail** (f) `({ id })` :365
 
 ### Dashboard.js
-> Imports: `preact, signals, hooks, auth.js, sync.js`...
-- **Dashboard** (f) `()` :141
+> Imports: `preact, signals, hooks, auth.js, sync.js, award-config.js`...
+- **Dashboard** (f) `()` :117
 
 ### Landing.js
 > Imports: `preact, signals, auth.js, demo.js, app.js`...


### PR DESCRIPTION
Extract shared AWARD_LABELS and AWARD_COLORS to src/award-config.js as single
source of truth. Both Dashboard.js and ActivityDetail.js now import from there.

Add rankSegmentAwards() to awards.js: applies subsumption rules (e.g. year_best
removes recent_best/monthly_best), tier-based ranking, and caps per-segment
awards to 3 regular + 1 comeback bonus slot.

https://claude.ai/code/session_01JAQpJ8xXmSwCDzZHfU6m1x