### PR TITLE
feat: add weekly ride streaks and group ride detection (#58)

### DIFF
--- a/src/award-config.js
+++ b/src/award-config.js
@@ -50,6 +50,9 @@ export const AWARD_LABELS = {
   indoor_work_year_best:{ label: "Indoor Work Best",  dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
   trainer_streak:       { label: "Trainer Streak",    dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
   indoor_vs_outdoor:    { label: "Indoor vs Outdoor", dot: "#4882A8", bg: "#E4EEF6", text: "#2A5470", border: "#B8D0E4" },
+  // Streak & consistency awards (#58)
+  weekly_streak:        { label: "Ride Streak",       dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
+  group_consistency:    { label: "Group Ride",        dot: "#5B6CA0", bg: "#E4E8F2", text: "#34406A", border: "#BCC4DC" },
 };
 
 // Share card colors derived from AWARD_LABELS

--- a/src/awards.js
+++ b/src/awards.js
@@ -48,6 +48,11 @@
  *   - Trainer Streak: Consecutive weeks with at least one indoor ride
  *   - Indoor vs Outdoor: NP comparison when outdoor ride follows indoor training
  *
+ * Streak & consistency awards (#58):
+ *   - Weekly Ride Streak: Consecutive weeks with at least one ride (mulligan support)
+ *   - Group Ride Consistency: Attendance tracking on recurring group rides
+ *   - Streak Danger: Warning when active streak is at risk
+ *
  * Data quality rules:
  *   - Minimum effort threshold: comparative awards (Year Best, Recent Best,
  *     Beat Median, Top Quartile, Monthly Best, YTD Best) require ≥3 total efforts.
@@ -1545,4 +1550,322 @@ export async function computeAwardsForActivities(activities) {
     }
   }
   return result;
+}
+
+// ── Streak & Consistency Awards (#58) ──────────────────────────────
+
+/** Weekly streak tier thresholds */
+const STREAK_TIERS = [4, 8, 12, 26, 52];
+
+/** Minimum consecutive weeks for a weekly ride streak award */
+const WEEKLY_STREAK_MIN = 4;
+
+/** Haversine distance in km between two [lat, lng] coordinates */
+function haversineKm(a, b) {
+  if (!a || !b || a.length < 2 || b.length < 2) return Infinity;
+  const R = 6371;
+  const dLat = (b[0] - a[0]) * Math.PI / 180;
+  const dLng = (b[1] - a[1]) * Math.PI / 180;
+  const sinLat = Math.sin(dLat / 2);
+  const sinLng = Math.sin(dLng / 2);
+  const h = sinLat * sinLat + Math.cos(a[0] * Math.PI / 180) * Math.cos(b[0] * Math.PI / 180) * sinLng * sinLng;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * Get ISO week string "YYYY-WNN" for a date.
+ * Uses ISO week number (Monday-start weeks).
+ */
+function isoWeekKey(dateStr) {
+  const d = new Date(dateStr);
+  // Thursday of the same ISO week determines the year
+  const thu = new Date(d);
+  thu.setDate(d.getDate() - ((d.getDay() + 6) % 7) + 3);
+  const yearStart = new Date(thu.getFullYear(), 0, 1);
+  const weekNum = Math.ceil(((thu - yearStart) / 86400000 + 1) / 7);
+  return `${thu.getFullYear()}-W${String(weekNum).padStart(2, "0")}`;
+}
+
+/**
+ * Compute weekly ride streaks from all activities.
+ * Returns { current, longest, mulliganUsed, streakStart, lastRideDate, danger }.
+ *
+ * Mulligan rule: one missed week is forgiven, but two consecutive misses
+ * break the streak. An assisted streak is flagged with mulliganUsed=true.
+ *
+ * @param {Array} allActivities — All activities sorted by date
+ * @returns {Object} Streak data
+ */
+export function computeWeeklyStreaks(allActivities) {
+  // Filter to cycling activities only
+  const rides = allActivities
+    .filter((a) => a.sport_type === "Ride" || a.sport_type === "VirtualRide")
+    .sort((a, b) => a.start_date_local.localeCompare(b.start_date_local));
+
+  if (rides.length === 0) {
+    return { current: 0, longest: 0, mulliganUsed: false, streakStart: null, lastRideDate: null, danger: null };
+  }
+
+  // Collect unique weeks that have rides
+  const rideWeeks = new Set();
+  for (const ride of rides) {
+    rideWeeks.add(isoWeekKey(ride.start_date_local));
+  }
+
+  // Build sorted list of all weeks from first ride to now
+  const firstRide = new Date(rides[0].start_date_local);
+  const now = new Date();
+  const allWeeks = [];
+  const d = new Date(firstRide);
+  // Move to Monday of first ride's week
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  while (d <= now) {
+    allWeeks.push(isoWeekKey(d.toISOString()));
+    d.setDate(d.getDate() + 7);
+  }
+
+  // Compute streaks with mulligan support
+  let currentStreak = 0;
+  let currentMulligan = false;
+  let currentStart = null;
+  let longestStreak = 0;
+  let longestMulligan = false;
+  let longestStart = null;
+  let consecutiveMisses = 0;
+
+  for (let i = 0; i < allWeeks.length; i++) {
+    const week = allWeeks[i];
+    if (rideWeeks.has(week)) {
+      if (currentStreak === 0) {
+        currentStart = week;
+        currentMulligan = false;
+      }
+      currentStreak++;
+      consecutiveMisses = 0;
+    } else {
+      consecutiveMisses++;
+      if (consecutiveMisses === 1 && currentStreak > 0) {
+        // First miss — use mulligan
+        currentStreak++;
+        currentMulligan = true;
+      } else {
+        // Two consecutive misses or no active streak — break
+        if (currentStreak > longestStreak) {
+          longestStreak = currentStreak;
+          longestMulligan = currentMulligan;
+          longestStart = currentStart;
+        }
+        currentStreak = 0;
+        currentMulligan = false;
+        currentStart = null;
+        consecutiveMisses = 0;
+      }
+    }
+  }
+  if (currentStreak > longestStreak) {
+    longestStreak = currentStreak;
+    longestMulligan = currentMulligan;
+    longestStart = currentStart;
+  }
+
+  // Determine danger state for current streak
+  const currentWeek = isoWeekKey(now.toISOString());
+  const thisWeekHasRide = rideWeeks.has(currentWeek);
+  let danger = null;
+  if (currentStreak >= WEEKLY_STREAK_MIN && !thisWeekHasRide) {
+    danger = currentMulligan
+      ? { level: "critical", message: `You used your mulligan last week — ride this week to keep your ${currentStreak}-week streak alive!` }
+      : { level: "warning", message: `Your ${currentStreak}-week streak is in danger! Get out there this week.` };
+  }
+
+  // Find highest tier reached by current streak
+  const tier = STREAK_TIERS.filter((t) => currentStreak >= t).pop() || 0;
+
+  const lastRideDate = rides[rides.length - 1].start_date_local;
+
+  return {
+    current: currentStreak,
+    longest: longestStreak,
+    mulliganUsed: currentMulligan,
+    streakStart: currentStart,
+    lastRideDate,
+    danger,
+    tier,
+  };
+}
+
+/**
+ * Detect recurring group rides by clustering activities by:
+ *   - Day of week
+ *   - Similar start time (±1hr)
+ *   - Similar start location (within 1km)
+ *   - Activity name patterns
+ *
+ * @param {Array} allActivities — All activities
+ * @returns {Array} Detected group rides with attendance data
+ */
+export function detectGroupRides(allActivities) {
+  const rides = allActivities
+    .filter((a) => (a.sport_type === "Ride" || a.sport_type === "VirtualRide") && a.has_efforts)
+    .sort((a, b) => a.start_date_local.localeCompare(b.start_date_local));
+
+  if (rides.length < 4) return [];
+
+  // Group rides by day-of-week
+  const byDow = {};
+  for (const ride of rides) {
+    const d = new Date(ride.start_date_local);
+    const dow = d.getDay(); // 0=Sun..6=Sat
+    if (!byDow[dow]) byDow[dow] = [];
+    byDow[dow].push(ride);
+  }
+
+  const groups = [];
+
+  for (const [dow, dowRides] of Object.entries(byDow)) {
+    if (dowRides.length < 3) continue;
+
+    // Cluster by start time and location
+    const clusters = [];
+    for (const ride of dowRides) {
+      const rideTime = new Date(ride.start_date_local);
+      const minuteOfDay = rideTime.getHours() * 60 + rideTime.getMinutes();
+      const latlng = ride.start_latlng || null;
+
+      let matched = false;
+      for (const cluster of clusters) {
+        // Check time proximity (within 60 min)
+        const timeDiff = Math.abs(cluster.avgMinute - minuteOfDay);
+        if (timeDiff > 60) continue;
+
+        // Check location proximity (within 1km) if both have coords
+        if (cluster.latlng && latlng) {
+          const dist = haversineKm(cluster.latlng, latlng);
+          if (dist > 1) continue;
+        }
+
+        // Match — add to cluster
+        cluster.rides.push(ride);
+        cluster.avgMinute = Math.round(
+          cluster.rides.reduce((sum, r) => {
+            const t = new Date(r.start_date_local);
+            return sum + t.getHours() * 60 + t.getMinutes();
+          }, 0) / cluster.rides.length
+        );
+        matched = true;
+        break;
+      }
+
+      if (!matched) {
+        clusters.push({
+          rides: [ride],
+          avgMinute: minuteOfDay,
+          latlng,
+          dow: parseInt(dow),
+        });
+      }
+    }
+
+    // Only keep clusters with 3+ rides
+    for (const cluster of clusters) {
+      if (cluster.rides.length < 3) continue;
+
+      // Determine group name from most common activity name pattern
+      const nameCounts = {};
+      for (const r of cluster.rides) {
+        // Normalize name: remove dates, numbers, trim
+        const normalized = r.name
+          .replace(/\d{1,2}\/\d{1,2}(\/\d{2,4})?/g, "")
+          .replace(/\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\b/gi, "")
+          .replace(/\d+/g, "")
+          .trim();
+        if (normalized.length > 2) {
+          nameCounts[normalized] = (nameCounts[normalized] || 0) + 1;
+        }
+      }
+
+      // Use the most common name, or fall back to day-of-week
+      const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+      let groupName;
+      const topName = Object.entries(nameCounts).sort((a, b) => b[1] - a[1])[0];
+      if (topName && topName[1] >= 2) {
+        groupName = topName[0];
+      } else {
+        const h = Math.floor(cluster.avgMinute / 60);
+        const period = h < 12 ? "Morning" : h < 17 ? "Afternoon" : "Evening";
+        groupName = `${dayNames[cluster.dow]} ${period} Ride`;
+      }
+
+      // Check if most rides have athlete_count > 1 (group indication)
+      const groupCount = cluster.rides.filter((r) => (r.athlete_count || 1) > 1).length;
+      const isGroupRide = groupCount > cluster.rides.length * 0.5;
+
+      // Compute attendance streaks
+      const rideWeeks = cluster.rides.map((r) => isoWeekKey(r.start_date_local));
+      const uniqueWeeks = [...new Set(rideWeeks)].sort();
+
+      // Find current consecutive attendance
+      let attendanceStreak = 0;
+      let attendanceMulligan = false;
+      if (uniqueWeeks.length >= 2) {
+        // Check from most recent backwards
+        const now = new Date();
+        const currentWeek = isoWeekKey(now.toISOString());
+        let weekPtr = currentWeek;
+        let misses = 0;
+
+        // Walk backwards from current week
+        const weekSet = new Set(uniqueWeeks);
+        const checkDate = new Date(now);
+        // Go to Monday of current week
+        checkDate.setDate(checkDate.getDate() - ((checkDate.getDay() + 6) % 7));
+
+        for (let i = 0; i < 52; i++) {
+          const wk = isoWeekKey(checkDate.toISOString());
+          if (weekSet.has(wk)) {
+            attendanceStreak++;
+            misses = 0;
+          } else {
+            misses++;
+            if (misses === 1 && attendanceStreak > 0) {
+              attendanceStreak++;
+              attendanceMulligan = true;
+            } else {
+              break;
+            }
+          }
+          checkDate.setDate(checkDate.getDate() - 7);
+        }
+      }
+
+      groups.push({
+        name: groupName,
+        dow: cluster.dow,
+        avgMinute: cluster.avgMinute,
+        totalRides: cluster.rides.length,
+        isGroupRide,
+        attendanceStreak,
+        attendanceMulligan,
+        lastRideDate: cluster.rides[cluster.rides.length - 1].start_date_local,
+        rides: cluster.rides.map((r) => ({ id: r.id, date: r.start_date_local, name: r.name })),
+      });
+    }
+  }
+
+  // Sort by total rides descending
+  groups.sort((a, b) => b.totalRides - a.totalRides);
+  return groups;
+}
+
+/**
+ * Compute all streak and consistency data for the dashboard.
+ * Called once from loadDashboard, not per-activity.
+ *
+ * @param {Array} allActivities — All activities from IndexedDB
+ * @returns {Object} { weeklyStreak, groupRides }
+ */
+export function computeStreakData(allActivities) {
+  const weeklyStreak = computeWeeklyStreaks(allActivities);
+  const groupRides = detectGroupRides(allActivities);
+  return { weeklyStreak, groupRides };
 }

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -18,7 +18,7 @@ import {
   rateLimitStatus,
   isSyncing,
 } from "../sync.js";
-import { computeAwardsForActivities } from "../awards.js";
+import { computeAwardsForActivities, computeStreakData } from "../awards.js";
 import {
   getAllActivities,
   getAllSegments,
@@ -67,6 +67,7 @@ const refDate = signal("");
 const refCount = signal("10");
 const refBirthday = signal("");
 const refAge = signal("40");
+const streakData = signal(null);
 
 async function loadDashboard() {
   loading.value = true;
@@ -80,6 +81,11 @@ async function loadDashboard() {
     activities.sort((a, b) => b.start_date_local.localeCompare(a.start_date_local));
     const recent = activities.slice(0, 20);
     recentActivities.value = recent;
+
+    // Compute streak data (#58) — uses all activities, not just recent 20
+    if (activities.length > 0) {
+      streakData.value = computeStreakData(activities);
+    }
 
     // Check sync completion state
     const state = await getSyncState();
@@ -292,6 +298,86 @@ export function Dashboard() {
           </div>
         `}
 
+        <!-- Streak Danger Warning (#58) -->
+        ${streakData.value?.weeklyStreak?.danger && html`
+          <div class="rounded-xl p-4 mb-6" style="background: ${streakData.value.weeklyStreak.danger.level === 'critical' ? '#F6DED4' : '#FBF0D8'}; border: 1px solid ${streakData.value.weeklyStreak.danger.level === 'critical' ? '#E4B8A4' : '#E8D4A0'};">
+            <div class="flex items-center gap-2">
+              ${renderIconSVG("weekly_streak", { size: 20, color: streakData.value.weeklyStreak.danger.level === "critical" ? "#7A3418" : "#6E5010" })}
+              <p style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: ${streakData.value.weeklyStreak.danger.level === 'critical' ? '#7A3418' : '#6E5010'};">
+                ${streakData.value.weeklyStreak.danger.message}
+              </p>
+            </div>
+          </div>
+        `}
+
+        <!-- Streak Cards (#58) -->
+        ${streakData.value?.weeklyStreak?.current >= 4 && html`
+          <div class="grid gap-4 mb-6" style="grid-template-columns: ${streakData.value.groupRides?.length > 0 ? '1fr 1fr' : '1fr'};">
+            <!-- Weekly Ride Streak -->
+            <div class="rounded-xl p-4" style="background: var(--surface); border: 1px solid var(--border);">
+              <div class="flex items-center gap-2 mb-2">
+                ${renderIconSVG("weekly_streak", { size: 18, color: "#3D7A4A" })}
+                <span style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: var(--text);">Ride Streak</span>
+                ${streakData.value.weeklyStreak.mulliganUsed && html`
+                  <span class="text-xs px-1.5 py-0.5 rounded-full" style="background: #FBF0D8; color: #6E5010; font-family: var(--font-mono);">mulligan</span>
+                `}
+              </div>
+              <div style="font-family: var(--font-display); font-size: 2rem; color: #3D7A4A;">${streakData.value.weeklyStreak.current}</div>
+              <div style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-secondary);">
+                consecutive weeks${streakData.value.weeklyStreak.streakStart ? ` since ${streakData.value.weeklyStreak.streakStart.replace("-W", " W")}` : ""}
+              </div>
+              ${streakData.value.weeklyStreak.longest > streakData.value.weeklyStreak.current && html`
+                <div class="mt-1" style="font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-tertiary);">
+                  Best: ${streakData.value.weeklyStreak.longest} weeks
+                </div>
+              `}
+            </div>
+
+            <!-- Top Group Ride -->
+            ${streakData.value.groupRides?.length > 0 && (() => {
+              const topGroup = streakData.value.groupRides[0];
+              return html`
+                <div class="rounded-xl p-4" style="background: var(--surface); border: 1px solid var(--border);">
+                  <div class="flex items-center gap-2 mb-2">
+                    ${renderIconSVG("group_consistency", { size: 18, color: "#5B6CA0" })}
+                    <span style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: var(--text);">Group Ride</span>
+                  </div>
+                  <div style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: #34406A;">${topGroup.name}</div>
+                  <div style="font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-secondary);">
+                    ${topGroup.totalRides} rides total${topGroup.attendanceStreak >= 3 ? ` · ${topGroup.attendanceStreak}-week streak` : ""}
+                  </div>
+                  ${topGroup.attendanceMulligan && topGroup.attendanceStreak >= 3 && html`
+                    <span class="text-xs px-1.5 py-0.5 rounded-full mt-1 inline-block" style="background: #FBF0D8; color: #6E5010; font-family: var(--font-mono);">mulligan used</span>
+                  `}
+                </div>
+              `;
+            })()}
+          </div>
+        `}
+
+        <!-- Additional Group Rides (if streak < 4 but groups exist) -->
+        ${streakData.value && !(streakData.value.weeklyStreak?.current >= 4) && streakData.value.groupRides?.length > 0 && html`
+          <div class="rounded-xl p-4 mb-6" style="background: var(--surface); border: 1px solid var(--border);">
+            <div class="flex items-center gap-2 mb-2">
+              ${renderIconSVG("group_consistency", { size: 18, color: "#5B6CA0" })}
+              <span style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: var(--text);">Recurring Rides</span>
+            </div>
+            <div class="space-y-2">
+              ${streakData.value.groupRides.slice(0, 3).map((g) => html`
+                <div class="flex items-center justify-between">
+                  <div>
+                    <span style="font-family: var(--font-body); font-size: 0.875rem; color: #34406A;">${g.name}</span>
+                    <span style="font-family: var(--font-mono); font-size: 0.75rem; color: var(--text-tertiary);"> · ${g.totalRides} rides</span>
+                  </div>
+                  ${g.attendanceStreak >= 3 && html`
+                    <span class="text-xs px-2 py-0.5 rounded-full" style="background: #E4E8F2; color: #34406A; border: 1px solid #BCC4DC;">${g.attendanceStreak}w streak</span>
+                  `}
+                </div>
+              `)}
+            </div>
+          </div>
+        `}
+
         <!-- Stats -->
         <div class="grid grid-cols-2 gap-4 mb-6">
           <div class="rounded-xl p-4 text-center" style="background: var(--surface); border: 1px solid var(--border);">
@@ -327,7 +413,7 @@ export function Dashboard() {
               for (const a of awards) {
                 typeCounts.set(a.type, (typeCounts.get(a.type) || 0) + 1);
               }
-              const typeOrder = ["route_season_first", "season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "reference_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record"];
+              const typeOrder = ["route_season_first", "season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "reference_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record", "weekly_streak", "group_consistency"];
               const summary = typeOrder
                 .filter((t) => typeCounts.has(t))
                 .map((t) => ({ type: t, count: typeCounts.get(t) }));
@@ -443,6 +529,8 @@ export function Dashboard() {
                     ["comeback_pb", "Comeback PB", "Post-injury personal best on a segment. Only appears when Comeback Mode is active."],
                     ["recovery_milestone", "Recovery", "You've reached 80%, 90%, or 95% of your pre-injury best on a segment."],
                     ["comeback_full", "You're Back!", "You've matched or beaten your pre-injury best. Full recovery on this segment."],
+                    ["weekly_streak", "Ride Streak", "Consecutive weeks with at least one ride. One missed week is forgiven (mulligan) — two consecutive misses break the streak."],
+                    ["group_consistency", "Group Ride", "Detects recurring rides by day, time, and location. Tracks your attendance streak on each group ride."],
                   ].map(([type, label, desc]) => {
                     const al = AWARD_LABELS[type];
                     return html`

--- a/src/icons.js
+++ b/src/icons.js
@@ -309,6 +309,22 @@ const ICON_DEFS = {
     { type: "circle", cx: 22, cy: 10, r: 0.8 },                           // dot
     { type: "circle", cx: 22, cy: 14, r: 0.8 },                           // dot
   ],
+
+  // ── Streak & Consistency Awards (#58) ──────────────────────────────
+
+  // 🔥 Weekly Ride Streak — flame
+  weekly_streak: [
+    { type: "path", d: "M12 22c-4 0-7-3-7-7 0-3 2-5 4-8 1 2 2 3 2 5 0-3 2-5 3-7 1 3 2 6 2 8 0 3-1.5 5.5-4 9" },
+    { type: "path", d: "M12 22c-2 0-3.5-1.5-3.5-3.5C8.5 16 10 14 12 13c2 1 3.5 3 3.5 5.5 0 2-1.5 3.5-3.5 3.5z" },
+  ],
+
+  // 👥 Group Ride Consistency — two cyclists
+  group_consistency: [
+    { type: "circle", cx: 8, cy: 7, r: 3 },                              // person 1 head
+    { type: "path", d: "M2 21v-2a4 4 0 014-4h4a4 4 0 014 4v2" },        // person 1 body
+    { type: "circle", cx: 16, cy: 7, r: 3 },                              // person 2 head
+    { type: "path", d: "M16 15h4a4 4 0 014 4v2" },                       // person 2 body
+  ],
 };
 
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -114,6 +114,9 @@ function toActivitySummary(a) {
     device_watts: a.device_watts || false,
     kilojoules: a.kilojoules || null,
     trainer: a.trainer || false,
+    // Group ride detection fields (#58)
+    start_latlng: a.start_latlng || null,
+    athlete_count: a.athlete_count || 1,
     has_efforts: false,
     segment_efforts: [],
   };
@@ -267,6 +270,9 @@ async function fetchActivityDetails() {
         device_watts: full.device_watts || activity.device_watts || false,
         kilojoules: full.kilojoules || activity.kilojoules || null,
         trainer: full.trainer || activity.trainer || false,
+        // Group ride detection fields (#58)
+        start_latlng: full.start_latlng || activity.start_latlng || null,
+        athlete_count: full.athlete_count || activity.athlete_count || 1,
       };
 
       await putActivity(updated);
@@ -690,6 +696,8 @@ export async function resyncActivity(activityId) {
     device_watts: full.device_watts || false,
     kilojoules: full.kilojoules || null,
     trainer: full.trainer || false,
+    start_latlng: full.start_latlng || existing.start_latlng || null,
+    athlete_count: full.athlete_count || existing.athlete_count || 1,
     has_efforts: true,
     segment_efforts: efforts,
   };


### PR DESCRIPTION
Implement consistency & streak awards:
- Weekly ride streak tracking with mulligan support (1 missed week forgiven)
- Group ride detection via day-of-week, start time, and location clustering
- Streak danger warnings when active streak is at risk
- Dashboard cards showing current streak, group rides, and attendance
- Store start_latlng and athlete_count from Strava API for group detection

https://claude.ai/code/session_01LJBWhCUVYCwECKa9Bh99T8