### PR TITLE
Fix demo mode exit getting stuck in re-entry loop

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -219,7 +219,7 @@ export function Dashboard() {
         menuItems=${[
           ...(isDemo.value ? [{
             label: "Exit Demo",
-            onClick: async () => { await exitDemo(); navigate("/"); window.location.reload(); },
+            onClick: async () => { navigate("/"); await exitDemo(); },
           }] : [{
             label: syncing ? "Syncing…" : "Sync now",
             onClick: async () => { try { await manualSync(loadDashboard); } catch(e) { console.error("Manual sync error:", e); } await loadDashboard(); },

--- a/src/demo.js
+++ b/src/demo.js
@@ -94,11 +94,11 @@ export async function startDemo() {
   isDemo.value = true;
 }
 
-/** Exit demo — delete the demo database and switch back to real DB */
+/** Exit demo — clear auth state, delete demo DB, switch back to real DB */
 export async function exitDemo() {
+  authState.value = null;
   isDemo.value = false;
   sessionStorage.removeItem("aeyu_demo_active");
   switchToRealDB();
   await deleteDemoDB();
-  return null;
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `exitDemo()` set `isDemo.value = false` without clearing `authState`, triggering a signal re-render that saw a truthy auth session. If the route was still `/demo`, the re-render fell into the `case "demo"` branch and called `startDemo()` again — creating an infinite re-entry loop.
- **Fix:** `exitDemo()` now clears `authState.value = null` so the re-render sees no auth and shows Landing. The exit handler also calls `navigate("/")` before `exitDemo()` so the route is already `/` when signal changes fire, preventing the `case "demo"` branch from triggering.
- Removed unnecessary `window.location.reload()` since state is now properly cleaned up.

## Test plan

- [ ] Navigate to `/demo` → verify demo loads
- [ ] Click avatar menu → "Exit Demo" → verify app returns to Landing page
- [ ] Start demo from Landing page "try the demo" link → exit → verify return to Landing
- [ ] After exiting demo, verify no `aeyu_demo_active` in sessionStorage and no `participation-awards-demo` IndexedDB

https://claude.ai/code/session_0131mouQoDWca7gKaACssydZ