### PR TITLE
Add long-press tooltip support for touch devices

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import { signal, effect } from "@preact/signals";
 import { authState, initAuth } from "./auth.js";
 import { checkDemo, isDemo, startDemo } from "./demo.js";
 import { initInstallDetection } from "./install.js";
+import { initTouchTooltips } from "./touch-tooltip.js";
 import { Landing } from "./components/Landing.js";
 import { Dashboard } from "./components/Dashboard.js";
 import { ActivityDetail } from "./components/ActivityDetail.js";
@@ -152,6 +153,12 @@ async function init() {
     initInstallDetection();
   } catch (err) {
     console.error("Install detection error:", err);
+  }
+
+  try {
+    initTouchTooltips();
+  } catch (err) {
+    console.error("Touch tooltip init error:", err);
   }
 
   try {

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -963,6 +963,16 @@ export function Dashboard() {
                   The app automatically detects recurring routes by comparing which segments appear on each ride. If two activities share 70%+ of their segments, they're considered the same route. This powers the Route Season First award — rather than listing a Season First for every segment on a familiar ride, it collapses them into a single route-level award.
                 </div>
               </details>
+
+              <details class="group py-3">
+                <summary class="flex items-center justify-between cursor-pointer" style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: var(--text);">
+                  How do I see award descriptions on my phone?
+                  <svg class="w-4 h-4 group-open:rotate-180 transition-transform flex-shrink-0 ml-2" style="color: var(--text-tertiary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                </summary>
+                <div class="pt-3 pb-1" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
+                  Long-press any award pill to see its description. On desktop you can hover, but touch screens don't have hover — so a half-second press triggers the tooltip instead.
+                </div>
+              </details>
             </div>
 
           </div>

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -79,9 +79,11 @@ export function Landing() {
           <h1 class="mb-2" style="font-family: var(--font-display); font-size: 4rem; font-weight: 400; line-height: 1;">
             <span style="color: var(--text);">aeyu</span><span style="color: var(--accent);">.io</span>
           </h1>
-          <p class="mb-8 group relative inline-block cursor-help" style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text-tertiary); font-style: italic;">
+          <p class="mb-8 group relative inline-block cursor-help" style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text-tertiary); font-style: italic;"
+            onClick=${(e) => { const tip = e.currentTarget.querySelector('.landing-tip'); if (tip) tip.classList.toggle('visible'); }}
+          >
             The sound you make at the top of the climb
-            <span class="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 top-full mt-2 text-white text-xs rounded px-3 py-2 whitespace-nowrap z-10" style="background: var(--text); font-family: var(--font-body); font-style: normal;">
+            <span class="landing-tip invisible group-hover:visible absolute left-1/2 -translate-x-1/2 top-full mt-2 text-white text-xs rounded px-3 py-2 whitespace-nowrap z-10" style="background: var(--text); font-family: var(--font-body); font-style: normal;">
               It's Norwegian — like "ow" but with more suffering
             </span>
           </p>

--- a/src/components/SegmentSparkline.js
+++ b/src/components/SegmentSparkline.js
@@ -132,6 +132,7 @@ export function SegmentSparkline({ segment, currentEffortId }) {
               stroke=${p.isCurrent ? "#fff" : "none"}
               stroke-width=${p.isCurrent ? 1.5 : 0}
               onMouseEnter=${() => expanded && setTooltip({ x: p.x, y: p.y, time: p.time, date: p.date, idx: i })}
+              onTouchStart=${(e) => { if (expanded) { e.stopPropagation(); setTooltip({ x: p.x, y: p.y, time: p.time, date: p.date, idx: i }); } }}
               style=${expanded ? "cursor: pointer;" : ""}
             />
           `)}

--- a/src/touch-tooltip.js
+++ b/src/touch-tooltip.js
@@ -1,0 +1,91 @@
+// Long-press tooltip support for touch devices.
+// On desktop, native title= attributes handle tooltips via hover.
+// On touch devices, a 500ms long-press on any element with a title attribute
+// shows a tooltip overlay. Tapping elsewhere dismisses it.
+
+let overlay = null;
+let timer = null;
+let startX = 0;
+let startY = 0;
+
+function findTitled(el) {
+  while (el && el !== document.body) {
+    if (el.getAttribute && el.getAttribute("title")) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+function show(text, x, y) {
+  dismiss();
+  overlay = document.createElement("div");
+  overlay.className = "touch-tooltip";
+  overlay.textContent = text;
+  // Position near the long-press point
+  overlay.style.cssText =
+    "position:fixed;z-index:9999;max-width:260px;padding:8px 12px;" +
+    "border-radius:8px;font-size:13px;line-height:1.4;pointer-events:none;" +
+    "font-family:var(--font-body);color:var(--bg);background:var(--text);" +
+    "box-shadow:0 2px 8px rgba(0,0,0,0.2);opacity:0;transition:opacity 0.15s;";
+  document.body.appendChild(overlay);
+  // Compute position: center horizontally on press point, above it
+  const rect = overlay.getBoundingClientRect();
+  let left = x - rect.width / 2;
+  let top = y - rect.height - 12;
+  // Keep on screen
+  if (left < 8) left = 8;
+  if (left + rect.width > window.innerWidth - 8) left = window.innerWidth - rect.width - 8;
+  if (top < 8) top = y + 20; // flip below if no room above
+  overlay.style.left = left + "px";
+  overlay.style.top = top + "px";
+  // Fade in
+  requestAnimationFrame(() => { if (overlay) overlay.style.opacity = "1"; });
+  // Auto-dismiss after 3s
+  setTimeout(dismiss, 3000);
+}
+
+function dismiss() {
+  if (overlay) {
+    overlay.remove();
+    overlay = null;
+  }
+}
+
+function cancel() {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+export function initTouchTooltips() {
+  if (!("ontouchstart" in window)) return;
+
+  document.addEventListener("touchstart", (e) => {
+    cancel();
+    const touch = e.touches[0];
+    startX = touch.clientX;
+    startY = touch.clientY;
+    const target = findTitled(e.target);
+    if (!target) return;
+    timer = setTimeout(() => {
+      const text = target.getAttribute("title");
+      if (text) show(text, startX, startY);
+    }, 500);
+  }, { passive: true });
+
+  document.addEventListener("touchmove", (e) => {
+    if (!timer) return;
+    const touch = e.touches[0];
+    const dx = touch.clientX - startX;
+    const dy = touch.clientY - startY;
+    if (dx * dx + dy * dy > 100) cancel(); // moved > 10px
+  }, { passive: true });
+
+  document.addEventListener("touchend", () => {
+    cancel();
+  }, { passive: true });
+
+  // Dismiss on any tap
+  document.addEventListener("click", dismiss, { passive: true });
+}


### PR DESCRIPTION
## Summary
Adds touch-friendly tooltip support for mobile and tablet devices. On touch screens, users can now long-press (500ms) on any element with a title attribute to see a tooltip overlay, complementing the native hover tooltips available on desktop.

## Key Changes
- **New `touch-tooltip.js` module**: Implements long-press detection and tooltip overlay rendering
  - Detects 500ms long-press on titled elements
  - Shows positioned tooltip overlay that auto-dismisses after 3 seconds or on tap
  - Handles touch movement to cancel tooltip if user drags more than 10px
  - Intelligently positions tooltip above or below press point, keeping it on-screen

- **Updated `app.js`**: Initializes touch tooltip system on app startup with error handling

- **Updated `Dashboard.js`**: Added FAQ entry explaining the long-press tooltip feature to users

- **Updated `Landing.js`**: Enhanced tagline tooltip with click handler for mobile accessibility (complements existing hover behavior)

- **Updated `SegmentSparkline.js`**: Added touch event handler for sparkline tooltips (partial change visible in diff)

## Implementation Details
- Uses passive event listeners for better scroll performance
- Tooltip styling uses CSS variables for theme consistency
- Gracefully degrades on non-touch devices (checks for `ontouchstart` support)
- Tooltip positioning accounts for viewport boundaries to prevent off-screen rendering
- Fade-in animation provides visual feedback

https://claude.ai/code/session_01EHGGpemwHGikxd1BAEMp41