### PR TITLE
feat: add mobile install interstitial on landing page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import { render } from "preact";
 import { signal, effect } from "@preact/signals";
 import { authState, initAuth } from "./auth.js";
 import { checkDemo, isDemo } from "./demo.js";
+import { initInstallDetection } from "./install.js";
 import { Landing } from "./components/Landing.js";
 import { Dashboard } from "./components/Dashboard.js";
 import { ActivityDetail } from "./components/ActivityDetail.js";
@@ -59,6 +60,7 @@ function App() {
 // --- Init ---
 
 async function init() {
+  initInstallDetection();
   await initAuth();
   await checkDemo();
   render(html`<${App} />`, document.getElementById("app"));

--- a/src/components/InstallBanner.js
+++ b/src/components/InstallBanner.js
@@ -1,0 +1,132 @@
+/**
+ * InstallBanner — Mobile install interstitial for Landing page.
+ * Guides mobile browser visitors to install the PWA before logging in,
+ * preventing the "double sync" problem (browser and PWA have separate IndexedDB).
+ */
+
+import { html } from "htm/preact";
+import {
+  installContext,
+  triggerInstall,
+  dismissInstallBanner,
+} from "../install.js";
+
+function ShareIcon() {
+  return html`
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline-block align-text-bottom" style="color: var(--accent);">
+      <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8"/>
+      <polyline points="16 6 12 2 8 6"/>
+      <line x1="12" y1="2" x2="12" y2="15"/>
+    </svg>
+  `;
+}
+
+function IOSInstructions() {
+  return html`
+    <div class="space-y-3 text-left">
+      <div class="flex items-start gap-3">
+        <span class="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold" style="background: var(--accent); color: white;">1</span>
+        <p style="font-size: 15px; color: var(--text-secondary);">
+          Tap the Share button <${ShareIcon} /> at the bottom of Safari
+        </p>
+      </div>
+      <div class="flex items-start gap-3">
+        <span class="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold" style="background: var(--accent); color: white;">2</span>
+        <p style="font-size: 15px; color: var(--text-secondary);">
+          Scroll down and tap <span style="font-weight: 500; color: var(--text);">Add to Home Screen</span>
+        </p>
+      </div>
+      <div class="flex items-start gap-3">
+        <span class="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold" style="background: var(--accent); color: white;">3</span>
+        <p style="font-size: 15px; color: var(--text-secondary);">
+          Tap <span style="font-weight: 500; color: var(--text);">Add</span>, then open aeyu.io from your home screen
+        </p>
+      </div>
+    </div>
+  `;
+}
+
+function AndroidInstructions() {
+  const ctx = installContext.value;
+
+  if (ctx.deferredPrompt) {
+    return html`
+      <button
+        onClick=${triggerInstall}
+        class="inline-flex items-center gap-2 font-semibold px-6 py-3 rounded-lg transition-colors w-full justify-center"
+        style="background: var(--text); color: var(--bg); font-family: var(--font-body);"
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/>
+          <polyline points="7 10 12 15 17 10"/>
+          <line x1="12" y1="15" x2="12" y2="3"/>
+        </svg>
+        Install App
+      </button>
+    `;
+  }
+
+  return html`
+    <div class="space-y-3 text-left">
+      <div class="flex items-start gap-3">
+        <span class="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold" style="background: var(--accent); color: white;">1</span>
+        <p style="font-size: 15px; color: var(--text-secondary);">
+          Tap the <span style="font-weight: 500; color: var(--text);">&#8942;</span> menu in your browser
+        </p>
+      </div>
+      <div class="flex items-start gap-3">
+        <span class="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold" style="background: var(--accent); color: white;">2</span>
+        <p style="font-size: 15px; color: var(--text-secondary);">
+          Tap <span style="font-weight: 500; color: var(--text);">Install App</span> or <span style="font-weight: 500; color: var(--text);">Add to Home Screen</span>
+        </p>
+      </div>
+      <div class="flex items-start gap-3">
+        <span class="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold" style="background: var(--accent); color: white;">3</span>
+        <p style="font-size: 15px; color: var(--text-secondary);">
+          Open aeyu.io from your home screen
+        </p>
+      </div>
+    </div>
+  `;
+}
+
+export function InstallBanner() {
+  const ctx = installContext.value;
+
+  return html`
+    <div class="text-center">
+      <h3 class="mb-2" style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text);">
+        Install for the best experience
+      </h3>
+      <p class="mb-5" style="font-family: var(--font-body); font-size: 15px; color: var(--text-secondary);">
+        Add aeyu.io to your home screen first, then connect
+        Strava inside the app. This keeps your ride data
+        with the app where it belongs.
+      </p>
+
+      <div class="mb-5 rounded-lg p-4" style="background: var(--bg); border: 1px solid var(--border-light);">
+        ${ctx.platform === "ios" && html`<${IOSInstructions} />`}
+        ${ctx.platform === "android" && html`<${AndroidInstructions} />`}
+        ${ctx.platform === "other" && html`
+          <p style="font-size: 15px; color: var(--text-secondary);">
+            Use your browser's menu to install or add this page to your home screen,
+            then open it from there.
+          </p>
+        `}
+      </div>
+
+      <button
+        onClick=${dismissInstallBanner}
+        class="transition-colors"
+        style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-tertiary);"
+      >
+        Use in browser instead
+      </button>
+      <p class="mt-1" style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">
+        You can always install later. If you do, you'll need to
+        reconnect Strava and sync again — no data is lost,
+        it just takes a few minutes.
+      </p>
+    </div>
+  `;
+}

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -10,6 +10,8 @@ import { startDemo } from "../demo.js";
 import { navigate } from "../app.js";
 import { authState } from "../auth.js";
 import { renderIconSVG } from "../icons.js";
+import { installContext } from "../install.js";
+import { InstallBanner } from "./InstallBanner.js";
 
 const demoLoading = signal(false);
 
@@ -93,29 +95,54 @@ export function Landing() {
               and personal milestones that Strava doesn't celebrate.
             </p>
 
-            <button
-              onClick=${() => startOAuth()}
-              class="inline-flex items-center gap-2 font-semibold px-6 py-3 rounded-lg transition-colors"
-              style="background: var(--strava); color: white; font-family: var(--font-body);"
-              onMouseOver=${(e) => e.currentTarget.style.background = 'var(--strava-hover)'}
-              onMouseOut=${(e) => e.currentTarget.style.background = 'var(--strava)'}
-            >
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"/>
-              </svg>
-              Connect with Strava
-            </button>
-
-            <div class="mt-4">
-              <button
-                onClick=${handleDemo}
-                disabled=${demoLoading.value}
-                class="transition-colors"
-                style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-tertiary);"
-              >
-                ${demoLoading.value ? "Loading demo..." : "or try the demo →"}
-              </button>
-            </div>
+            ${(() => {
+              const ctx = installContext.value;
+              const showInstall = ctx.isMobile && !ctx.isStandalone && !ctx.dismissed;
+              if (showInstall) {
+                return html`
+                  <${InstallBanner} />
+                  <div class="mt-4">
+                    <button
+                      onClick=${handleDemo}
+                      disabled=${demoLoading.value}
+                      class="transition-colors"
+                      style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-tertiary);"
+                    >
+                      ${demoLoading.value ? "Loading demo..." : "or try the demo →"}
+                    </button>
+                  </div>
+                `;
+              }
+              return html`
+                <button
+                  onClick=${() => startOAuth()}
+                  class="inline-flex items-center gap-2 font-semibold px-6 py-3 rounded-lg transition-colors"
+                  style="background: var(--strava); color: white; font-family: var(--font-body);"
+                  onMouseOver=${(e) => e.currentTarget.style.background = 'var(--strava-hover)'}
+                  onMouseOut=${(e) => e.currentTarget.style.background = 'var(--strava)'}
+                >
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066m-7.008-5.599l2.836 5.598h4.172L10.463 0l-7 13.828h4.169"/>
+                  </svg>
+                  Connect with Strava
+                </button>
+                ${ctx.dismissed && ctx.isMobile && !ctx.isStandalone && html`
+                  <p class="mt-2" style="font-family: var(--font-body); font-size: 0.75rem; color: var(--accent);">
+                    Tip: If you install as an app later, you'll need to reconnect and sync again.
+                  </p>
+                `}
+                <div class="mt-4">
+                  <button
+                    onClick=${handleDemo}
+                    disabled=${demoLoading.value}
+                    class="transition-colors"
+                    style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-tertiary);"
+                  >
+                    ${demoLoading.value ? "Loading demo..." : "or try the demo →"}
+                  </button>
+                </div>
+              `;
+            })()}
           </div>
 
           <div class="space-y-1" style="font-family: var(--font-body);">

--- a/src/install.js
+++ b/src/install.js
@@ -1,0 +1,65 @@
+/**
+ * Install Detection & PWA Install Prompt
+ * Detects mobile vs desktop, standalone vs browser, captures beforeinstallprompt.
+ * Exports signals consumed by Landing.js / InstallBanner.js.
+ */
+
+import { signal } from "@preact/signals";
+
+export const installContext = signal({
+  isMobile: false,
+  isStandalone: false,
+  platform: "unknown", // 'ios' | 'android' | 'other'
+  deferredPrompt: null,
+  dismissed: false,
+});
+
+const DISMISS_KEY = "aeyu-install-dismissed";
+
+function update(patch) {
+  installContext.value = { ...installContext.value, ...patch };
+}
+
+export function initInstallDetection() {
+  // Standalone detection
+  const isStandalone =
+    window.matchMedia("(display-mode: standalone)").matches ||
+    navigator.standalone === true;
+
+  // Mobile detection: touch + narrow viewport
+  const hasTouch =
+    "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  const isMobile = hasTouch && window.innerWidth < 768;
+
+  // Platform detection
+  const ua = navigator.userAgent;
+  const isIOS = /iPhone|iPad|iPod/.test(ua) && !window.MSStream;
+  const isAndroid = /Android/i.test(ua);
+  const platform = isIOS ? "ios" : isAndroid ? "android" : "other";
+
+  // Dismissal persistence
+  const dismissed = localStorage.getItem(DISMISS_KEY) === "1";
+
+  update({ isMobile, isStandalone, platform, dismissed });
+
+  // Capture beforeinstallprompt (Chrome/Edge on Android)
+  window.addEventListener("beforeinstallprompt", (e) => {
+    e.preventDefault();
+    update({ deferredPrompt: e });
+  });
+}
+
+export async function triggerInstall() {
+  const { deferredPrompt } = installContext.value;
+  if (!deferredPrompt) return;
+  deferredPrompt.prompt();
+  const { outcome } = await deferredPrompt.userChoice;
+  if (outcome === "accepted") {
+    update({ deferredPrompt: null });
+  }
+}
+
+export function dismissInstallBanner() {
+  localStorage.setItem(DISMISS_KEY, "1");
+  update({ dismissed: true });
+}

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
  * All Strava data lives in IndexedDB — SW just needs to serve the app offline.
  */
 
-const CACHE_NAME = "aeyu-v3";
+const CACHE_NAME = "aeyu-v4";
 
 const APP_SHELL = [
   "/",
@@ -16,10 +16,12 @@ const APP_SHELL = [
   "/src/config.js",
   "/src/db.js",
   "/src/sync.js",
+  "/src/install.js",
   "/src/components/Landing.js",
   "/src/components/Dashboard.js",
   "/src/components/SyncProgress.js",
   "/src/components/ActivityDetail.js",
+  "/src/components/InstallBanner.js",
   "/icons/icon-192.png",
   "/icons/icon-512.png",
 ];


### PR DESCRIPTION
Guide mobile browser visitors to install the PWA before logging in,
preventing the "double sync" problem where browser and installed app
have separate IndexedDB instances.

- Detect mobile/standalone/platform via matchMedia + navigator.standalone
- Capture beforeinstallprompt for native Android install button
- Show platform-specific install instructions (iOS Safari, Android Chrome)
- Replace Strava login CTA with install guidance on mobile browsers
- "Use in browser instead" bypass with amber tip about re-sync
- No change for desktop visitors or already-installed PWA
- Bump service worker cache to v4 with new files

https://claude.ai/code/session_01JauRxWxoJ614SSb9JmJ48Z