### PR TITLE
Enrich comparative awards with rank position and % delta

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -362,7 +362,7 @@ function dayOfYear(date) {
  * @param {Array} allEfforts - All efforts on this segment
  * @param {Date} activityDate - Date of the current activity
  * @param {string} field - "elapsed_time" (lower=better) or "average_watts" (higher=better)
- * @returns {{ sinceYear: number, span: number } | null}
+ * @returns {{ sinceYear: number, span: number, rank: number, totalYears: number, pctDelta: number } | null}
  */
 function computeYtdComparison(currentValue, allEfforts, activityDate, field) {
   if (currentValue == null) return null;
@@ -422,7 +422,19 @@ function computeYtdComparison(currentValue, allEfforts, activityDate, field) {
   }
 
   if (sinceYear == null) return null;
-  return { sinceYear, span: currentYear - sinceYear };
+
+  // Rank among all years' bests and % delta from average
+  const allBests = Object.values(bestByYear);
+  const totalYears = allBests.length;
+  const rank = lowerIsBetter
+    ? allBests.filter((v) => v < currentValue).length + 1
+    : allBests.filter((v) => v > currentValue).length + 1;
+  const avg = allBests.reduce((s, v) => s + v, 0) / allBests.length;
+  const pctDelta = avg !== 0
+    ? Math.round(Math.abs(currentValue - avg) / avg * 1000) / 10
+    : 0;
+
+  return { sinceYear, span: currentYear - sinceYear, rank, totalYears, pctDelta };
 }
 
 
@@ -627,6 +639,12 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
           .sort((a, b) => a.elapsed_time - b.elapsed_time);
         const previousBest = otherEfforts.length > 0 ? otherEfforts[0] : null;
 
+        const yearTimes = thisYearEfforts.map((e) => e.elapsed_time);
+        const yearAvg = yearTimes.reduce((s, v) => s + v, 0) / yearTimes.length;
+        const ybPctDelta = yearAvg !== 0
+          ? Math.round(Math.abs(effort.elapsed_time - yearAvg) / yearAvg * 1000) / 10
+          : 0;
+
         awards.push({
           type: "year_best",
           segment: segment.name,
@@ -637,6 +655,9 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
           delta: previousBest
             ? previousBest.elapsed_time - effort.elapsed_time
             : null,
+          rank: 1,
+          totalInSet: thisYearEfforts.length,
+          pctDelta: ybPctDelta,
           message: previousBest
             ? `Year Best on ${segment.name}! ${formatTime(effort.elapsed_time)} (previous: ${formatTime(previousBest.elapsed_time)} on ${formatDate(previousBest.start_date_local)})`
             : `Year Best on ${segment.name}! ${formatTime(effort.elapsed_time)}`,
@@ -654,6 +675,12 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
       const bestOfLast5 = Math.min(...last5.map((e) => e.elapsed_time));
 
       if (effort.elapsed_time === bestOfLast5) {
+        const recentTimes = last5.map((e) => e.elapsed_time);
+        const recentAvg = recentTimes.reduce((s, v) => s + v, 0) / recentTimes.length;
+        const rbPctDelta = recentAvg !== 0
+          ? Math.round(Math.abs(effort.elapsed_time - recentAvg) / recentAvg * 1000) / 10
+          : 0;
+
         awards.push({
           type: "recent_best",
           segment: segment.name,
@@ -662,6 +689,9 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
           power: effort.average_watts || null,
           comparison: null,
           delta: null,
+          rank: 1,
+          totalInSet: last5.length,
+          pctDelta: rbPctDelta,
           message: `Best of your last ${last5.length} on ${segment.name}! ${formatTime(effort.elapsed_time)}`,
         });
       }
@@ -748,6 +778,12 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
       const bestThisMonth = Math.min(...thisMonthEfforts.map((e) => e.elapsed_time));
       if (effort.elapsed_time === bestThisMonth) {
         const monthName = activityDate.toLocaleDateString("en-US", { month: "long" });
+        const monthTimes = thisMonthEfforts.map((e) => e.elapsed_time);
+        const monthAvg = monthTimes.reduce((s, v) => s + v, 0) / monthTimes.length;
+        const mbPctDelta = monthAvg !== 0
+          ? Math.round(Math.abs(effort.elapsed_time - monthAvg) / monthAvg * 1000) / 10
+          : 0;
+
         awards.push({
           type: "monthly_best",
           segment: segment.name,
@@ -756,6 +792,9 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
           power: effort.average_watts || null,
           comparison: null,
           delta: null,
+          rank: 1,
+          totalInSet: thisMonthEfforts.length,
+          pctDelta: mbPctDelta,
           message: `${monthName} Best on ${segment.name}! ${formatTime(effort.elapsed_time)} — fastest of ${thisMonthEfforts.length} efforts this month`,
         });
       }
@@ -831,6 +870,12 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
           if (hasPriorYears) {
             const monthName = activityDate.toLocaleDateString("en-US", { month: "long" });
             const yearsSpanned = new Set(sameMonthEfforts.map((e) => new Date(e.start_date_local).getFullYear())).size;
+            const sameMonthTimes = sameMonthEfforts.map((e) => e.elapsed_time);
+            const sameMonthAvg = sameMonthTimes.reduce((s, v) => s + v, 0) / sameMonthTimes.length;
+            const bmePctDelta = sameMonthAvg !== 0
+              ? Math.round(Math.abs(effort.elapsed_time - sameMonthAvg) / sameMonthAvg * 1000) / 10
+              : 0;
+
             awards.push({
               type: "best_month_ever",
               segment: segment.name,
@@ -839,6 +884,9 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
               power: effort.average_watts || null,
               comparison: null,
               delta: null,
+              rank: 1,
+              totalInSet: sameMonthEfforts.length,
+              pctDelta: bmePctDelta,
               message: `Best ${monthName} ever on ${segment.name}! ${formatTime(effort.elapsed_time)} — fastest across ${yearsSpanned} years`,
             });
           }
@@ -909,6 +957,9 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
           power: effort.average_watts || null,
           comparison: null,
           delta: null,
+          rank: ytdTime.rank,
+          totalInSet: ytdTime.totalYears,
+          pctDelta: ytdTime.pctDelta,
           message: `Fastest by ${monthDay} since ${ytdTime.sinceYear}! ${formatTime(effort.elapsed_time)} on ${segment.name} — best YTD across ${ytdTime.span + 1} years`,
         });
       }
