### PR TITLE
Fitness indicators: Performance Capacity + Aerobic Efficiency (#106)

### DIFF
--- a/src/_MAP.md
+++ b/src/_MAP.md
@@ -1,5 +1,5 @@
 # src/
-*Files: 11 | Subdirectories: 1*
+*Files: 12 | Subdirectories: 1*
 
 ## Subdirectories
 
@@ -63,7 +63,8 @@
 - **getActivitiesByYear** (f) `(year)` :128
 - **getActivitiesWithoutEfforts** (f) `()` :142
 - **getActivitiesWithoutPower** (f) `()` :161
-- **getAllActivities** (f) `()` :174
+- **getActivitiesWithoutHeartRate** (f) `()` :174
+- **getAllActivities** (f) `()` :191
 - **putSegment** (f) `(segment)` :186
 - **getSegment** (f) `(id)` :196
 - **getAllSegments** (f) `()` :206
@@ -77,6 +78,12 @@
 - **getSyncState** (f) `()` :350
 - **updateSyncState** (f) `(updates)` :360
 - **clearAllData** (f) `()` :372
+
+### fitness.js
+> Imports: `db.js`
+- **computePerformanceCapacity** (f) `()` :69
+- **computeAerobicEfficiency** (f) `()` :169
+- **computeFitnessSummary** (f) `()` :237
 
 ### demo.js
 > Imports: `signals, db.js`

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -46,6 +46,7 @@ import {
 import { isDemo, exitDemo } from "../demo.js";
 import { renderIconSVG } from "../icons.js";
 import { AWARD_LABELS } from "../award-config.js";
+import { computeFitnessSummary } from "../fitness.js";
 
 const recentActivities = signal([]);
 const activityAwards = signal(new Map());
@@ -69,6 +70,7 @@ const refCount = signal("10");
 const refBirthday = signal("");
 const refAge = signal("40");
 const streakData = signal(null);
+const fitnessData = signal(null);
 
 async function loadDashboard() {
   loading.value = true;
@@ -115,6 +117,13 @@ async function loadDashboard() {
       activityAwards.value = new Map();
       const segments = await getAllSegments();
       stats.value = { segments: segments.length, awards: 0 };
+    }
+
+    // Compute fitness indicators (#106)
+    try {
+      fitnessData.value = await computeFitnessSummary();
+    } catch (e) {
+      console.warn("Fitness computation failed:", e);
     }
   } finally {
     loading.value = false;
@@ -394,6 +403,110 @@ export function Dashboard() {
           </div>
         </div>
 
+        <!-- Fitness Indicators (#106) -->
+        ${!loading.value && fitnessData.value && (fitnessData.value.performanceCapacity.hasData || fitnessData.value.aerobicEfficiency.hasData) && html`
+          <div class="mb-6 rounded-xl p-5" style="background: var(--surface); border: 1px solid var(--border);">
+            <h2 style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text); margin-bottom: 1rem;">Fitness Indicators</h2>
+
+            <div class="grid grid-cols-1 gap-4" style="${fitnessData.value.performanceCapacity.hasData && fitnessData.value.aerobicEfficiency.hasData ? 'display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;' : ''}">
+
+              <!-- Performance Capacity -->
+              ${fitnessData.value.performanceCapacity.hasData && html`
+                <div class="rounded-lg p-4" style="background: var(--bg); border: 1px solid var(--border);">
+                  <div class="flex items-center gap-2 mb-2">
+                    <span style="font-family: var(--font-body); font-size: 0.8125rem; font-weight: 500; color: var(--text-secondary);">Performance Capacity</span>
+                    ${fitnessData.value.performanceCapacity.trend != null && html`
+                      <span style="font-size: 0.75rem; color: ${fitnessData.value.performanceCapacity.trend > 2 ? '#3D7A4A' : fitnessData.value.performanceCapacity.trend < -2 ? '#A05060' : 'var(--text-tertiary)'};">
+                        ${fitnessData.value.performanceCapacity.trend > 2 ? '\u2191' : fitnessData.value.performanceCapacity.trend < -2 ? '\u2193' : '\u2192'}
+                      </span>
+                    `}
+                  </div>
+                  <div style="font-family: var(--font-display); font-size: 2rem; color: var(--text);">${fitnessData.value.performanceCapacity.score}</div>
+                  <div style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary); margin-top: 0.25rem;">
+                    from ${fitnessData.value.performanceCapacity.segments.length} climb${fitnessData.value.performanceCapacity.segments.length !== 1 ? 's' : ''}
+                  </div>
+                  <!-- Mini segment breakdown -->
+                  ${fitnessData.value.performanceCapacity.segments.slice(0, 3).map((seg) => html`
+                    <div class="mt-2 flex justify-between items-center" style="font-size: 0.75rem; color: var(--text-secondary);">
+                      <span class="truncate" style="max-width: 70%;">${seg.segmentName}</span>
+                      <span style="font-family: var(--font-mono); color: var(--text);">${Math.round(seg.score)}</span>
+                    </div>
+                  `)}
+                </div>
+              `}
+
+              <!-- Aerobic Efficiency -->
+              ${fitnessData.value.aerobicEfficiency.hasData && html`
+                <div class="rounded-lg p-4" style="background: var(--bg); border: 1px solid var(--border);">
+                  <div class="flex items-center gap-2 mb-2">
+                    <span style="font-family: var(--font-body); font-size: 0.8125rem; font-weight: 500; color: var(--text-secondary);">Aerobic Efficiency</span>
+                    ${fitnessData.value.aerobicEfficiency.ef.trend != null && html`
+                      <span style="font-size: 0.75rem; color: ${fitnessData.value.aerobicEfficiency.ef.trend > 2 ? '#3D7A4A' : fitnessData.value.aerobicEfficiency.ef.trend < -2 ? '#A05060' : 'var(--text-tertiary)'};">
+                        ${fitnessData.value.aerobicEfficiency.ef.trend > 2 ? '\u2191' : fitnessData.value.aerobicEfficiency.ef.trend < -2 ? '\u2193' : '\u2192'}
+                        ${fitnessData.value.aerobicEfficiency.ef.trend != null ? ` ${Math.abs(fitnessData.value.aerobicEfficiency.ef.trend).toFixed(1)}%` : ''}
+                      </span>
+                    `}
+                  </div>
+                  <div style="font-family: var(--font-display); font-size: 2rem; color: var(--text);">${fitnessData.value.aerobicEfficiency.ef.current}</div>
+                  <div style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary); margin-top: 0.25rem;">
+                    EF ${fitnessData.value.aerobicEfficiency.ef.hasPowerData ? '(W/bpm)' : '(speed/bpm)'}
+                    \u2022 ${fitnessData.value.aerobicEfficiency.ef.recentCount} recent rides
+                  </div>
+                  <!-- Monthly EF trend (last 6 months) -->
+                  ${fitnessData.value.aerobicEfficiency.ef.monthlyHistory.length > 1 && html`
+                    <div class="mt-3" style="display: flex; align-items: flex-end; gap: 2px; height: 40px;">
+                      ${fitnessData.value.aerobicEfficiency.ef.monthlyHistory.slice(-6).map((m) => {
+                        const allEf = fitnessData.value.aerobicEfficiency.ef.monthlyHistory;
+                        const maxEf = Math.max(...allEf.map((x) => x.ef));
+                        const minEf = Math.min(...allEf.map((x) => x.ef));
+                        const range = maxEf - minEf || 1;
+                        const pct = ((m.ef - minEf) / range) * 100;
+                        return html`
+                          <div style="flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px;">
+                            <div style="width: 100%; background: #4882A8; border-radius: 2px; min-height: 4px; height: ${Math.max(15, pct)}%;" title="${m.month}: EF ${m.ef}"></div>
+                            <span style="font-size: 0.5625rem; color: var(--text-tertiary); font-family: var(--font-mono);">${m.month.slice(5)}</span>
+                          </div>
+                        `;
+                      })}
+                    </div>
+                  `}
+                </div>
+              `}
+            </div>
+
+            <!-- Interpretation -->
+            ${fitnessData.value.interpretation && html`
+              <div class="mt-3 px-3 py-2 rounded-lg" style="background: ${
+                fitnessData.value.interpretation === 'ideal' ? '#E8F2E6' :
+                fitnessData.value.interpretation === 'overreaching' ? '#F4E4E8' :
+                fitnessData.value.interpretation === 'detraining' ? '#F4E4E8' :
+                'var(--bg)'
+              }; border: 1px solid ${
+                fitnessData.value.interpretation === 'ideal' ? '#C0D8B8' :
+                fitnessData.value.interpretation === 'overreaching' ? '#DCC0C8' :
+                fitnessData.value.interpretation === 'detraining' ? '#DCC0C8' :
+                'var(--border)'
+              };">
+                <span style="font-family: var(--font-body); font-size: 0.8125rem; color: ${
+                  fitnessData.value.interpretation === 'ideal' ? '#1E4D28' :
+                  fitnessData.value.interpretation === 'overreaching' ? '#6E2E3C' :
+                  fitnessData.value.interpretation === 'detraining' ? '#6E2E3C' :
+                  'var(--text-secondary)'
+                };">
+                  ${{
+                    ideal: "Getting stronger and more efficient",
+                    pushing: "Pushing harder \u2014 output up, economy steady",
+                    building: "Base building \u2014 economy improving, capacity stable",
+                    overreaching: "Watch out \u2014 output up but costing more",
+                    detraining: "Both capacity and efficiency declining",
+                    maintaining: "Maintaining current fitness level",
+                  }[fitnessData.value.interpretation]}
+                </span>
+              </div>
+            `}
+          </div>
+        `}
+
         <!-- Loading -->
         ${loading.value && html`
           <div class="text-center py-12" style="color: var(--text-tertiary);">Loading activities...</div>
@@ -551,6 +664,18 @@ export function Dashboard() {
                       </div>
                     `;
                   })}
