### PR TITLE
Fix demo mode destroying real user data on exit

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -219,7 +219,7 @@ export function Dashboard() {
         menuItems=${[
           ...(isDemo.value ? [{
             label: "Exit Demo",
-            onClick: async () => { const restored = await exitDemo(); authState.value = restored; navigate("/"); },
+            onClick: async () => { await exitDemo(); navigate("/"); window.location.reload(); },
           }] : [{
             label: syncing ? "Syncing…" : "Sync now",
             onClick: async () => { try { await manualSync(loadDashboard); } catch(e) { console.error("Manual sync error:", e); } await loadDashboard(); },
@@ -233,11 +233,11 @@ export function Dashboard() {
             label: "Disconnect Strava",
             onClick: handleDisconnect,
           }] : []),
-          {
+          ...(!isDemo.value ? [{
             label: "Delete all data",
             onClick: () => { showDeleteConfirm.value = true; deleteConfirmText.value = ""; },
             danger: true,
-          },
+          }] : []),
         ]}
       />
 

--- a/src/db.js
+++ b/src/db.js
@@ -5,14 +5,37 @@
  */
 
 const DB_NAME = "participation-awards";
+const DEMO_DB_NAME = "participation-awards-demo";
 const DB_VERSION = 3;
 
 let dbPromise = null;
+let activeDBName = DB_NAME;
+
+export function switchToDemoDB() {
+  if (activeDBName === DEMO_DB_NAME) return;
+  activeDBName = DEMO_DB_NAME;
+  dbPromise = null;
+}
+
+export function switchToRealDB() {
+  if (activeDBName === DB_NAME) return;
+  activeDBName = DB_NAME;
+  dbPromise = null;
+}
+
+export function deleteDemoDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(DEMO_DB_NAME);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => resolve();
+  });
+}
 
 export function openDB() {
   if (dbPromise) return dbPromise;
   dbPromise = new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    const request = indexedDB.open(activeDBName, DB_VERSION);
 
     request.onupgradeneeded = (event) => {
       const db = event.target.result;

--- a/src/demo.js
+++ b/src/demo.js
@@ -1,13 +1,10 @@
 /**
- * Demo Mode — loads canned data into IndexedDB for preview without Strava auth.
- * Data: ~60 activities, 10 segments, 3 years of riding history.
- *
- * When an authenticated user enters demo mode, their real session is backed up
- * to sessionStorage and restored on demo exit — no real data is destroyed.
+ * Demo Mode — loads canned data into a separate IndexedDB for preview without Strava auth.
+ * Uses an isolated "participation-awards-demo" database so real user data is never touched.
  */
 
 import { signal } from "@preact/signals";
-import { openDB } from "./db.js";
+import { openDB, switchToDemoDB, switchToRealDB, deleteDemoDB } from "./db.js";
 import { authState } from "./auth.js";
 
 export const isDemo = signal(false);
@@ -19,10 +16,11 @@ const DEMO_ATHLETE = {
   lastname: "Rider",
   profile: "",
 };
-const BACKUP_KEY = "aeyu_real_session_backup";
 
-/** Check if current session is demo mode */
+/** Check if current session is demo mode (checks for demo flag in sessionStorage) */
 export async function checkDemo() {
+  if (sessionStorage.getItem("aeyu_demo_active") !== "true") return;
+  switchToDemoDB();
   const db = await openDB();
   const session = await new Promise((resolve, reject) => {
     const tx = db.transaction("auth", "readonly");
@@ -32,30 +30,23 @@ export async function checkDemo() {
   });
   if (session && session.athlete && session.athlete.id === DEMO_ATHLETE.id) {
     isDemo.value = true;
+    authState.value = session;
+  } else {
+    // Demo DB doesn't have valid session — switch back to real
+    switchToRealDB();
+    sessionStorage.removeItem("aeyu_demo_active");
   }
 }
 
-/** Load demo data into IndexedDB and set fake auth.
- *  If a real session exists, it is backed up to sessionStorage first. */
+/** Load demo data into a separate demo database. Real data is never touched. */
 export async function startDemo() {
   const resp = await fetch(DEMO_DATA_URL);
   if (!resp.ok) throw new Error("Failed to load demo data");
   const data = await resp.json();
 
+  // Switch to the isolated demo database
+  switchToDemoDB();
   const db = await openDB();
-
-  // Back up existing real session (if any) so we can restore on demo exit
-  const existingSession = await new Promise((resolve, reject) => {
-    const tx = db.transaction("auth", "readonly");
-    const req = tx.objectStore("auth").get("session");
-    req.onsuccess = () => resolve(req.result || null);
-    req.onerror = () => reject(req.error);
-  });
-  if (existingSession && existingSession.athlete && existingSession.athlete.id !== DEMO_ATHLETE.id) {
-    try {
-      sessionStorage.setItem(BACKUP_KEY, JSON.stringify(existingSession));
-    } catch { /* sessionStorage unavailable — real session will be lost */ }
-  }
 
   // Set fake auth session
   const session = {
@@ -71,12 +62,9 @@ export async function startDemo() {
     tx.onerror = () => reject(tx.error);
   });
 
-  // Clear existing data then store demo activities, segments, and sync state
+  // Store demo activities, segments, and sync state
   await new Promise((resolve, reject) => {
     const tx = db.transaction(["activities", "segments", "sync_state"], "readwrite");
-    tx.objectStore("activities").clear();
-    tx.objectStore("segments").clear();
-    tx.objectStore("sync_state").clear();
     for (const act of data.activities) {
       tx.objectStore("activities").put(act);
     }
@@ -101,38 +89,16 @@ export async function startDemo() {
     tx.onerror = () => reject(tx.error);
   });
 
+  sessionStorage.setItem("aeyu_demo_active", "true");
   authState.value = session;
   isDemo.value = true;
 }
 
-/** Exit demo — clear demo data, restore real session if backed up */
+/** Exit demo — delete the demo database and switch back to real DB */
 export async function exitDemo() {
-  const db = await openDB();
-  const storeNames = ["auth", "activities", "segments", "sync_state"];
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction(storeNames, "readwrite");
-    for (const name of storeNames) {
-      tx.objectStore(name).clear();
-    }
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
   isDemo.value = false;
-
-  // Restore backed-up real session if present
-  try {
-    const backup = sessionStorage.getItem(BACKUP_KEY);
-    if (backup) {
-      const realSession = JSON.parse(backup);
-      await new Promise((resolve, reject) => {
-        const tx = db.transaction("auth", "readwrite");
-        tx.objectStore("auth").put(realSession, "session");
-        tx.oncomplete = () => resolve();
-        tx.onerror = () => reject(tx.error);
-      });
-      sessionStorage.removeItem(BACKUP_KEY);
-      return realSession;
-    }
-  } catch { /* sessionStorage unavailable — user will need to re-auth */ }
+  sessionStorage.removeItem("aeyu_demo_active");
+  switchToRealDB();
+  await deleteDemoDB();
   return null;
 }


### PR DESCRIPTION
## Summary
- **Root cause**: Demo mode used the same IndexedDB database as real data. `startDemo()` cleared activities/segments/sync_state before loading demo data, and `exitDemo()` cleared everything again, only restoring the auth session. Real sync data was permanently lost.
- **Fix**: Demo mode now uses a completely separate IndexedDB (`participation-awards-demo`). Real data is never read, written, or cleared during demo. A `sessionStorage` flag tracks demo state across page reloads.
- **Also**: Removed "Delete all data" from the avatar menu in demo mode — it should never be available when viewing canned data.

## Changes
- `src/db.js`: Added `switchToDemoDB()`, `switchToRealDB()`, `deleteDemoDB()` — the DB name is switchable and `openDB()` connects to whichever is active
- `src/demo.js`: Rewritten to use isolated demo DB. No more backup/restore of auth sessions. `startDemo()` switches to demo DB and populates it; `exitDemo()` switches back and deletes the demo DB
- `src/components/Dashboard.js`: "Delete all data" menu item hidden in demo mode; exit demo handler simplified (reload to reinit from real DB)

## Test plan
- [ ] Enter demo mode from landing page — verify demo data loads
- [ ] Refresh page while in demo mode — verify demo persists
- [ ] Exit demo mode — verify return to landing (or real dashboard if authenticated)
- [ ] With real Strava data synced: enter demo, browse, exit — verify real data is intact and no resync needed
- [ ] Verify "Delete all data" does NOT appear in demo rider's avatar menu
- [ ] Verify "Delete all data" still works normally for authenticated users

https://claude.ai/code/session_01MN5McF6EncUHrfMfT8tfFx