### PR TITLE
Fix broken import map that prevented app from loading

### DIFF
--- a/activity.html
+++ b/activity.html
@@ -45,7 +45,7 @@
       {
         "imports": {
           "preact": "/vendor/preact.mjs",
-          "preact/": "/vendor/",
+          "preact/hooks": "/vendor/hooks.mjs",
           "@preact/signals": "/vendor/signals.mjs",
           "htm/preact": "/vendor/htm-preact.mjs"
         }
@@ -142,7 +142,7 @@
       setTimeout(function() {
         if (!window.__appRendered) {
           var detail = !window.__appModuleLoaded
-            ? "Module failed to load (CDN or network issue)"
+            ? "Module failed to load (missing vendor file or import error)"
             : "App loaded but failed to render";
           showLoadError(detail);
         }
@@ -151,7 +151,7 @@
       setTimeout(function() {
         if (!window.__appRendered) {
           var detail = !window.__appModuleLoaded
-            ? "Module failed to load — CDN may be unreachable"
+            ? "Module failed to load — check browser console for details"
             : "App module loaded but rendering failed";
           showLoadError(detail);
         }

--- a/callback.html
+++ b/callback.html
@@ -15,7 +15,7 @@
       {
         "imports": {
           "preact": "/vendor/preact.mjs",
-          "preact/": "/vendor/",
+          "preact/hooks": "/vendor/hooks.mjs",
           "@preact/signals": "/vendor/signals.mjs",
           "htm/preact": "/vendor/htm-preact.mjs"
         }

--- a/dashboard.html
+++ b/dashboard.html
@@ -45,7 +45,7 @@
       {
         "imports": {
           "preact": "/vendor/preact.mjs",
-          "preact/": "/vendor/",
+          "preact/hooks": "/vendor/hooks.mjs",
           "@preact/signals": "/vendor/signals.mjs",
           "htm/preact": "/vendor/htm-preact.mjs"
         }
@@ -142,7 +142,7 @@
       setTimeout(function() {
         if (!window.__appRendered) {
           var detail = !window.__appModuleLoaded
-            ? "Module failed to load (CDN or network issue)"
+            ? "Module failed to load (missing vendor file or import error)"
             : "App loaded but failed to render";
           showLoadError(detail);
         }
@@ -151,7 +151,7 @@
       setTimeout(function() {
         if (!window.__appRendered) {
           var detail = !window.__appModuleLoaded
-            ? "Module failed to load — CDN may be unreachable"
+            ? "Module failed to load — check browser console for details"
             : "App module loaded but rendering failed";
           showLoadError(detail);
         }

--- a/demo.html
+++ b/demo.html
@@ -45,7 +45,7 @@
       {
         "imports": {
           "preact": "/vendor/preact.mjs",
-          "preact/": "/vendor/",
+          "preact/hooks": "/vendor/hooks.mjs",
           "@preact/signals": "/vendor/signals.mjs",
           "htm/preact": "/vendor/htm-preact.mjs"
         }
@@ -142,7 +142,7 @@
       setTimeout(function() {
         if (!window.__appRendered) {
           var detail = !window.__appModuleLoaded
-            ? "Module failed to load (CDN or network issue)"
+            ? "Module failed to load (missing vendor file or import error)"
             : "App loaded but failed to render";
           showLoadError(detail);
         }
@@ -151,7 +151,7 @@
       setTimeout(function() {
         if (!window.__appRendered) {
           var detail = !window.__appModuleLoaded
-            ? "Module failed to load — CDN may be unreachable"
+            ? "Module failed to load — check browser console for details"
             : "App module loaded but rendering failed";
           showLoadError(detail);
         }

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
       {
         "imports": {
           "preact": "/vendor/preact.mjs",
-          "preact/": "/vendor/",
+          "preact/hooks": "/vendor/hooks.mjs",
           "@preact/signals": "/vendor/signals.mjs",
           "htm/preact": "/vendor/htm-preact.mjs"
         }
@@ -142,7 +142,7 @@
       setTimeout(function() {
         if (!window.__appRendered) {
           var detail = !window.__appModuleLoaded
-            ? "Module failed to load (CDN or network issue)"
+            ? "Module failed to load (missing vendor file or import error)"
             : "App loaded but failed to render";
           showLoadError(detail);
         }
@@ -151,7 +151,7 @@
       setTimeout(function() {
         if (!window.__appRendered) {
           var detail = !window.__appModuleLoaded
-            ? "Module failed to load — CDN may be unreachable"
+            ? "Module failed to load — check browser console for details"
             : "App module loaded but rendering failed";
           showLoadError(detail);
         }


### PR DESCRIPTION
## Summary
- Fix import map `"preact/"` prefix mapping that resolved `"preact/hooks"` to `/vendor/hooks` (missing `.mjs` extension), breaking module loading on all pages
- Replace with explicit `"preact/hooks" → "/vendor/hooks.mjs"` mapping in all 5 HTML files
- Update error messages to reflect vendored deps instead of CDN

## Root Cause
Commit #140 vendored all dependencies locally and added an import map prefix `"preact/" → "/vendor/"`. This correctly maps the prefix but doesn't append file extensions — so `import ... from "preact/hooks"` in `vendor/signals.mjs` resolved to `/vendor/hooks` instead of `/vendor/hooks.mjs`, causing a 404 and the "Module failed to load" error screen.

## Test plan
- [ ] Load index.html — app should render instead of showing error
- [ ] Load dashboard.html, activity.html, demo.html, callback.html — all should work
- [ ] Verify no console errors about failed module imports

https://claude.ai/code/session_016DXKYt4TcUCXNPa976cR4m