### PR TITLE
Refresh dashboard during backfill so newest activities appear immediately

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -221,7 +221,7 @@ export function Dashboard() {
             onClick: async () => { const restored = await exitDemo(); authState.value = restored; navigate("/"); },
           }] : [{
             label: syncing ? "Syncing…" : "Sync now",
-            onClick: async () => { try { await manualSync(); } catch(e) { console.error("Manual sync error:", e); } await loadDashboard(); },
+            onClick: async () => { try { await manualSync(loadDashboard); } catch(e) { console.error("Manual sync error:", e); } await loadDashboard(); },
             hidden: syncing,
           }]),
           ...(!isDemo.value ? [{
@@ -308,7 +308,7 @@ export function Dashboard() {
             <div class="flex items-center justify-between mb-1">
               <p class="font-medium">Initial sync paused</p>
               <button
-                onClick=${() => manualSync().catch(() => {}).then(() => loadDashboard())}
+                onClick=${() => manualSync(loadDashboard).catch(() => {}).then(() => loadDashboard())}
                 class="text-xs font-medium px-3 py-1.5 rounded-lg transition-colors"
                 style="background: var(--strava); color: white;"
               >Sync Now</button>

--- a/src/sync.js
+++ b/src/sync.js
@@ -454,8 +454,9 @@ async function runHeartRateMigration() {
  * Fetches one page of activities (~100), then their details, then the next page.
  * This gives users visible data much faster than loading all activities first.
  * Resumable: checks has_efforts flag and sync_state on restart.
+ * @param {Function} [onProgress] - called after each page+detail cycle so the UI can refresh
  */
-export async function startBackfill() {
+export async function startBackfill(onProgress) {
   if (isSyncing.value) return;
   isSyncing.value = true;
 
@@ -529,6 +530,9 @@ export async function startBackfill() {
 
         // Detail-fetch everything pending (includes this page + any prior)
         await fetchActivityDetails();
+
+        // Notify UI so dashboard refreshes with newly synced activities
+        if (onProgress) onProgress();
 
         if (!result.hasMore) break;
 
@@ -679,13 +683,13 @@ export async function updateSyncWindow(newEpoch) {
  * Runs backfill or incremental as appropriate, same as auto-sync cycle.
  * Returns without error on rate-limit (progress signal shows status).
  */
-export async function manualSync() {
+export async function manualSync(onProgress) {
   if (isSyncing.value) return;
 
   const state = await getSyncState();
 
   if (!state.backfill_complete) {
-    await startBackfill();
+    await startBackfill(onProgress);
   } else {
     await incrementalSync();
   }
@@ -741,7 +745,8 @@ async function runAutoSyncCycle() {
 
     if (!state.backfill_complete) {
       // Initial backfill — interleaved list+detail
-      await startBackfill();
+      // Pass callback so dashboard refreshes after each page+detail cycle
+      await startBackfill(autoSyncCallback);
     } else {
       // Incremental — check for new activities, resume pending details
       await incrementalSync();


### PR DESCRIPTION
## Summary
- During backfill, `loadDashboard` only ran after the **entire** multi-page sync completed — users saw sync progress messages ("page 7...") but no activities appeared until all pages were done
- Added `onProgress` callback to `startBackfill()` that fires after each page+detail cycle, triggering a dashboard refresh
- Threaded callback through `manualSync()` and `runAutoSyncCycle()` so all sync paths refresh the dashboard progressively

The sync **order** was already correct (newest-first pages via client-side cutoff, newest-first detail fetch via sorted `getActivitiesWithoutEfforts`). The issue was that the dashboard only refreshed after the full backfill returned, so users couldn't see their newest activities until much later.

## Test plan
- [ ] Clear IndexedDB and trigger fresh backfill — verify activities appear in dashboard after first page+detail cycle (not after all pages)
- [ ] Interrupt backfill (close/reopen) and resume — verify newest activities already visible, older pages continue filling in
- [ ] Manual "Sync now" button during incomplete backfill — verify progressive dashboard refresh
- [ ] Verify no duplicate `loadDashboard` calls cause UI flicker

https://claude.ai/code/session_01XqNgTa5jJajDX6qpDazLks