@@ -941,6 +992,9 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
             power: effort.average_watts,
             comparison: null,
             delta: null,
+            rank: ytdPower.rank,
+            totalInSet: ytdPower.totalYears,
+            pctDelta: ytdPower.pctDelta,
             message: `Best power by ${monthDay} since ${ytdPower.sinceYear}! ${Math.round(effort.average_watts)}W on ${segment.name} — best YTD across ${ytdPower.span + 1} years`,
           });
         }

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -1110,10 +1110,17 @@ export function ActivityDetail({ id }) {
                         (a) => {
                           const al = AWARD_LABELS[a.type];
                           const pillStyle = al ? `background: ${al.bg}; color: ${al.text}; border: 1px solid ${al.border};` : "background: #ECEAE6; color: #3E3A36;";
+                          const rankSuffix = (n) => { const s = ["th","st","nd","rd"]; const v = n % 100; return n + (s[(v-20)%10]||s[v]||s[0]); };
+                          const isYtd = a.type === "ytd_best_time" || a.type === "ytd_best_power";
+                          const deltaLabel = a.type === "ytd_best_power" ? "more powerful" : "faster";
+                          const setLabel = isYtd ? (a.totalInSet === 1 ? "year" : "years") : "";
+                          const rankInfo = a.rank != null && a.totalInSet != null
+                            ? ` · ${rankSuffix(a.rank)} of ${a.totalInSet}${isYtd ? ` ${setLabel}` : ""}${a.pctDelta ? `, ${a.pctDelta}% ${deltaLabel}` : ""}`
+                            : "";
                           return html`
                             <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full" style=${pillStyle}>
                               ${al ? renderIconSVG(a.type, { size: 12, color: al.dot }) : null}
-                              ${al?.label || a.type}
+                              ${al?.label || a.type}${rankInfo}
                             </span>
                           `;
                         }


### PR DESCRIPTION
## Summary
- Adds `rank`, `totalInSet`, and `pctDelta` fields to comparative award objects: `year_best`, `recent_best`, `monthly_best`, `best_month_ever`, `ytd_best_time`, `ytd_best_power`
- Extends `computeYtdComparison()` to return rank among all years' bests and % delta from average
- Displays rank and delta inline on award pills in ActivityDetail segment view (e.g. "Year Best · 1st of 14, 6.3% faster")
- Uses "faster" for time-based awards, "more powerful" for power awards; shows "years" label for YTD awards

## Test plan
- [ ] Load an activity with segment awards in ActivityDetail view
- [ ] Verify Year Best, Recent Best, Monthly Best, Best Month Ever pills show rank and % delta
- [ ] Verify YTD Best Time and YTD Best Power pills show rank across years with appropriate label
- [ ] Verify non-comparative awards (Season First, Milestone, etc.) show no rank info
- [ ] Verify pills remain readable and don't overflow on mobile

Closes #130

https://claude.ai/code/session_01KP6TetJs4aKFLKz5To2U1A