### PR TITLE
Move avatar to right of help button with increased spacing for touch targets

### DIFF
--- a/src/components/StickyHeader.js
+++ b/src/components/StickyHeader.js
@@ -123,7 +123,7 @@ export function StickyHeader({
             `}
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-3">
           ${syncing && html`
             <div class="inline-flex items-center gap-1.5 text-xs px-2 py-1" style="color: rgba(255,255,255,0.8);">
               <div class="w-3 h-3 border-2 border-t-transparent rounded-full animate-spin flex-shrink-0" style="border-color: white; border-top-color: transparent;"></div>
@@ -141,6 +141,20 @@ export function StickyHeader({
             >
               <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"/>
+              </svg>
+            </button>
+          `}
+
+          <!-- Help button -->
+          ${onHelp && html`
+            <button
+              onClick=${onHelp}
+              class="transition-colors flex-shrink-0"
+              style="color: rgba(255,255,255,0.7);"
+              title="FAQ & Help"
+            >
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
               </svg>
             </button>
           `}
@@ -163,20 +177,6 @@ export function StickyHeader({
               title="Menu"
             >
               ${athlete ? athlete.firstname[0] : "?"}
-            </button>
-          `}
-
-          <!-- Help button -->
-          ${onHelp && html`
-            <button
-              onClick=${onHelp}
-              class="transition-colors flex-shrink-0"
-              style="color: rgba(255,255,255,0.7);"
-              title="FAQ & Help"
-            >
-              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-              </svg>
             </button>
           `}
         </div>
@@ -213,7 +213,7 @@ export function StickyHeader({
             </div>
           `}
         </div>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-3">
           ${rightSlot}
 
           <!-- Search button (compact header) -->
@@ -226,6 +226,20 @@ export function StickyHeader({
             >
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"/>
+              </svg>
+            </button>
+          `}
+
+          <!-- Help button (compact) -->
+          ${onHelp && html`
+            <button
+              onClick=${onHelp}
+              class="transition-colors flex-shrink-0"
+              style="color: rgba(255,255,255,0.7);"
+              title="FAQ & Help"
+            >
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
               </svg>
             </button>
           `}
@@ -246,20 +260,6 @@ export function StickyHeader({
               style="width: 26px; height: 26px; background: rgba(255,255,255,0.2); border: 1.5px solid rgba(255,255,255,0.4); color: rgba(255,255,255,0.9); font-size: 0.65rem; font-family: var(--font-body); font-weight: 600;"
             >
               ${athlete ? athlete.firstname[0] : "?"}
-            </button>
-          `}
-
-          <!-- Help button (compact) -->
-          ${onHelp && html`
-            <button
-              onClick=${onHelp}
-              class="transition-colors flex-shrink-0"
-              style="color: rgba(255,255,255,0.7);"
-              title="FAQ & Help"
-            >
-              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-              </svg>
             </button>
           `}
         </div>


### PR DESCRIPTION
Reorder header icons: search → help → avatar (was search → avatar → help).
Increase gap from gap-2 to gap-3 in both full and compact headers for
better touch targeting on mobile.

https://claude.ai/code/session_01Px7rMf9Vx1dt5ywnWKAGwR