### PR TITLE
Add manual sync button in FAQ & Settings menu

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -14,6 +14,7 @@ import { authState, disconnect } from "../auth.js";
 import {
   startAutoSync,
   stopAutoSync,
+  manualSync,
   syncProgress,
   rateLimitStatus,
   isSyncing,
@@ -857,6 +858,31 @@ export function Dashboard() {
             </div>
 
             <div class="mt-4 pt-4 space-y-3" style="border-top: 1px solid var(--border-light);">
+              ${!isDemo.value && html`
+                <div>
+                  <button
+                    onClick=${async () => {
+                      try {
+                        await manualSync();
+                      } catch (e) {
+                        console.error("Manual sync error:", e);
+                      }
+                      await loadDashboard();
+                    }}
+                    disabled=${syncing}
+                    class="text-xs font-medium transition-colors inline-flex items-center gap-1.5"
+                    style=${syncing
+                      ? "color: var(--text-tertiary); cursor: not-allowed;"
+                      : "color: var(--strava);"}
+                  >
+                    ${syncing ? html`
+                      <div class="w-3 h-3 border-2 border-t-transparent rounded-full animate-spin flex-shrink-0" style="border-color: var(--strava); border-top-color: transparent;"></div>
+                      Syncing…
+                    ` : "Sync now"}
+                  </button>
+                  <p class="text-xs mt-1" style="color: var(--border);">Check Strava for new activities. The app syncs automatically every 5 minutes.</p>
+                </div>
+              `}
               ${isDemo.value ? html`
                 <div>
                   <button

--- a/src/sync.js
+++ b/src/sync.js
@@ -561,6 +561,23 @@ export async function incrementalSync() {
   }
 }
 
+/**
+ * Manual sync — triggered by user from settings menu.
+ * Runs backfill or incremental as appropriate, same as auto-sync cycle.
+ * Returns without error on rate-limit (progress signal shows status).
+ */
+export async function manualSync() {
+  if (isSyncing.value) return;
+
+  const state = await getSyncState();
+
+  if (!state.backfill_complete) {
+    await startBackfill();
+  } else {
+    await incrementalSync();
+  }
+}
+
 // --- Auto-Sync Scheduler ---
 
 const SYNC_INTERVAL = 5 * 60 * 1000;       // 5 min between incremental checks


### PR DESCRIPTION
## Summary
- Adds a "Sync now" button in the ? (FAQ & Settings) menu so users can manually trigger a check for new Strava activities
- Simpler alternative to webhook-based push sync (#32) — no server-side data storage, webhook management, or cache invalidation needed
- Users already know when their latest rides are not showing; this gives them a one-click way to pull them in

## Changes
- **src/sync.js**: New `manualSync()` export that runs backfill or incremental sync as appropriate
- **src/components/Dashboard.js**: "Sync now" button in FAQ modal, above Disconnect/Delete. Shows spinner while syncing, disabled during active sync, hidden in demo mode. Dashboard data reloads after sync completes.

## Test plan
- [ ] Open the ? menu - verify "Sync now" button appears with Strava-orange text
- [ ] Click "Sync now" - verify spinner appears and button disables during sync
- [ ] After sync completes - verify dashboard refreshes with any new activities
- [ ] While auto-sync is running - verify button shows syncing state
- [ ] In demo mode - verify "Sync now" button is not shown
- [ ] Verify auto-sync continues working normally alongside manual sync

https://claude.ai/code/session_01XWQuj9AdePVTemVU1bWkjN