### PR TITLE
Fix backfill sync fetching oldest activities first

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -136,7 +136,7 @@ async function fetchActivityListPage(page, afterEpoch) {
     page: String(page),
   });
 
-  if (afterEpoch !== undefined) {
+  if (afterEpoch) {
     params.set("after", String(afterEpoch));
   }
 
@@ -149,7 +149,7 @@ async function fetchActivityListPage(page, afterEpoch) {
   const summaries = activities.map(toActivitySummary);
   await putActivities(summaries);
 
-  // Strava returns newest first; track the most recent date
+  // Strava returns newest first (when no `after` param); track the most recent date
   const newestDate = activities[0].start_date;
 
   return {
@@ -418,7 +418,7 @@ export async function startBackfill() {
           message: `Fetching activities (page ${page})...`,
         };
 
-        const result = await fetchActivityListPage(page, 0);
+        const result = await fetchActivityListPage(page);
 
         if (result.summaries.length === 0) break;
 


### PR DESCRIPTION
## Summary
- Remove `after=0` from backfill's `fetchActivityListPage` call so Strava returns activities newest-first (its default behavior without `after`)
- Guard the `after` query param with a truthy check so epoch 0 is never sent
- Clarify comment about Strava's sort order depending on `after` param

Fixes #107

## Test plan
- [ ] Fresh user OAuth → first sync should show recent activities, not 2019 data
- [ ] Incremental sync (existing user) still works correctly with `after` param
- [ ] Interrupted backfill resumes correctly

https://claude.ai/code/session_01M6Ak5Axn64u5hvEaXeihQ3