### PR TITLE
Fix duplicate isoWeekKey causing app load failure

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -1858,20 +1858,6 @@ function haversineKm(a, b) {
 }
 
 /**
- * Get ISO week string "YYYY-WNN" for a date.
- * Uses ISO week number (Monday-start weeks).
- */
-function isoWeekKey(dateStr) {
-  const d = new Date(dateStr);
-  // Thursday of the same ISO week determines the year
-  const thu = new Date(d);
-  thu.setDate(d.getDate() - ((d.getDay() + 6) % 7) + 3);
-  const yearStart = new Date(thu.getFullYear(), 0, 1);
-  const weekNum = Math.ceil(((thu - yearStart) / 86400000 + 1) / 7);
-  return `${thu.getFullYear()}-W${String(weekNum).padStart(2, "0")}`;
-}
-
-/**
  * Compute weekly ride streaks from all activities.
  * Returns { current, longest, mulliganUsed, streakStart, lastRideDate, danger }.
  *


### PR DESCRIPTION
## Summary
- Fixes the `SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'isoWeekKey'` that prevents the app from loading
- Root cause: two `function isoWeekKey()` declarations existed in `src/awards.js` (line 315 and line 1864), which is illegal in ES modules
- Removed the second duplicate; the first definition already handles both `Date` objects and date strings

## Test plan
- [ ] Verify `node -c src/awards.js` passes (confirmed locally)
- [ ] Load the app in browser — should no longer show the SyntaxError
- [ ] Verify weekly streak calculations still work correctly (they use isoWeekKey)

https://claude.ai/code/session_01McNQb6VzrfxFy87iaVe5YJ