### PR TITLE
Configurable sync window: limit historical backfill depth (#111)

### DIFF
--- a/src/_MAP.md
+++ b/src/_MAP.md
@@ -104,8 +104,10 @@
 - **syncProgress** (variable) :21
 - **rateLimitStatus** (variable) :30
 - **isSyncing** (variable) :37
-- **startBackfill** (f) `()` :364
-- **incrementalSync** (f) `()` :415
+- **startBackfill** (f) `()` :434
+- **incrementalSync** (f) `()` :565
+- **updateSyncWindow** (f) `(newEpoch)` :633
+- **manualSync** (f) `()` :658
 
 ### units.js
 > Imports: `signals, db.js`

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -15,6 +15,7 @@ import {
   startAutoSync,
   stopAutoSync,
   manualSync,
+  updateSyncWindow,
   syncProgress,
   rateLimitStatus,
   isSyncing,
@@ -71,6 +72,9 @@ const refBirthday = signal("");
 const refAge = signal("40");
 const streakData = signal(null);
 const fitnessData = signal(null);
+const syncWindowChoice = signal("3y"); // "2y" | "3y" | "4y" | "all" | "custom"
+const syncWindowCustomDate = signal("");
+const currentSyncAfterEpoch = signal(null);
 
 async function loadDashboard() {
   loading.value = true;
@@ -93,6 +97,23 @@ async function loadDashboard() {
     // Check sync completion state
     const state = await getSyncState();
     backfillComplete.value = state.backfill_complete;
+
+    // Load sync window preference (#111)
+    currentSyncAfterEpoch.value = state.sync_after_epoch || null;
+    if (state.sync_after_epoch) {
+      // Determine which preset matches, if any
+      const now = Date.now() / 1000;
+      const diffYears = (now - state.sync_after_epoch) / (365.25 * 24 * 3600);
+      if (Math.abs(diffYears - 2) < 0.1) syncWindowChoice.value = "2y";
+      else if (Math.abs(diffYears - 3) < 0.1) syncWindowChoice.value = "3y";
+      else if (Math.abs(diffYears - 4) < 0.1) syncWindowChoice.value = "4y";
+      else {
+        syncWindowChoice.value = "custom";
+        syncWindowCustomDate.value = new Date(state.sync_after_epoch * 1000).toISOString().slice(0, 10);
+      }
+    } else {
+      syncWindowChoice.value = "all";
+    }
 
     // Count activities awaiting detail fetch (no efforts yet)
     const pending = await getActivitiesWithoutEfforts();
@@ -988,6 +1009,85 @@ export function Dashboard() {
                 `}
               </div>
             </div>
+
+            ${!isDemo.value && html`
+            <div class="mt-4 pt-4 space-y-3" style="border-top: 1px solid var(--border-light);">
+              <!-- Sync Window Settings (#111) -->
+              <div>
+                <p class="text-xs font-medium mb-1.5" style="color: var(--text-secondary); font-family: var(--font-body);">Sync Window</p>
+                <p class="text-xs mb-2" style="color: var(--text-tertiary);">How far back to sync activities from Strava. Shorter windows sync faster and use less storage.</p>
+
+                <div class="flex flex-wrap gap-1.5 mb-2">
+                  ${["2y", "3y", "4y", "all"].map((opt) => {
+                    const labels = { "2y": "Last 2 years", "3y": "Last 3 years", "4y": "Last 4 years", "all": "All time" };
+                    const isActive = syncWindowChoice.value === opt;
+                    return html`
+                      <button
+                        key=${opt}
+                        onClick=${() => { syncWindowChoice.value = opt; }}
+                        class="text-xs px-2.5 py-1.5 rounded-lg transition-colors"
+                        style=${isActive
+                          ? "background: var(--text); color: var(--surface); font-family: var(--font-body);"
+                          : "border: 1px solid var(--border); color: var(--text-secondary); font-family: var(--font-body);"}
+                      >
+                        ${labels[opt]}
+                      </button>
+                    `;
+                  })}
+                  <button
+                    onClick=${() => { syncWindowChoice.value = "custom"; }}
+                    class="text-xs px-2.5 py-1.5 rounded-lg transition-colors"
+                    style=${syncWindowChoice.value === "custom"
+                      ? "background: var(--text); color: var(--surface); font-family: var(--font-body);"
+                      : "border: 1px solid var(--border); color: var(--text-secondary); font-family: var(--font-body);"}
+                  >
+                    Custom
+                  </button>
+                </div>
+
+                ${syncWindowChoice.value === "custom" && html`
+                  <input
+                    type="date"
+                    value=${syncWindowCustomDate.value}
+                    onInput=${(e) => { syncWindowCustomDate.value = e.target.value; }}
+                    class="w-full text-xs rounded px-2 py-1.5 mb-2 focus:outline-none focus:ring-1"
+                    style="border: 1px solid var(--border); font-family: var(--font-mono);"
+                  />
+                `}
+
+                <button
+                  onClick=${async () => {
+                    let epoch = null;
+                    const now = Date.now() / 1000;
+                    if (syncWindowChoice.value === "2y") epoch = Math.floor(now - 2 * 365.25 * 24 * 3600);
+                    else if (syncWindowChoice.value === "3y") epoch = Math.floor(now - 3 * 365.25 * 24 * 3600);
+                    else if (syncWindowChoice.value === "4y") epoch = Math.floor(now - 4 * 365.25 * 24 * 3600);
+                    else if (syncWindowChoice.value === "custom" && syncWindowCustomDate.value) {
+                      epoch = Math.floor(new Date(syncWindowCustomDate.value).getTime() / 1000);
+                    }
+                    // null = all time
+                    if (epoch === currentSyncAfterEpoch.value) return;
+                    await updateSyncWindow(epoch);
+                    currentSyncAfterEpoch.value = epoch;
+                    await loadDashboard();
+                  }}
+                  disabled=${syncing || (syncWindowChoice.value === "custom" && !syncWindowCustomDate.value)}
+                  class="text-xs px-3 py-1.5 rounded font-medium transition-colors"
+                  style=${syncing || (syncWindowChoice.value === "custom" && !syncWindowCustomDate.value)
+                    ? "background: var(--border); color: var(--text-tertiary); cursor: not-allowed;"
+                    : "background: var(--strava); color: white;"}
+                >
+                  Apply
+                </button>
+
+                ${currentSyncAfterEpoch.value && html`
+                  <p class="text-xs mt-1.5" style="color: var(--text-tertiary); font-family: var(--font-mono);">
+                    Currently syncing since ${new Date(currentSyncAfterEpoch.value * 1000).toLocaleDateString("en-US", { month: "short", year: "numeric" })}
+                  </p>
+                `}
+              </div>
+            </div>
+            `}
 
             <div class="mt-4 pt-4 space-y-3" style="border-top: 1px solid var(--border-light);">
               ${!isDemo.value && html`

--- a/src/db.js
+++ b/src/db.js
@@ -403,6 +403,7 @@ const DEFAULT_SYNC_STATE = {
   last_sync: null,
   power_backfill_complete: false,
   schema_version: 0,
+  sync_after_epoch: null, // Unix timestamp — limits how far back to sync (#111)
 };
 
 export async function getSyncState() {

--- a/src/sync.js
+++ b/src/sync.js
@@ -458,15 +458,28 @@ export async function startBackfill() {
       let lastActivityDate = state.last_activity_fetch;
       let totalFetched = 0;
 
+      // Apply sync window cutoff (#111) — Strava `after` param is epoch seconds
+      // Default to 3 years on first backfill if no preference set
+      let syncAfterEpoch = state.sync_after_epoch;
+      if (syncAfterEpoch === null && page === 1) {
+        syncAfterEpoch = Math.floor(Date.now() / 1000 - 3 * 365.25 * 24 * 3600);
+        await updateSyncState({ sync_after_epoch: syncAfterEpoch });
+      }
+
+      // Show sync window in progress messages
+      const windowLabel = syncAfterEpoch
+        ? `since ${new Date(syncAfterEpoch * 1000).toLocaleDateString("en-US", { month: "short", year: "numeric" })}`
+        : "all time";
+
       while (true) {
         // Fetch one page of activity summaries
         syncProgress.value = {
           ...syncProgress.value,
           phase: "list",
-          message: `Fetching activities (page ${page})...`,
+          message: `Fetching activities ${windowLabel} (page ${page})...`,
         };
 
-        const result = await fetchActivityListPage(page);
+        const result = await fetchActivityListPage(page, syncAfterEpoch);
 
         if (result.summaries.length === 0) break;
 
@@ -607,6 +620,33 @@ export async function incrementalSync() {
     throw err;
   } finally {
     isSyncing.value = false;
+  }
+}
+
+/**
+ * Update the sync window cutoff (#111).
+ * If the window is extended (sync_after_epoch moved earlier or removed),
+ * resets backfill so the newly-included period gets fetched.
+ * If the window is shrunk, just updates the preference — no data deleted.
+ * @param {number|null} newEpoch - Unix timestamp cutoff, or null for all-time
+ */
+export async function updateSyncWindow(newEpoch) {
+  const state = await getSyncState();
+  const oldEpoch = state.sync_after_epoch || null;
+
+  await updateSyncState({ sync_after_epoch: newEpoch });
+
+  // If window was extended (new epoch is earlier or removed), trigger re-backfill
+  const windowExtended =
+    (oldEpoch !== null && newEpoch === null) || // expanded to all-time
+    (oldEpoch !== null && newEpoch !== null && newEpoch < oldEpoch); // moved earlier
+
+  if (windowExtended && state.backfill_complete) {
+    // Reset backfill so the new range gets fetched
+    await updateSyncState({
+      backfill_complete: false,
+      backfill_page: 1,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds a configurable sync window that limits how far back the initial backfill fetches from Strava
- **Defaults to 3 years** on first sync, balancing history depth against sync time and storage
- Users can choose Last 2 years / Last 3 years / Last 4 years / All time / Custom date in FAQ & Settings
- Extending the window triggers re-backfill for newly included activities; shrinking just saves the preference
- Sync progress messages show the active window (e.g. "Fetching activities since Mar 2023")

## Changes

- **`src/db.js`**: Add `sync_after_epoch` to default sync state
- **`src/sync.js`**: Pass `sync_after_epoch` as Strava `after` param during backfill; add `updateSyncWindow()` export for changing the window and triggering re-backfill when extended
- **`src/components/Dashboard.js`**: Add Sync Window settings section with preset buttons, custom date picker, and Apply button (hidden in demo mode)
- **`src/_MAP.md`**: Update line numbers and add new exports

## Test plan

- [ ] Fresh login: verify default 3-year window is applied and shown in sync progress
- [ ] Change to "Last 2 years" → Apply: confirm preference persists and sync messages update
- [ ] Extend to "All time" → Apply: confirm backfill resets and fetches older activities
- [ ] Shrink to "Last 2 years" after syncing all-time: confirm no data deleted, only preference updated
- [ ] Custom date picker: select a date, Apply, verify epoch stored correctly
- [ ] Demo mode: verify sync window section is hidden

Closes #111

https://claude.ai/code/session_01PxEthWCjYV3NHd8dSD64Np