### PR TITLE
Update branding from aeyu to aeyu.io throughout

### DIFF
--- a/activity.html
+++ b/activity.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>aeyu — Participation Awards</title>
+    <title>aeyu.io — Participation Awards</title>
     <meta name="description" content="Giving recognition for efforts where effort was given">
 
     <!-- Open Graph / Link Preview -->

--- a/dashboard.html
+++ b/dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>aeyu — Participation Awards</title>
+    <title>aeyu.io — Participation Awards</title>
     <meta name="description" content="Giving recognition for efforts where effort was given">
 
     <!-- Open Graph / Link Preview -->

--- a/demo.html
+++ b/demo.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>aeyu — Participation Awards</title>
+    <title>aeyu.io — Participation Awards</title>
     <meta name="description" content="Giving recognition for efforts where effort was given">
 
     <!-- Open Graph / Link Preview -->

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>aeyu — Participation Awards</title>
+    <title>aeyu.io — Participation Awards</title>
     <meta name="description" content="Giving recognition for efforts where effort was given">
 
     <!-- Open Graph / Link Preview -->

--- a/src/components/StickyHeader.js
+++ b/src/components/StickyHeader.js
@@ -1,7 +1,7 @@
 /**
  * StickyHeader — Shared header component for Dashboard and ActivityDetail
  *
- * Full mode (at page top): aeyu logo + "Participation Awards" subtitle + athlete name
+ * Full mode (at page top): aeyu.io logo + "Participation Awards" subtitle + athlete name
  * Compact mode (scrolled): Thin sticky bar with avatar menu, nav context, help, search placeholder
  *
  * Avatar dropdown contains: sync controls, unit toggle, disconnect, delete data
@@ -110,7 +110,7 @@ export function StickyHeader({
           `}
           <div>
             <h1 style="font-family: var(--font-display); font-size: 1.75rem; color: var(--text-on-dark); line-height: 1.1; white-space: nowrap;">
-              aeyu
+              aeyu<span style="color: var(--accent);">.io</span>
             </h1>
             <p style="font-family: var(--font-body); font-size: 0.7rem; color: rgba(255,255,255,0.6); letter-spacing: 0.04em; margin-top: 1px;">
               Participation Awards
@@ -205,7 +205,7 @@ export function StickyHeader({
             <img src="icons/icon-192.png" alt="aeyu.io" style="height: 24px; width: 24px; border-radius: 4px;" />
           `}
           <span style="font-family: var(--font-display); font-size: 1rem; color: var(--text-on-dark); white-space: nowrap;">
-            ${onBack && contextLabel ? contextLabel : "aeyu"}
+            ${onBack && contextLabel ? contextLabel : "aeyu.io"}
           </span>
           ${syncing && !onBack && html`
             <div class="inline-flex items-center gap-1 text-xs" style="color: rgba(255,255,255,0.7);">


### PR DESCRIPTION
Change page titles, sticky header wordmark, and compact header
fallback text to use the full "aeyu.io" branding consistently.

https://claude.ai/code/session_01YNn8ib4QHPhv6q37kN7eie