### PR TITLE
Hide Form Indicators when no recent data; rename from Fitness

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -145,7 +145,7 @@ async function loadDashboard() {
       stats.value = { segments: segments.length, awards: 0 };
     }
 
-    // Compute fitness indicators (#106)
+    // Compute form indicators (#106)
     try {
       fitnessData.value = await computeFitnessSummary();
     } catch (e) {
@@ -468,10 +468,10 @@ export function Dashboard() {
           </div>
         </div>
 
-        <!-- Fitness Indicators (#106) -->
+        <!-- Form Indicators (#106) -->
         ${!loading.value && fitnessData.value && (fitnessData.value.performanceCapacity.hasData || fitnessData.value.aerobicEfficiency.hasData) && html`
           <div class="mb-6 rounded-xl p-5" style="background: var(--surface); border: 1px solid var(--border);">
-            <h2 style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text); margin-bottom: 1rem;">Fitness Indicators</h2>
+            <h2 style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text); margin-bottom: 1rem;">Form Indicators</h2>
 
             <div class="grid grid-cols-1 gap-4" style="${fitnessData.value.performanceCapacity.hasData && fitnessData.value.aerobicEfficiency.hasData ? 'display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;' : ''}">
 
@@ -769,7 +769,7 @@ export function Dashboard() {
 
               <details class="group py-3">
                 <summary class="flex items-center justify-between cursor-pointer" style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: var(--text);">
-                  What are the Fitness Indicators?
+                  What are the Form Indicators?
                   <svg class="w-4 h-4 group-open:rotate-180 transition-transform flex-shrink-0 ml-2" style="color: var(--text-tertiary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
                 </summary>
                 <div class="pt-3 pb-1 space-y-2" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">

--- a/src/fitness.js
+++ b/src/fitness.js
@@ -1,7 +1,7 @@
 /**
- * Fitness Indicators — Performance Capacity + Aerobic Efficiency (#106)
+ * Form Indicators — Performance Capacity + Aerobic Efficiency (#106)
  *
- * Two complementary fitness indicators computed entirely from local IndexedDB data.
+ * Two complementary form indicators computed entirely from local IndexedDB data.
  * No new API calls required — uses segment efforts and activity data already synced.
  *
  * Indicator 1: Performance Capacity (no HR required)
@@ -279,6 +279,11 @@ export async function computeAerobicEfficiency() {
     ? recentEF.reduce((sum, d) => sum + d.ef, 0) / recentEF.length
     : null;
 
+  // If no recent rides, don't claim we have data — the card would show stale/empty info
+  if (currentEF == null) {
+    return { ef: null, hasData: false, reason: "no_recent_data" };
+  }
+
   const olderEFAvg = olderEF.length > 0
     ? olderEF.reduce((sum, d) => sum + d.ef, 0) / olderEF.length
     : null;
@@ -326,10 +331,10 @@ function buildMonthlyHistory(efData) {
     .sort((a, b) => a.month.localeCompare(b.month));
 }
 
-// --- Combined Fitness Summary ---
+// --- Combined Form Summary ---
 
 /**
- * Compute all fitness indicators and return a combined summary.
+ * Compute all form indicators and return a combined summary.
  * This is the main entry point for the Dashboard UI.
  */
 export async function computeFitnessSummary() {


### PR DESCRIPTION
- Aerobic Efficiency now returns hasData:false when there are no rides
  in the recent 90-day window, preventing a confusing card showing
  "0 recent rides" with stale historical chart bars
- Rename "Fitness Indicators" to "Form Indicators" throughout UI and
  code to avoid confusion with Strava's existing Fitness feature

https://claude.ai/code/session_01MsvSase98SegAdRTBVUfAp