### PR TITLE
Fix disconnect clearing all synced data instead of just auth session

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -11,7 +11,7 @@ import {
   OAUTH_REDIRECT_URI,
   OAUTH_SCOPE,
 } from "./config.js";
-import { getAuth, setAuth, clearAuth, clearAllData } from "./db.js";
+import { getAuth, setAuth, clearAuth } from "./db.js";
 
 // Auth state signal — null means not logged in, object means logged in
 export const authState = signal(null);
@@ -110,8 +110,8 @@ export async function getValidToken() {
   return updated.access_token;
 }
 
-/** Disconnect — clear all stored data and reset auth state */
+/** Disconnect — clear auth session but preserve synced data */
 export async function disconnect() {
-  await clearAllData();
+  await clearAuth();
   authState.value = null;
 }


### PR DESCRIPTION
disconnect() was calling clearAllData() which wiped activities, segments,
sync_state, and routes. Now calls clearAuth() to only remove the auth
session, so re-login resumes incremental sync instead of re-downloading
everything.

Fixes #89

https://claude.ai/code/session_01DBMxGosnSK13e1nwMMsgUy