### PR TITLE
Fix backfill syncing oldest activities first instead of newest

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -136,7 +136,7 @@ async function fetchActivityListPage(page, afterEpoch) {
     page: String(page),
   });
 
-  if (afterEpoch !== undefined) {
+  if (afterEpoch) {
     params.set("after", String(afterEpoch));
   }
 
@@ -418,7 +418,7 @@ export async function startBackfill() {
           message: `Fetching activities (page ${page})...`,
         };
 
-        const result = await fetchActivityListPage(page, 0);
+        const result = await fetchActivityListPage(page);
 
         if (result.summaries.length === 0) break;
 


### PR DESCRIPTION
## Summary
- Remove `after=0` from backfill's `fetchActivityListPage` call so Strava returns activities newest-first (default behavior)
- Change `afterEpoch !== undefined` guard to truthy check (`if (afterEpoch)`) so `0` and `undefined` both skip the `after` param
- First-time users now see their recent rides immediately instead of ~2019 data

Fixes #107

## Test plan
- [ ] Fresh install: verify initial backfill shows recent activities first
- [ ] Incremental sync still works correctly (passes real afterEpoch values)
- [ ] Interrupted backfill resumes correctly

https://claude.ai/code/session_01T8dN7cWtGUDEdfEvSnqTEi