### PR TITLE
Fix Form Indicators layout to stack vertically on mobile

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -478,7 +478,7 @@ export function Dashboard() {
           <div class="mb-6 rounded-xl p-5" style="background: var(--surface); border: 1px solid var(--border);">
             <h2 style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text); margin-bottom: 1rem;">Form Indicators</h2>
 
-            <div class="grid grid-cols-1 gap-4" style="${fitnessData.value.performanceCapacity.hasData && fitnessData.value.aerobicEfficiency.hasData ? 'display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;' : ''}">
+            <div class="${fitnessData.value.performanceCapacity.hasData && fitnessData.value.aerobicEfficiency.hasData ? 'grid grid-cols-1 sm:grid-cols-2 gap-4' : 'grid grid-cols-1 gap-4'}">
 
               <!-- Performance Capacity -->
               ${fitnessData.value.performanceCapacity.hasData && html`


### PR DESCRIPTION
Replace inline 2-column grid style with Tailwind responsive classes
(grid-cols-1 on mobile, sm:grid-cols-2 on wider screens) so the
Performance Capacity and Aerobic Efficiency cards aren't cramped
side-by-side on phone screens.

https://claude.ai/code/session_01QP82DTvWihqt3Du6m446LZ