### PR TITLE
Fix loading state: error boundary, safe render, flag-based detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,9 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png">
 
-    <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif&family=DM+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <!-- Fonts (non-render-blocking: load as print, swap to all on load) -->
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif&family=DM+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+    <noscript><link href="https://fonts.googleapis.com/css2?family=Instrument+Serif&family=DM+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"></noscript>
 
     <script src="https://cdn.tailwindcss.com"></script>
     <script type="importmap">
@@ -73,24 +74,62 @@
     <script>
       // Register service worker
       if ("serviceWorker" in navigator) {
-        navigator.serviceWorker.register("/sw.js").catch(() => {});
+        navigator.serviceWorker.register("/sw.js").catch(function() {});
       }
 
-      // Detect stuck loading: if module fails to load (CDN down, SW cache miss,
-      // network error), init() never runs and "Loading..." stays forever.
-      // After 10s, show an error with a reload button.
+      // Global error handlers — catch unhandled errors and show them to the user
+      // instead of silently failing with "Loading..." stuck on screen.
+      window.__appModuleLoaded = false;
+      window.__appRendered = false;
+
+      window.onerror = function(msg, url, line, col, error) {
+        console.error("Global error:", msg, url, line, col, error);
+        showLoadError("JS error: " + msg);
+      };
+
+      window.addEventListener("unhandledrejection", function(event) {
+        console.error("Unhandled rejection:", event.reason);
+        showLoadError("Async error: " + (event.reason && event.reason.message || event.reason));
+      });
+
+      // Detect stuck loading using flags set by app.js instead of fragile DOM text matching.
+      // Checks at 8s and 15s to catch both fast and slow failure scenarios.
       setTimeout(function() {
-        var app = document.getElementById("app");
-        if (app && app.querySelector("p") && app.textContent.trim() === "Loading...") {
-          app.innerHTML =
-            '<div class="min-h-screen flex flex-col items-center justify-center gap-4 px-4 text-center">' +
-            '<p style="color: var(--text-secondary); font-family: var(--font-body);">' +
-            'Failed to load the app. This can happen due to a network issue or stale cache.</p>' +
-            '<button onclick="clearCacheAndReload()" style="background: var(--strava); color: white; ' +
-            'padding: 0.5rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer; ' +
-            'font-family: var(--font-body);">Clear Cache & Reload</button></div>';
+        if (!window.__appRendered) {
+          var detail = !window.__appModuleLoaded
+            ? "Module failed to load (CDN or network issue)"
+            : "App loaded but failed to render";
+          showLoadError(detail);
         }
-      }, 10000);
+      }, 8000);
+
+      setTimeout(function() {
+        if (!window.__appRendered) {
+          var detail = !window.__appModuleLoaded
+            ? "Module failed to load — CDN may be unreachable"
+            : "App module loaded but rendering failed";
+          showLoadError(detail);
+        }
+      }, 15000);
+
+      function showLoadError(detail) {
+        // Don't overwrite if app has successfully rendered
+        if (window.__appRendered) return;
+        var app = document.getElementById("app");
+        if (!app) return;
+        app.innerHTML =
+          '<div style="min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1rem;padding:1rem;text-align:center;">' +
+          '<p style="color: var(--text-secondary, #5C5548); font-family: var(--font-body, sans-serif);">' +
+          'Failed to load the app.</p>' +
+          '<p style="color: var(--text-tertiary, #8C8374); font-family: var(--font-mono, monospace); font-size: 0.75rem; max-width: 400px; word-break: break-word;">' +
+          (detail || "Unknown error") + '</p>' +
+          '<button onclick="clearCacheAndReload()" style="background: var(--strava, #FC4C02); color: white; ' +
+          'padding: 0.5rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer; ' +
+          'font-family: var(--font-body, sans-serif);">Clear Cache & Reload</button>' +
+          '<button onclick="window.location.reload()" style="background: none; border: none; cursor: pointer; ' +
+          'font-family: var(--font-body, sans-serif); color: var(--text-tertiary, #8C8374); font-size: 0.875rem;">' +
+          'Simple Reload</button></div>';
+      }
 
       function clearCacheAndReload() {
         if ("caches" in window) {

--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,7 @@
  */
 
 import { html } from "htm/preact";
-import { render } from "preact";
+import { render, Component } from "preact";
 import { signal, effect } from "@preact/signals";
 import { authState, initAuth } from "./auth.js";
 import { checkDemo, isDemo } from "./demo.js";
@@ -35,6 +35,46 @@ export function navigate(path) {
   window.location.hash = path;
 }
 
+// --- Error Boundary ---
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Render error:", error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return html`
+        <div class="min-h-screen flex flex-col items-center justify-center gap-4 px-4 text-center">
+          <p style="color: var(--text-secondary); font-family: var(--font-body);">
+            Something went wrong while loading the app.
+          </p>
+          <p style="color: var(--text-tertiary); font-family: var(--font-mono); font-size: 0.75rem; max-width: 400px; word-break: break-word;">
+            ${this.state.error.message || "Unknown error"}
+          </p>
+          <button
+            onClick=${() => {
+              this.setState({ error: null });
+              window.location.reload();
+            }}
+            style="background: var(--strava); color: white; padding: 0.5rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer; font-family: var(--font-body);"
+          >Reload</button>
+        </div>
+      `;
+    }
+    return this.props.children;
+  }
+}
+
 // --- App ---
 
 function App() {
@@ -59,16 +99,49 @@ function App() {
 
 // --- Init ---
 
+function safeRender() {
+  try {
+    render(
+      html`<${ErrorBoundary}><${App} /></${ErrorBoundary}>`,
+      document.getElementById("app")
+    );
+    window.__appRendered = true;
+  } catch (err) {
+    console.error("Render failed:", err);
+    const app = document.getElementById("app");
+    if (app) {
+      app.innerHTML =
+        '<div class="min-h-screen flex flex-col items-center justify-center gap-4 px-4 text-center">' +
+        '<p style="color: var(--text-secondary); font-family: var(--font-body);">Failed to render the app.</p>' +
+        '<p style="color: var(--text-tertiary); font-family: var(--font-mono); font-size: 0.75rem; max-width: 400px; word-break: break-word;">' +
+        (err.message || "Unknown error") + "</p>" +
+        '<button onclick="window.location.reload()" style="background: var(--strava); color: white; ' +
+        'padding: 0.5rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer; ' +
+        'font-family: var(--font-body);">Reload</button></div>';
+    }
+  }
+}
+
 async function init() {
   try {
     initInstallDetection();
-    await initAuth();
-    await checkDemo();
   } catch (err) {
-    console.error("Init error:", err);
+    console.error("Install detection error:", err);
   }
 
-  render(html`<${App} />`, document.getElementById("app"));
+  try {
+    await initAuth();
+  } catch (err) {
+    console.error("Auth init error:", err);
+  }
+
+  try {
+    await checkDemo();
+  } catch (err) {
+    console.error("Demo check error:", err);
+  }
+
+  safeRender();
 
   // Re-render on auth and route changes
   effect(() => {
@@ -76,8 +149,11 @@ async function init() {
     const __ = route.value;
     const ___ = routeParams.value;
     const ____ = isDemo.value;
-    render(html`<${App} />`, document.getElementById("app"));
+    safeRender();
   });
 }
+
+// Signal that the module loaded (even if init hasn't finished yet)
+window.__appModuleLoaded = true;
 
 init();

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
  * All Strava data lives in IndexedDB — SW just needs to serve the app offline.
  */
 
-const CACHE_NAME = "aeyu-v6";
+const CACHE_NAME = "aeyu-v7";
 
 const APP_SHELL = [
   "/",


### PR DESCRIPTION
## Summary

PRs #99 and #101 tried to fix the stuck "Loading..." screen but the site is still broken. This PR addresses the **root causes** that those PRs missed:

- **`render()` was unprotected** — if any Preact component threw during render, the error was unhandled. The "Loading..." text stayed in the DOM (or Preact left a partial DOM), and the 10s fallback couldn't detect it because it relied on exact `textContent === "Loading..."` matching.
- **No error boundary** — Preact render errors propagated silently to the console with no user-visible feedback.
- **Google Fonts blocked rendering** — the `<link rel="stylesheet">` for Google Fonts is render-blocking by default, adding latency before first paint.

### What changed

- **Preact `ErrorBoundary` component** catches render errors and shows actionable error UI with the error message and a reload button
- **`safeRender()` wrapper** — `render()` is now in a try/catch; if it throws, falls back to plain HTML error UI
- **Each init step has its own try/catch** — `initInstallDetection()`, `initAuth()`, and `checkDemo()` can't take each other down
- **Flag-based stuck detection** — `window.__appModuleLoaded` and `__appRendered` flags replace the fragile DOM text matching. The fallback now tells users *what* failed (module load vs render)
- **Global error handlers** — `window.onerror` and `unhandledrejection` catch anything that slips through and show it to the user
- **Non-blocking Google Fonts** — `media="print" onload="this.media='all'"` eliminates font CDN as a render-blocking dependency
- **SW cache bump to v7** — forces fresh service worker activation

## Test plan

- [ ] Load https://aeyu.io in a fresh browser (no cache) — should show Landing page
- [ ] Load with DevTools → Network → Block `esm.sh` — should show "Module failed to load" error after 8s
- [ ] Load with DevTools → Console → verify no unhandled errors
- [ ] Check that Google Fonts load asynchronously (no render-blocking in Network waterfall)
- [ ] Test on mobile Safari and Chrome
- [ ] Verify demo mode still works

https://claude.ai/code/session_017wwcFXWeHwaLXtpaDcYjyh