### PR TITLE
feat: add power curve computation, trend & milestone awards (#47, #48)

### DIFF
--- a/src/_MAP.md
+++ b/src/_MAP.md
@@ -1,5 +1,5 @@
 # src/
-*Files: 10 | Subdirectories: 1*
+*Files: 11 | Subdirectories: 1*
 
 ## Subdirectories
 
@@ -32,6 +32,17 @@
 - **computeAwards** (f) `(activity, resetEvent = null, referencePoints = [])` :472
 - **computeRideLevelAwards** (f) `(activity, allActivities, resetEvent = null)` :988
 - **computeAwardsForActivities** (f) `(activities)` :1484
+
+### power-curve.js
+> Imports: `signals, config.js, auth.js, db.js`
+- **POWER_CURVE_DURATIONS** (variable) :27
+- **DURATION_LABELS** (variable) :30
+- **powerCurveProgress** (variable) :41
+- **computePowerCurve** (f) `(watts)` :53
+- **estimateFTP** (f) `(powerCurve)` :81
+- **fetchAndComputePowerCurve** (f) `(activityId)` :123
+- **getActivitiesNeedingPowerCurves** (f) `()` :155
+- **getAllTimeBestCurve** (f) `()` :167
 
 ### config.js
 - **STRAVA_CLIENT_ID** (variable) :6

--- a/src/award-config.js
+++ b/src/award-config.js
@@ -53,6 +53,15 @@ export const AWARD_LABELS = {
   // Streak & consistency awards (#58)
   weekly_streak:        { label: "Ride Streak",       dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
   group_consistency:    { label: "Group Ride",        dot: "#5B6CA0", bg: "#E4E8F2", text: "#34406A", border: "#BCC4DC" },
+  // Power trend & milestone awards (#47)
+  watt_milestone:       { label: "Watt Milestone",    dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
+  kj_milestone:         { label: "kJ Milestone",      dot: "#B85A28", bg: "#F8E4D4", text: "#7A3418", border: "#E8C0A4" },
+  power_progression:    { label: "Power Up",          dot: "#3D7A4A", bg: "#E4F0E4", text: "#204E28", border: "#B8D4B0" },
+  power_consistency:    { label: "Steady Power",      dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
+  ftp_milestone:        { label: "FTP Milestone",     dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
+  // Power curve awards (#48)
+  curve_year_best:      { label: "Curve Year Best",   dot: "#B8862E", bg: "#FBF0D8", text: "#6E5010", border: "#E8D4A0" },
+  curve_all_time:       { label: "Curve Record",      dot: "#A03020", bg: "#F6DCD4", text: "#6E1810", border: "#E4B0A4" },
 };
 
 // Share card colors derived from AWARD_LABELS

--- a/src/awards.js
+++ b/src/awards.js
@@ -48,6 +48,17 @@
  *   - Trainer Streak: Consecutive weeks with at least one indoor ride
  *   - Indoor vs Outdoor: NP comparison when outdoor ride follows indoor training
  *
+ * Power trend & milestone awards (Phase 3, #47):
+ *   - Watt Milestone: First ride averaging 100/150/200/250/300/350W
+ *   - kJ Milestone: First ride exceeding 500/1000/1500/2000/2500/3000 kJ
+ *   - Power Progression: NP trending upward over last 10 rides (linear regression)
+ *   - Power Consistency: Low CV in NP across last 10 rides
+ *   - FTP Milestone: Estimated FTP (95% of 20-min best) crossing thresholds
+ *
+ * Power curve awards (Phase 2, #48):
+ *   - Curve Year Best: Year's best power at a standard duration (5s/30s/1m/5m/20m/60m)
+ *   - Curve All-Time: All-time personal record at a standard duration
+ *
  * Streak & consistency awards (#58):
  *   - Weekly Ride Streak: Consecutive weeks with at least one ride (mulligan support)
  *   - Group Ride Consistency: Attendance tracking on recurring group rides
@@ -113,6 +124,34 @@ const TRAINER_STREAK_MIN_WEEKS = 3;
 
 /** Minimum recent indoor rides to compute indoor vs outdoor comparison */
 const INDOOR_VS_OUTDOOR_MIN_INDOOR = 3;
+
+/** Minimum powered rides for power trend awards */
+const POWER_TREND_MIN_RIDES = 10;
+
+/** R² threshold for power progression trend to trigger award */
+const POWER_TREND_R2_THRESHOLD = 0.3;
+
+/** NP Watt milestones */
+const WATT_MILESTONES = [100, 150, 200, 250, 300, 350];
+
+/** kJ milestones */
+const KJ_MILESTONES = [500, 1000, 1500, 2000, 2500, 3000];
+
+/** FTP milestones (based on 95% of 20-min best power) */
+const FTP_MILESTONES = [150, 200, 250, 300, 350, 400];
+
+/** Power curve duration labels for award messages */
+const CURVE_DURATION_LABELS = {
+  5: "5-second",
+  30: "30-second",
+  60: "1-minute",
+  300: "5-minute",
+  1200: "20-minute",
+  3600: "60-minute",
+};
+
+/** Standard power curve durations */
+const POWER_CURVE_DURATIONS = [5, 30, 60, 300, 1200, 3600];
 
 /** Recovery ratio above which normal comparative awards are suppressed */
 const RECOVERY_ZONE_THRESHOLD = 1.15;
@@ -1473,6 +1512,217 @@ export function computeRideLevelAwards(activity, allActivities, resetEvent = nul
     }
   }
 
+  // ── Power Trend & Milestone Awards (Phase 3, #47) ──────────────────
+
+  if (activity.device_watts && activity.weighted_average_watts > 0) {
+    // --- Watt Milestone (#47) ---
+    // First ride where weighted_average_watts exceeds a threshold
+    const allPoweredSameType = allActivities.filter(
+      (a) =>
+        a.sport_type === activity.sport_type &&
+        a.device_watts &&
+        a.weighted_average_watts > 0 &&
+        a.id !== activity.id &&
+        a.start_date_local < activity.start_date_local
+    );
+
+    for (const threshold of WATT_MILESTONES) {
+      if (activity.weighted_average_watts >= threshold) {
+        const anyPrior = allPoweredSameType.some(
+          (a) => a.weighted_average_watts >= threshold
+        );
+        if (!anyPrior) {
+          awards.push({
+            type: "watt_milestone",
+            segment: null,
+            segment_id: null,
+            time: null,
+            power: activity.weighted_average_watts,
+            comparison: null,
+            delta: null,
+            message: `First ride averaging ${threshold}W! Welcome to the ${threshold}W club`,
+          });
+          break; // Only award the highest milestone crossed for the first time
+        }
+      }
+    }
+
+    // --- kJ Milestone (#47) ---
+    // First ride exceeding energy thresholds
+    if (activity.kilojoules > 0) {
+      const allPoweredWithKJ = allPoweredSameType.filter((a) => a.kilojoules > 0);
+      for (const threshold of KJ_MILESTONES) {
+        if (activity.kilojoules >= threshold) {
+          const anyPrior = allPoweredWithKJ.some(
+            (a) => a.kilojoules >= threshold
+          );
+          if (!anyPrior) {
+            awards.push({
+              type: "kj_milestone",
+              segment: null,
+              segment_id: null,
+              time: null,
+              power: activity.weighted_average_watts,
+              comparison: null,
+              delta: null,
+              message: `First ${threshold.toLocaleString()} kJ ride — that's a massive effort!`,
+            });
+            break;
+          }
+        }
+      }
+    }
+
+    // --- Power Progression (#47) ---
+    // NP trending upward over last N rides (linear regression)
+    const recentPowered = allActivities
+      .filter(
+        (a) =>
+          a.sport_type === activity.sport_type &&
+          a.device_watts &&
+          a.weighted_average_watts > 0
+      )
+      .sort((a, b) => a.start_date_local.localeCompare(b.start_date_local));
+
+    // Find this activity's position and take the window ending with it
+    const actIdx = recentPowered.findIndex((a) => a.id === activity.id);
+    if (actIdx >= POWER_TREND_MIN_RIDES - 1) {
+      const window = recentPowered.slice(actIdx - POWER_TREND_MIN_RIDES + 1, actIdx + 1);
+      const npValues = window.map((a) => a.weighted_average_watts);
+      const { slope, r2 } = linearRegression(npValues);
+
+      if (slope > 0 && r2 >= POWER_TREND_R2_THRESHOLD) {
+        const totalGain = Math.round(slope * (POWER_TREND_MIN_RIDES - 1));
+        awards.push({
+          type: "power_progression",
+          segment: null,
+          segment_id: null,
+          time: null,
+          power: activity.weighted_average_watts,
+          comparison: null,
+          delta: totalGain,
+          message: `Power trending up! Your NP has increased ~${totalGain}W over your last ${POWER_TREND_MIN_RIDES} rides`,
+        });
+      }
+    }
+
+    // --- Power Consistency (#47) ---
+    // Low coefficient of variation in NP across recent rides
+    if (actIdx >= POWER_TREND_MIN_RIDES - 1) {
+      const window = recentPowered.slice(actIdx - POWER_TREND_MIN_RIDES + 1, actIdx + 1);
+      const npValues = window.map((a) => a.weighted_average_watts);
+      const mean = npValues.reduce((s, v) => s + v, 0) / npValues.length;
+      const variance = npValues.reduce((s, v) => s + (v - mean) ** 2, 0) / npValues.length;
+      const stddev = Math.sqrt(variance);
+      const cv = stddev / mean;
+
+      if (cv < CONSISTENCY_CV_THRESHOLD && mean > 0) {
+        awards.push({
+          type: "power_consistency",
+          segment: null,
+          segment_id: null,
+          time: null,
+          power: activity.weighted_average_watts,
+          comparison: null,
+          delta: null,
+          message: `Rock solid: your last ${POWER_TREND_MIN_RIDES} rides averaged ${Math.round(mean)}W ± ${Math.round(stddev)}W. That's remarkably consistent`,
+        });
+      }
+    }
+
+    // --- FTP Milestone (#47) ---
+    // When estimated FTP (95% of 20-min best from power_curve) crosses thresholds
+    if (activity.power_curve && activity.power_curve[1200]) {
+      const currentFTP = Math.round(activity.power_curve[1200] * 0.95);
+      const priorWithCurves = allPoweredSameType.filter(
+        (a) => a.power_curve && a.power_curve[1200]
+      );
+      for (const threshold of FTP_MILESTONES) {
+        if (currentFTP >= threshold) {
+          const anyPrior = priorWithCurves.some(
+            (a) => Math.round(a.power_curve[1200] * 0.95) >= threshold
+          );
+          if (!anyPrior) {
+            awards.push({
+              type: "ftp_milestone",
+              segment: null,
+              segment_id: null,
+              time: null,
+              power: currentFTP,
+              comparison: null,
+              delta: null,
+              message: `Estimated FTP: ${currentFTP}W — you've crossed the ${threshold}W threshold!`,
+            });
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  // --- Power Curve Year Best & All-Time Best (#48) ---
+  if (activity.power_curve) {
+    const activityDate = new Date(activity.start_date_local);
+    const afterCalendarGate = (activityDate.getMonth() + 1) >= YEAR_BEST_CALENDAR_GATE_MONTH;
+
+    const allWithCurves = allActivities.filter(
+      (a) =>
+        a.sport_type === activity.sport_type &&
+        a.power_curve &&
+        a.id !== activity.id
+    );
+
+    const sameYearWithCurves = allWithCurves.filter(
+      (a) => new Date(a.start_date_local).getFullYear() === currentYear
+    );
+
+    for (const dur of POWER_CURVE_DURATIONS) {
+      if (!activity.power_curve[dur]) continue;
+
+      // Year Best at this duration
+      if (afterCalendarGate && sameYearWithCurves.length >= 3) {
+        const priorBest = Math.max(
+          0,
+          ...sameYearWithCurves.map((a) => a.power_curve[dur] || 0)
+        );
+        if (activity.power_curve[dur] > priorBest && priorBest > 0) {
+          awards.push({
+            type: "curve_year_best",
+            segment: null,
+            segment_id: null,
+            time: null,
+            power: activity.power_curve[dur],
+            comparison: null,
+            delta: activity.power_curve[dur] - priorBest,
+            message: `Year Best ${CURVE_DURATION_LABELS[dur]} power: ${activity.power_curve[dur]}W — ${activity.power_curve[dur] - priorBest}W above previous best`,
+            curve_duration: dur,
+          });
+        }
+      }
+
+      // All-time best at this duration
+      if (allWithCurves.length >= 5) {
+        const allTimeBest = Math.max(
+          0,
+          ...allWithCurves.map((a) => a.power_curve[dur] || 0)
+        );
+        if (activity.power_curve[dur] > allTimeBest && allTimeBest > 0) {
+          awards.push({
+            type: "curve_all_time",
+            segment: null,
+            segment_id: null,
+            time: null,
+            power: activity.power_curve[dur],
+            comparison: null,
+            delta: activity.power_curve[dur] - allTimeBest,
+            message: `All-time best ${CURVE_DURATION_LABELS[dur]} power: ${activity.power_curve[dur]}W! New personal record`,
+            curve_duration: dur,
+          });
+        }
+      }
+    }
+  }
+
   return awards;
 }
 
@@ -1559,6 +1809,41 @@ const STREAK_TIERS = [4, 8, 12, 26, 52];
 
 /** Minimum consecutive weeks for a weekly ride streak award */
 const WEEKLY_STREAK_MIN = 4;
+
+/**
+ * Simple linear regression on an array of values (y values, x = 0..n-1).
+ * Returns { slope, intercept, r2 }.
+ */
+function linearRegression(values) {
+  const n = values.length;
+  if (n < 2) return { slope: 0, intercept: values[0] || 0, r2: 0 };
+
+  let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0, sumY2 = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += i;
+    sumY += values[i];
+    sumXY += i * values[i];
+    sumX2 += i * i;
+    sumY2 += values[i] * values[i];
+  }
+
+  const denom = n * sumX2 - sumX * sumX;
+  if (denom === 0) return { slope: 0, intercept: sumY / n, r2: 0 };
+
+  const slope = (n * sumXY - sumX * sumY) / denom;
+  const intercept = (sumY - slope * sumX) / n;
+
+  // R² (coefficient of determination)
+  const yMean = sumY / n;
+  let ssTot = 0, ssRes = 0;
+  for (let i = 0; i < n; i++) {
+    ssTot += (values[i] - yMean) ** 2;
+    ssRes += (values[i] - (intercept + slope * i)) ** 2;
+  }
+  const r2 = ssTot === 0 ? 0 : 1 - ssRes / ssTot;
+
+  return { slope, intercept, r2 };
+}
 
 /** Haversine distance in km between two [lat, lng] coordinates */
 function haversineKm(a, b) {

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -531,6 +531,13 @@ export function Dashboard() {
                     ["comeback_full", "You're Back!", "You've matched or beaten your pre-injury best. Full recovery on this segment."],
                     ["weekly_streak", "Ride Streak", "Consecutive weeks with at least one ride. One missed week is forgiven (mulligan) — two consecutive misses break the streak."],
                     ["group_consistency", "Group Ride", "Detects recurring rides by day, time, and location. Tracks your attendance streak on each group ride."],
+                    ["watt_milestone", "Watt Milestone", "First ride where your average power exceeds a threshold (100W, 150W, ... 350W). Measures sustained effort."],
+                    ["kj_milestone", "kJ Milestone", "First ride exceeding an energy threshold (500kJ, 1000kJ, ... 3000kJ). Energy is energy — sport-agnostic."],
+                    ["power_progression", "Power Up", "Your Normalized Power is trending upward over your last 10 rides. Uses linear regression to detect real improvement."],
+                    ["power_consistency", "Steady Power", "Low variation in NP across your last 10 rides — steady, repeatable power output."],
+                    ["ftp_milestone", "FTP Milestone", "Your estimated FTP (95% of 20-min best) crosses a threshold (150W, 200W, ... 400W). Requires power curve data."],
+                    ["curve_year_best", "Curve Year Best", "Year's best power at a standard duration (5s sprint, 1min anaerobic, 5min VO2max, 20min FTP, etc)."],
+                    ["curve_all_time", "Curve Record", "All-time personal record at a standard power curve duration. Your best ever."],
                   ].map(([type, label, desc]) => {
                     const al = AWARD_LABELS[type];
                     return html`

--- a/src/power-curve.js
+++ b/src/power-curve.js
@@ -1,0 +1,195 @@
+/**
+ * Power Curve — Stream fetching and duration-based power bests (#48)
+ *
+ * Fetches second-by-second power data via the Strava Streams API and computes
+ * best average power over standard durations (the "power curve").
+ *
+ * Standard durations:
+ *   5s   — peak sprint
+ *   30s  — sprint endurance
+ *   60s  — anaerobic capacity
+ *   300s — VO2max proxy (5 min)
+ *   1200s — FTP proxy (20 min, subtract 5% for estimated FTP)
+ *   3600s — sustained threshold (60 min)
+ *
+ * Power curve data is stored on the activity object as `power_curve`.
+ * Only available for activities with device_watts === true.
+ */
+
+import { STRAVA_API_BASE } from "./config.js";
+import { getValidToken } from "./auth.js";
+import { getActivity, putActivity, getAllActivities } from "./db.js";
+import { signal } from "@preact/signals";
+
+/** Standard power curve durations in seconds */
+export const POWER_CURVE_DURATIONS = [5, 30, 60, 300, 1200, 3600];
+
+/** Human-readable labels for each duration */
+export const DURATION_LABELS = {
+  5: "5s",
+  30: "30s",
+  60: "1min",
+  300: "5min",
+  1200: "20min",
+  3600: "60min",
+};
+
+/** Sync progress for power curve fetching */
+export const powerCurveProgress = signal({
+  phase: "idle", // idle | fetching | done | error
+  current: 0,
+  total: 0,
+  message: "",
+});
+
+/**
+ * Compute best average power for each standard duration using a sliding window.
+ * Returns { 5: number, 30: number, 60: number, 300: number, 1200: number, 3600: number }
+ * or null if watts array is too short for any computation.
+ *
+ * @param {number[]} watts — Per-second power values
+ * @returns {Object|null} Power curve bests
+ */
+export function computePowerCurve(watts) {
+  if (!watts || watts.length < 5) return null;
+
+  const curve = {};
+  // Build prefix sum for efficient sliding window
+  const prefixSum = new Float64Array(watts.length + 1);
+  for (let i = 0; i < watts.length; i++) {
+    prefixSum[i + 1] = prefixSum[i] + watts[i];
+  }
+
+  for (const duration of POWER_CURVE_DURATIONS) {
+    if (watts.length < duration) continue;
+    let maxAvg = 0;
+    for (let i = 0; i <= watts.length - duration; i++) {
+      const avg = (prefixSum[i + duration] - prefixSum[i]) / duration;
+      if (avg > maxAvg) maxAvg = avg;
+    }
+    curve[duration] = Math.round(maxAvg);
+  }
+
+  return Object.keys(curve).length > 0 ? curve : null;
+}
+
+/**
+ * Estimate FTP from 20-minute best power (95% of 20-min best).
+ * @param {Object} powerCurve — Power curve object
+ * @returns {number|null} Estimated FTP in watts
+ */
+export function estimateFTP(powerCurve) {
+  if (!powerCurve || !powerCurve[1200]) return null;
+  return Math.round(powerCurve[1200] * 0.95);
+}
+
+/**
+ * Fetch power stream for a single activity from Strava API.
+ * Returns array of per-second watts, or null if unavailable.
+ *
+ * @param {number} activityId — Strava activity ID
+ * @returns {number[]|null} Watts array
+ */
+async function fetchPowerStream(activityId) {
+  const token = await getValidToken();
+  const url = `${STRAVA_API_BASE}/activities/${activityId}/streams?keys=watts,time&key_by_type=true`;
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (response.status === 404 || response.status === 403) {
+    // No streams available for this activity
+    return null;
+  }
+
+  if (response.status === 429) {
+    const retryAfter = parseInt(response.headers.get("Retry-After") || "900");
+    throw new RateLimitError(retryAfter);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Strava Streams API error: ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  // Streams API returns { watts: { data: [...] }, time: { data: [...] } }
+  if (!data.watts || !data.watts.data) return null;
+
+  return data.watts.data;
+}
+
+class RateLimitError extends Error {
+  constructor(retryAfter) {
+    super(`Rate limited. Retry after ${retryAfter}s`);
+    this.retryAfter = retryAfter;
+  }
+}
+
+/**
+ * Fetch power stream and compute power curve for a single activity.
+ * Stores the result on the activity object in IndexedDB.
+ * No-ops if the activity already has a power_curve or lacks device_watts.
+ *
+ * @param {number} activityId — Activity ID
+ * @returns {Object|null} Power curve, or null if unavailable
+ */
+export async function fetchAndComputePowerCurve(activityId) {
+  const activity = await getActivity(activityId);
+  if (!activity) return null;
+
+  // Already computed
+  if (activity.power_curve !== undefined) return activity.power_curve;
+
+  // No power meter
+  if (!activity.device_watts) {
+    await putActivity({ ...activity, power_curve: null });
+    return null;
+  }
+
+  try {
+    const watts = await fetchPowerStream(activityId);
+    const curve = watts ? computePowerCurve(watts) : null;
+    await putActivity({ ...activity, power_curve: curve });
+    return curve;
+  } catch (err) {
+    if (err instanceof RateLimitError) throw err;
+    console.warn(`Failed to fetch power stream for activity ${activityId}:`, err);
+    // Mark as attempted but failed — store null so we don't retry
+    await putActivity({ ...activity, power_curve: null });
+    return null;
+  }
+}
+
+/**
+ * Get all activities that need power curve computation.
+ * These are activities with device_watts === true but no power_curve field.
+ *
+ * @returns {Array} Activities needing power curves
+ */
+export async function getActivitiesNeedingPowerCurves() {
+  const all = await getAllActivities();
+  return all.filter(
+    (a) => a.device_watts && a.has_efforts && !("power_curve" in a)
+  );
+}
+
+/**
+ * Get all-time best power curve across all activities.
+ * @returns {Object} { 5: number, 30: number, ... } all-time bests per duration
+ */
+export async function getAllTimeBestCurve() {
+  const all = await getAllActivities();
+  const best = {};
+
+  for (const a of all) {
+    if (!a.power_curve) continue;
+    for (const dur of POWER_CURVE_DURATIONS) {
+      if (a.power_curve[dur] && (!best[dur] || a.power_curve[dur] > best[dur])) {
+        best[dur] = a.power_curve[dur];
+      }
+    }
+  }
+
+  return best;
+}


### PR DESCRIPTION
Phase 2 (#48): Power curve module that fetches second-by-second power
streams from Strava API and computes best average power over standard
durations (5s, 30s, 1min, 5min, 20min, 60min) using sliding windows.
Includes FTP estimation (95% of 20-min best).

Phase 3 (#47): Power trend and milestone awards:
- Watt Milestone: first ride averaging 100/150/200/250/300/350W
- kJ Milestone: first ride exceeding energy thresholds
- Power Progression: NP trending up over last 10 rides (linear regression)
- Power Consistency: low CV in NP across last 10 rides
- FTP Milestone: estimated FTP crossing threshold levels
- Curve Year Best: year's best power at each standard duration
- Curve All-Time: all-time PR at each standard duration

https://claude.ai/code/session_01AdcGVsTTnf9GL7zecpR5DV