### PR TITLE
Fix site stuck on Loading: add init error handling, bust stale SW cache

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -60,9 +60,14 @@ function App() {
 // --- Init ---
 
 async function init() {
-  initInstallDetection();
-  await initAuth();
-  await checkDemo();
+  try {
+    initInstallDetection();
+    await initAuth();
+    await checkDemo();
+  } catch (err) {
+    console.error("Init error:", err);
+  }
+
   render(html`<${App} />`, document.getElementById("app"));
 
   // Re-render on auth and route changes

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
  * All Strava data lives in IndexedDB — SW just needs to serve the app offline.
  */
 
-const CACHE_NAME = "aeyu-v4";
+const CACHE_NAME = "aeyu-v5";
 
 const APP_SHELL = [
   "/",
@@ -17,6 +17,11 @@ const APP_SHELL = [
   "/src/db.js",
   "/src/sync.js",
   "/src/install.js",
+  "/src/demo.js",
+  "/src/units.js",
+  "/src/icons.js",
+  "/src/award-config.js",
+  "/src/power-curve.js",
   "/src/components/Landing.js",
   "/src/components/Dashboard.js",
   "/src/components/SyncProgress.js",
@@ -76,8 +81,9 @@ self.addEventListener("fetch", (event) => {
   }
 
   // App shell: network-first, cache fallback (deploys are immediately visible)
+  // Use cache: "no-cache" to bypass browser HTTP cache and always revalidate
   event.respondWith(
-    fetch(event.request)
+    fetch(event.request, { cache: "no-cache" })
       .then((response) => {
         if (response.ok && event.request.method === "GET") {
           const clone = response.clone();


### PR DESCRIPTION
The site could get stuck on "Loading..." forever because:
1. init() had no error handling — any failure in initAuth() or checkDemo()
   (e.g. IndexedDB issues) silently prevented rendering
2. Service worker cache (aeyu-v4) was missing 5 JS files added since last
   SW update (demo.js, units.js, icons.js, award-config.js, power-curve.js)
3. SW network-first fetch used browser HTTP cache, which could serve stale
   files after a deploy

Fixes:
- Wrap init() try/catch so app always renders even if auth/demo check fails
- Bump SW cache to v5 and add all missing JS files to APP_SHELL
- Add cache: "no-cache" to SW fetch so network-first actually revalidates

https://claude.ai/code/session_014EJQTyzXCiVhNCcVEUpAXt