### PR TITLE
Add Strava deep links to activity detail page

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -587,7 +587,12 @@ export function ActivityDetail({ id }) {
             ← Back to dashboard
           </button>
           <div class="flex items-center justify-between gap-3">
-            <h1 style="font-family: var(--font-display); font-size: 1.25rem; color: var(--text);">${act.name}</h1>
+            <div class="flex items-center gap-2">
+              <h1 style="font-family: var(--font-display); font-size: 1.25rem; color: var(--text);">${act.name}</h1>
+              <a href=${`https://www.strava.com/activities/${act.id}`} target="_blank" rel="noopener noreferrer" title="View on Strava" class="flex-shrink-0" style="color: var(--strava); opacity: 0.7; transition: opacity 0.15s;" onMouseOver=${e => e.currentTarget.style.opacity = '1'} onMouseOut=${e => e.currentTarget.style.opacity = '0.7'}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              </a>
+            </div>
             ${!isDemo.value && html`
               <button
                 onClick=${handleResync}
@@ -745,7 +750,12 @@ export function ActivityDetail({ id }) {
                 <div class="rounded-xl p-4" style=${hasAwards
                   ? "background: var(--surface); border: 1px solid var(--border);"
                   : "background: var(--surface); border: 1px solid var(--border); opacity: 0.7;"}>
-                  <div style="font-family: var(--font-body); font-size: 16px; font-weight: 500; color: var(--text);">${effort.segment.name}</div>
+                  <div class="flex items-center gap-1.5" style="font-family: var(--font-body); font-size: 16px; font-weight: 500; color: var(--text);">
+                    ${effort.segment.name}
+                    <a href=${`https://www.strava.com/segments/${effort.segment.id}`} target="_blank" rel="noopener noreferrer" title="View segment on Strava" class="flex-shrink-0" style="color: var(--strava); opacity: 0.5; transition: opacity 0.15s;" onMouseOver=${e => e.currentTarget.style.opacity = '1'} onMouseOut=${e => e.currentTarget.style.opacity = '0.5'} onClick=${e => e.stopPropagation()}>
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                    </a>
+                  </div>
                   <div class="mt-1" style="font-family: var(--font-mono); font-size: 14px; color: var(--text-secondary);">
                     ${formatDistance(effort.segment.distance)}
                     · ${effort.segment.average_grade}% grade


### PR DESCRIPTION
Add external-link icons next to the activity title (links to the activity
on Strava) and next to each segment name (links to the segment on Strava).
Icons use Strava brand color with subtle hover effect.

https://claude.ai/code/session_019nYTL44dFwCRo2rv2hCbvD