### PR TITLE
Fix demo mode not replacing real user activities

### DIFF
--- a/src/demo.js
+++ b/src/demo.js
@@ -71,31 +71,18 @@ export async function startDemo() {
     tx.onerror = () => reject(tx.error);
   });
 
-  // Store activities
+  // Clear existing data then store demo activities, segments, and sync state
   await new Promise((resolve, reject) => {
-    const tx = db.transaction("activities", "readwrite");
-    const store = tx.objectStore("activities");
+    const tx = db.transaction(["activities", "segments", "sync_state"], "readwrite");
+    tx.objectStore("activities").clear();
+    tx.objectStore("segments").clear();
+    tx.objectStore("sync_state").clear();
     for (const act of data.activities) {
-      store.put(act);
+      tx.objectStore("activities").put(act);
     }
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
-
-  // Store segments
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction("segments", "readwrite");
-    const store = tx.objectStore("segments");
     for (const seg of data.segments) {
-      store.put(seg);
+      tx.objectStore("segments").put(seg);
     }
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
-
-  // Set sync state as complete
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction("sync_state", "readwrite");
     tx.objectStore("sync_state").put(
       {
         last_activity_fetch: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- When a logged-in user navigated to `/demo`, `startDemo()` added demo data to IndexedDB without clearing existing real user data, causing a mix of real + demo activities in the Dashboard
- Now clears the `activities`, `segments`, and `sync_state` stores before populating them with demo data, all in a single IndexedDB transaction
- Also consolidates what were 3 separate transactions into 1 for the data population step

## Test plan
- [ ] Log in with a real Strava account, verify activities load
- [ ] Navigate to `/demo` while logged in, verify only Demo Rider activities appear
- [ ] Exit demo mode, verify real session is restored and re-sync works
- [ ] Navigate to `/demo` without being logged in, verify demo works as before

https://claude.ai/code/session_01RFhpz18sSsaeyfjvDiUZUg