+                </div>
+              </details>
+
+              <details class="group py-3">
+                <summary class="flex items-center justify-between cursor-pointer" style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: var(--text);">
+                  What are the Fitness Indicators?
+                  <svg class="w-4 h-4 group-open:rotate-180 transition-transform flex-shrink-0 ml-2" style="color: var(--text-tertiary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                </summary>
+                <div class="pt-3 pb-1 space-y-2" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
+                  <p><strong>Performance Capacity</strong> (0-100) measures what your body can produce. It tracks your climb segment times, converts them to estimated power-to-weight (VAM/Ferrari formula), and ranks recent efforts against your own history. Requires at least 3 climb segments with 3+ efforts each.</p>
+                  <p><strong>Aerobic Efficiency</strong> measures output per heartbeat (Efficiency Factor = power/HR or speed/HR). Higher is better. Only appears when your activities include heart rate data.</p>
+                  <p>Together they tell a training story: rising capacity + rising efficiency = ideal. Rising capacity + falling efficiency = possible overreaching.</p>
                 </div>
               </details>
 

--- a/src/db.js
+++ b/src/db.js
@@ -181,6 +181,23 @@ export async function getActivitiesWithoutPower() {
   });
 }
 
+/**
+ * Get activities that were stored before HR fields were tracked.
+ * These lack the has_heartrate property entirely.
+ */
+export async function getActivitiesWithoutHeartRate() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction("activities", "readonly");
+    const req = tx.objectStore("activities").getAll();
+    req.onsuccess = () => {
+      const results = req.result.filter((a) => !("has_heartrate" in a));
+      resolve(results);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
 export async function getAllActivities() {
   const db = await openDB();
   return new Promise((resolve, reject) => {

--- a/src/fitness.js
+++ b/src/fitness.js
@@ -1,0 +1,362 @@
+/**
+ * Fitness Indicators — Performance Capacity + Aerobic Efficiency (#106)
+ *
+ * Two complementary fitness indicators computed entirely from local IndexedDB data.
+ * No new API calls required — uses segment efforts and activity data already synced.
+ *
+ * Indicator 1: Performance Capacity (no HR required)
+ *   - Measures what your body can produce on the bike
+ *   - Uses climb segment performance (VAM, estimated W/kg) over time
+ *   - 0-100 index relative to athlete's own all-time range
+ *
+ * Indicator 2: Aerobic Efficiency (when HR data available)
+ *   - Measures what that output costs you
+ *   - Efficiency Factor: power/HR or speed/HR
+ *   - Only activates when HR data is present
+ */
+
+import { getAllSegments, getAllActivities } from "./db.js";
+
+// --- Constants ---
+
+const MIN_EFFORTS_PER_SEGMENT = 3;   // Need at least 3 efforts for meaningful comparison
+const MIN_MOVING_TIME = 120;          // 2 min minimum to avoid approach-speed slingshot
+const MIN_GRADE_PERCENT = 4;          // Minimum gradient for climb identification
+const ROLLING_WINDOW_DAYS = 90;       // Performance index rolling window
+const RECENCY_HALF_LIFE_DAYS = 30;    // Exponential recency weighting half-life
+
+// --- Climb Identification ---
+
+/**
+ * Check if a segment qualifies as a climb for Performance Capacity.
+ * Climbs >= 4% grade or with a Strava climb category.
+ */
+function isClimbSegment(segment) {
+  if (segment.climb_category > 0) return true;
+  if (segment.average_grade >= MIN_GRADE_PERCENT) return true;
+  return false;
+}
+
+/**
+ * Calculate VAM (Vertical Ascent Meters per hour) for a segment effort.
+ */
+function calcVAM(segment, effort) {
+  const elevGain = (segment.elevation_high || 0) - (segment.elevation_low || 0);
+  if (elevGain <= 0 || !effort.moving_time || effort.moving_time <= 0) return null;
+  return (elevGain * 3600) / effort.moving_time;
+}
+
+/**
+ * Estimate relative power (W/kg) from VAM using the Ferrari formula.
+ * VAM / (200 + 10 * gradient)
+ * Allows comparing efforts across different-gradient climbs.
+ */
+function estimateRelativePower(vam, averageGrade) {
+  if (!vam || !averageGrade || averageGrade <= 0) return null;
+  return vam / (200 + 10 * averageGrade);
+}
+
+// --- Performance Capacity Computation ---
+
+/**
+ * Compute Performance Capacity score (0-100) from climb segment history.
+ *
+ * Algorithm:
+ * 1. Filter segments to climbs with >= MIN_EFFORTS_PER_SEGMENT efforts
+ * 2. For each qualifying segment, compute estimated W/kg per effort
+ *    (or use actual watts if device_watts is true)
+ * 3. Rank recent efforts (last 90 days) against all-time history
+ * 4. Weight by recency, composite across segments
+ * 5. Return 0-100 index relative to athlete's own range
+ *
+ * Returns: { score, trend, segments: [...], hasData }
+ */
+export async function computePerformanceCapacity() {
+  const allSegments = await getAllSegments();
+
+  // Filter to climb segments with enough history
+  const climbSegments = allSegments.filter((seg) => {
+    if (!isClimbSegment(seg)) return false;
+    if (!seg.efforts || seg.efforts.length < MIN_EFFORTS_PER_SEGMENT) return false;
+    return true;
+  });
+
+  if (climbSegments.length === 0) {
+    return { score: null, trend: null, segments: [], hasData: false, reason: "no_climbs" };
+  }
+
+  const now = Date.now();
+  const windowMs = ROLLING_WINDOW_DAYS * 86400000;
+  const halfLifeMs = RECENCY_HALF_LIFE_DAYS * 86400000;
+  const segmentScores = [];
+
+  for (const seg of climbSegments) {
+    // Filter efforts with valid moving time
+    const validEfforts = seg.efforts.filter(
+      (e) => e.moving_time >= MIN_MOVING_TIME
+    );
+    if (validEfforts.length < MIN_EFFORTS_PER_SEGMENT) continue;
+
+    // Compute performance metric per effort
+    const scored = validEfforts.map((e) => {
+      const effortDate = new Date(e.start_date).getTime();
+      let performance;
+
+      // Prefer actual power from power meter
+      if (e.device_watts && e.average_watts > 0) {
+        performance = e.average_watts;
+      } else {
+        // Estimate from VAM
+        const vam = calcVAM(seg, e);
+        performance = estimateRelativePower(vam, seg.average_grade);
+      }
+
+      return { performance, date: effortDate, effort: e };
+    }).filter((s) => s.performance != null && s.performance > 0);
+
+    if (scored.length < MIN_EFFORTS_PER_SEGMENT) continue;
+
+    // Sort by performance to compute percentiles
+    const allPerfs = scored.map((s) => s.performance).sort((a, b) => a - b);
+    const minPerf = allPerfs[0];
+    const maxPerf = allPerfs[allPerfs.length - 1];
+    const range = maxPerf - minPerf;
+
+    if (range === 0) continue; // No variation
+
+    // Recent efforts (within rolling window)
+    const recentScored = scored.filter((s) => now - s.date <= windowMs);
+    if (recentScored.length === 0) continue;
+
+    // Compute recency-weighted percentile for recent efforts
+    let weightedSum = 0;
+    let weightSum = 0;
+
+    for (const s of recentScored) {
+      const ageMs = now - s.date;
+      const weight = Math.exp(-Math.LN2 * ageMs / halfLifeMs);
+      const percentile = ((s.performance - minPerf) / range) * 100;
+      weightedSum += percentile * weight;
+      weightSum += weight;
+    }
+
+    const segScore = weightSum > 0 ? weightedSum / weightSum : 0;
+
+    // Also compute older window for trend
+    const olderWindowStart = now - windowMs * 2;
+    const olderScored = scored.filter(
+      (s) => s.date >= olderWindowStart && s.date < now - windowMs
+    );
+
+    let olderScore = null;
+    if (olderScored.length > 0) {
+      let olderWeightedSum = 0;
+      let olderWeightSum = 0;
+      for (const s of olderScored) {
+        const ageMs = now - windowMs - s.date; // age relative to older window end
+        const weight = Math.exp(-Math.LN2 * ageMs / halfLifeMs);
+        const percentile = ((s.performance - minPerf) / range) * 100;
+        olderWeightedSum += percentile * weight;
+        olderWeightSum += weight;
+      }
+      olderScore = olderWeightSum > 0 ? olderWeightedSum / olderWeightSum : null;
+    }
+
+    segmentScores.push({
+      segmentId: seg.id,
+      segmentName: seg.name,
+      score: segScore,
+      olderScore,
+      effortCount: validEfforts.length,
+      recentCount: recentScored.length,
+      averageGrade: seg.average_grade,
+      climbCategory: seg.climb_category,
+      // Best and latest effort for display
+      bestEffort: scored.reduce((best, s) => s.performance > best.performance ? s : best),
+      latestEffort: scored.reduce((latest, s) => s.date > latest.date ? s : latest),
+    });
+  }
+
+  if (segmentScores.length === 0) {
+    return { score: null, trend: null, segments: [], hasData: false, reason: "insufficient_efforts" };
+  }
+
+  // Composite score: average across qualifying segments (equal weight)
+  const compositeScore = segmentScores.reduce((sum, s) => sum + s.score, 0) / segmentScores.length;
+
+  // Trend: compare current composite to older composite
+  const segmentsWithTrend = segmentScores.filter((s) => s.olderScore != null);
+  let trend = null;
+  if (segmentsWithTrend.length > 0) {
+    const currentAvg = segmentsWithTrend.reduce((s, seg) => s + seg.score, 0) / segmentsWithTrend.length;
+    const olderAvg = segmentsWithTrend.reduce((s, seg) => s + seg.olderScore, 0) / segmentsWithTrend.length;
+    trend = currentAvg - olderAvg; // Positive = improving
+  }
+
+  return {
+    score: Math.round(compositeScore),
+    trend,
+    segments: segmentScores.sort((a, b) => b.effortCount - a.effortCount),
+    hasData: true,
+  };
+}
+
+// --- Aerobic Efficiency Computation ---
+
+/**
+ * Compute Aerobic Efficiency metrics from activity data.
+ *
+ * Efficiency Factor (EF) = power / HR or adjusted speed / HR
+ * Higher EF = more output per heartbeat = fitter.
+ *
+ * Only activates when HR data is present. Returns null metrics gracefully
+ * when no HR data exists — no nagging.
+ *
+ * Returns: { ef: { current, trend, history }, hasData }
+ */
+export async function computeAerobicEfficiency() {
+  const allActivities = await getAllActivities();
+
+  // Filter to cycling activities with HR data
+  const withHR = allActivities.filter((a) =>
+    a.has_heartrate &&
+    a.average_heartrate > 0 &&
+    a.has_efforts &&
+    (a.sport_type === "Ride" || a.sport_type === "VirtualRide" || a.sport_type === "MountainBikeRide")
+  );
+
+  if (withHR.length < 3) {
+    return { ef: null, hasData: false, reason: withHR.length === 0 ? "no_hr_data" : "insufficient_hr_data" };
+  }
+
+  // Compute EF per activity
+  const efData = withHR.map((a) => {
+    const date = new Date(a.start_date).getTime();
+    let ef;
+
+    if (a.device_watts && a.weighted_average_watts > 0) {
+      // Power-based EF (most accurate)
+      ef = a.weighted_average_watts / a.average_heartrate;
+    } else if (a.device_watts && a.average_watts > 0) {
+      ef = a.average_watts / a.average_heartrate;
+    } else if (a.average_speed > 0) {
+      // Speed-based EF (less accurate but directional)
+      // Normalize by elevation gain to partially account for terrain
+      const elevFactor = a.total_elevation_gain > 0
+        ? 1 + (a.total_elevation_gain / (a.distance || 1)) * 10
+        : 1;
+      ef = (a.average_speed * elevFactor) / a.average_heartrate;
+    } else {
+      return null;
+    }
+
+    return {
+      ef,
+      date,
+      activityId: a.id,
+      activityName: a.name,
+      hasPower: !!(a.device_watts && (a.weighted_average_watts || a.average_watts)),
+      movingTime: a.moving_time,
+      avgHR: a.average_heartrate,
+    };
+  }).filter(Boolean);
+
+  if (efData.length < 3) {
+    return { ef: null, hasData: false, reason: "insufficient_ef_data" };
+  }
+
+  // Sort by date
+  efData.sort((a, b) => a.date - b.date);
+
+  const now = Date.now();
+  const windowMs = ROLLING_WINDOW_DAYS * 86400000;
+
+  // Current window EF (last 90 days)
+  const recentEF = efData.filter((d) => now - d.date <= windowMs);
+  const olderEF = efData.filter((d) => d.date >= now - windowMs * 2 && d.date < now - windowMs);
+
+  const currentEF = recentEF.length > 0
+    ? recentEF.reduce((sum, d) => sum + d.ef, 0) / recentEF.length
+    : null;
+
+  const olderEFAvg = olderEF.length > 0
+    ? olderEF.reduce((sum, d) => sum + d.ef, 0) / olderEF.length
+    : null;
+
+  let trend = null;
+  if (currentEF != null && olderEFAvg != null) {
+    trend = ((currentEF - olderEFAvg) / olderEFAvg) * 100; // Percentage change
+  }
+
+  // Build monthly history for chart
+  const monthlyEF = buildMonthlyHistory(efData);
+
+  return {
+    ef: {
+      current: currentEF ? +currentEF.toFixed(2) : null,
+      trend,
+      history: efData.slice(-50), // Last 50 data points for chart
+      monthlyHistory: monthlyEF,
+      recentCount: recentEF.length,
+      totalCount: efData.length,
+      hasPowerData: efData.some((d) => d.hasPower),
+    },
+    hasData: true,
+  };
+}
+
+/**
+ * Build monthly averages from EF data for trend display.
+ */
+function buildMonthlyHistory(efData) {
+  const months = {};
+  for (const d of efData) {
+    const date = new Date(d.date);
+    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+    if (!months[key]) months[key] = { sum: 0, count: 0 };
+    months[key].sum += d.ef;
+    months[key].count++;
+  }
+  return Object.entries(months)
+    .map(([month, { sum, count }]) => ({
+      month,
+      ef: +(sum / count).toFixed(2),
+      count,
+    }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+}
+
+// --- Combined Fitness Summary ---
+
+/**
+ * Compute all fitness indicators and return a combined summary.
+ * This is the main entry point for the Dashboard UI.
+ */
+export async function computeFitnessSummary() {
+  const [capacity, efficiency] = await Promise.all([
+    computePerformanceCapacity(),
+    computeAerobicEfficiency(),
+  ]);
+
+  // Interpret the combination
+  let interpretation = null;
+  if (capacity.hasData && efficiency.hasData && capacity.trend != null && efficiency.ef?.trend != null) {
+    const capUp = capacity.trend > 2;
+    const capDown = capacity.trend < -2;
+    const efUp = efficiency.ef.trend > 2;
+    const efDown = efficiency.ef.trend < -2;
+
+    if (capUp && efUp) interpretation = "ideal";           // Stronger AND more efficient
+    else if (capUp && !efDown) interpretation = "pushing";  // Stronger but not more economical
+    else if (!capDown && efUp) interpretation = "building";  // Base building — economy improving
+    else if (capUp && efDown) interpretation = "overreaching"; // Output up but cost up more
+    else if (capDown && efDown) interpretation = "detraining"; // Both declining
+    else interpretation = "maintaining";
+  }
+
+  return {
+    performanceCapacity: capacity,
+    aerobicEfficiency: efficiency,
+    interpretation,
+  };
+}

--- a/src/sync.js
+++ b/src/sync.js
@@ -12,6 +12,7 @@ import {
   getActivity,
   getActivitiesWithoutEfforts,
   getActivitiesWithoutPower,
+  getActivitiesWithoutHeartRate,
   getSyncState,
   updateSyncState,
   appendEffort,
@@ -114,6 +115,10 @@ function toActivitySummary(a) {
     device_watts: a.device_watts || false,
     kilojoules: a.kilojoules || null,
     trainer: a.trainer || false,
+    // Heart rate fields (#106)
+    has_heartrate: a.has_heartrate || false,
+    average_heartrate: a.average_heartrate || null,
+    max_heartrate: a.max_heartrate || null,
     // Group ride detection fields (#58)
     start_latlng: a.start_latlng || null,
     athlete_count: a.athlete_count || 1,
@@ -257,6 +262,9 @@ async function fetchActivityDetails() {
         // Power fields per segment effort
         average_watts: e.average_watts || null,
         device_watts: e.device_watts || false,
+        // Heart rate fields per segment effort (#106)
+        average_heartrate: e.average_heartrate || null,
+        max_heartrate: e.max_heartrate || null,
       }));
 
       const updated = {
@@ -270,6 +278,10 @@ async function fetchActivityDetails() {
         device_watts: full.device_watts || activity.device_watts || false,
         kilojoules: full.kilojoules || activity.kilojoules || null,
         trainer: full.trainer || activity.trainer || false,
+        // Heart rate fields from detail response (#106)
+        has_heartrate: full.has_heartrate || false,
+        average_heartrate: full.average_heartrate || null,
+        max_heartrate: full.max_heartrate || null,
         // Group ride detection fields (#58)
         start_latlng: full.start_latlng || activity.start_latlng || null,
         athlete_count: full.athlete_count || activity.athlete_count || 1,
@@ -277,7 +289,7 @@ async function fetchActivityDetails() {
 
       await putActivity(updated);
 
-      // Denormalize into segments store — include power in effort record
+      // Denormalize into segments store — include power + HR in effort record
       for (const effort of efforts) {
         await appendEffort(effort.segment.id, effort.segment, {
           effort_id: effort.id,
@@ -289,6 +301,8 @@ async function fetchActivityDetails() {
           pr_rank: effort.pr_rank,
           average_watts: effort.average_watts,
           device_watts: effort.device_watts,
+          average_heartrate: effort.average_heartrate,
+          max_heartrate: effort.max_heartrate,
         });
       }
 
@@ -376,6 +390,39 @@ async function runPowerMigration() {
   await updateSyncState({ schema_version: 2, power_backfill_complete: true });
 }
 
+// --- Phase 4: Heart Rate Fields Migration (#106) ---
+
+/**
+ * One-time migration for activities stored before HR tracking.
+ * Resets has_efforts on legacy activities so the detail fetch pipeline
+ * re-processes them — capturing activity-level and effort-level HR fields.
+ * Triggered when schema_version is below 3.
+ */
+async function runHeartRateMigration() {
+  const state = await getSyncState();
+  if (state.schema_version >= 3) return;
+
+  const legacy = await getActivitiesWithoutHeartRate();
+  const needsRefetch = legacy.filter((a) => a.has_efforts);
+
+  if (needsRefetch.length === 0) {
+    await updateSyncState({ schema_version: 3 });
+    return;
+  }
+
+  syncProgress.value = {
+    ...syncProgress.value,
+    phase: "detail",
+    message: `Migrating ${needsRefetch.length} activities for heart rate data...`,
+  };
+
+  // Reset has_efforts so fetchActivityDetails() will re-fetch them
+  const reset = needsRefetch.map((a) => ({ ...a, has_efforts: false }));
+  await putActivities(reset);
+
+  await updateSyncState({ schema_version: 3 });
+}
+
 // --- Public API ---
 
 /**
@@ -403,6 +450,7 @@ export async function startBackfill() {
     // If backfill was already completed, this is a resume for pending details
     if (state.backfill_complete) {
       await runPowerMigration();
+      await runHeartRateMigration();
       await fetchActivityDetails();
     } else {
       // Interleaved backfill: fetch page → detail → fetch page → detail
@@ -463,7 +511,8 @@ export async function startBackfill() {
       if (!isRateLimited()) {
         await updateSyncState({ backfill_complete: true });
         await runPowerMigration();
-        // Final detail pass for any remaining from power migration
+        await runHeartRateMigration();
+        // Final detail pass for any remaining from migration
         await fetchActivityDetails();
       }
     }
@@ -695,6 +744,8 @@ export async function resyncActivity(activityId) {
     achievements: e.achievements || [],
     average_watts: e.average_watts || null,
     device_watts: e.device_watts || false,
+    average_heartrate: e.average_heartrate || null,
+    max_heartrate: e.max_heartrate || null,
   }));
 
   const updated = {
@@ -713,6 +764,9 @@ export async function resyncActivity(activityId) {
     device_watts: full.device_watts || false,
     kilojoules: full.kilojoules || null,
     trainer: full.trainer || false,
+    has_heartrate: full.has_heartrate || false,
+    average_heartrate: full.average_heartrate || null,
+    max_heartrate: full.max_heartrate || null,
     start_latlng: full.start_latlng || existing.start_latlng || null,
     athlete_count: full.athlete_count || existing.athlete_count || 1,
     has_efforts: true,
@@ -734,6 +788,8 @@ export async function resyncActivity(activityId) {
       pr_rank: effort.pr_rank,
       average_watts: effort.average_watts,
       device_watts: effort.device_watts,
+      average_heartrate: effort.average_heartrate,
+      max_heartrate: effort.max_heartrate,
     });
   }
 


### PR DESCRIPTION
## Summary

Implements the first phases of #106 — two complementary fitness indicators that measure actual cycling fitness using data we already collect. No new API calls required.

- **Phase 1a: HR data capture** — Adds `has_heartrate`, `average_heartrate`, `max_heartrate` to activity and segment effort storage from Strava detail responses already fetched. Includes schema v3 migration to backfill existing activities.
- **Phase 1b: Performance Capacity** — New `fitness.js` module. Identifies climb segments (≥4% grade), calculates VAM and estimated W/kg via Ferrari formula, builds a 0-100 rolling performance index from repeated climbs. Prefers actual power meter data when available.
- **Phase 2: Aerobic Efficiency** — Efficiency Factor (power/HR or speed/HR) computed per activity, with monthly trend history. Only activates when HR data is present.
- **Dashboard UI** — Fitness Indicators section showing both scores with trend arrows, per-segment breakdown, mini EF bar chart, and combined interpretation (ideal/pushing/building/overreaching/detraining). FAQ entry added.

### Not included (future phases per #106)
- Stream-based aerobic decoupling (requires new API calls)
- Cached `fitness_scores` IndexedDB store

## Test plan

- [ ] Verify existing sync still works — HR fields added to activity detail responses
- [ ] Verify HR migration triggers on first sync for users with existing data (schema_version < 3)
- [ ] Verify Performance Capacity shows for users with climb segment history (≥3 climbs, ≥3 efforts each)
- [ ] Verify Aerobic Efficiency shows only when HR data is present
- [ ] Verify Fitness Indicators section is hidden when no data is available
- [ ] Verify demo mode still works (demo data may not have climb segments — section will be hidden)
- [ ] Check FAQ entry renders correctly in modal

https://claude.ai/code/session_01Q9LHBYvmn12YndeHZkHN6h