### PR TITLE
Darken header background for better contrast with logo

### DIFF
--- a/src/components/StickyHeader.js
+++ b/src/components/StickyHeader.js
@@ -59,7 +59,7 @@ export function StickyHeader({
     <div ref=${sentinelRef} style="height: 0; overflow: hidden;" />
     <header
       class="sticky-header-full ${isCompact ? 'sticky-header-full--hidden' : ''}"
-      style="background: var(--accent);"
+      style="background: linear-gradient(135deg, #6B3518, #8E4A1F);"
     >
       <div class="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
         <div class="flex items-center gap-3">
@@ -151,7 +151,7 @@ export function StickyHeader({
 
     <header
       class="sticky-header-compact ${isCompact ? 'sticky-header-compact--visible' : ''}"
-      style="background: var(--accent); position: fixed; top: 0; left: 0; right: 0; z-index: 50;"
+      style="background: linear-gradient(135deg, #6B3518, #8E4A1F); position: fixed; top: 0; left: 0; right: 0; z-index: 50;"
     >
       <div class="max-w-3xl mx-auto px-4 py-2 flex items-center justify-between">
         <div class="flex items-center gap-2">


### PR DESCRIPTION
The header and logo icon shared the same #B85A28 background color,
making the logo blend in. Use a darker gradient (135deg, #6B3518 to
#8E4A1F) so the logo clearly stands out against the header.

https://claude.ai/code/session_018NKfEAMb4BVJW8ZUZ9VwVZ