### PR TITLE
Fix demo mode leaking into logged-in user sessions

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,7 @@ import { html } from "htm/preact";
 import { render, Component } from "preact";
 import { signal, effect } from "@preact/signals";
 import { authState, initAuth } from "./auth.js";
-import { checkDemo, isDemo, startDemo } from "./demo.js";
+import { checkDemo, isDemo, startDemo, exitDemo } from "./demo.js";
 import { initInstallDetection } from "./install.js";
 import { initTouchTooltips } from "./touch-tooltip.js";
 import { Landing } from "./components/Landing.js";
@@ -97,6 +97,13 @@ class ErrorBoundary extends Component {
 function App() {
   const auth = authState.value;
   const currentRoute = route.value;
+
+  // If demo is active but user navigated away from /demo, exit demo mode
+  // and let the app re-render with the real auth state.
+  if (currentRoute !== "demo" && isDemo.value) {
+    exitDemo();
+    return null;
+  }
 
   // /demo is always accessible — start demo if needed
   if (currentRoute === "demo") {

--- a/src/demo.js
+++ b/src/demo.js
@@ -20,6 +20,14 @@ const DEMO_ATHLETE = {
 /** Check if current session is demo mode (checks for demo flag in sessionStorage) */
 export async function checkDemo() {
   if (sessionStorage.getItem("aeyu_demo_active") !== "true") return;
+  // Only restore demo mode if we're actually on the /demo route.
+  // Without this, a logged-in user who previously visited /demo would get
+  // demo data on every page load because the sessionStorage flag persists.
+  const path = window.location.pathname.replace(/\.html$/, "").replace(/^\//, "") || "";
+  if (path !== "demo") {
+    sessionStorage.removeItem("aeyu_demo_active");
+    return;
+  }
   switchToDemoDB();
   const db = await openDB();
   const session = await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- **`checkDemo()` now checks the current URL** before restoring demo mode on page load. Previously, the `sessionStorage` flag from a prior `/demo` visit would cause `checkDemo()` to switch to the demo DB and overwrite the real `authState`, even when the user loaded `/dashboard` or any other route.
- **`App()` now exits demo mode when navigating away from `/demo`**. Previously, in-app navigation (e.g. clicking a link to dashboard) left `isDemo` true, `authState` pointing at the demo session, and the DB pointer stuck on the demo database.

## Root Cause
Two independent paths allowed demo state to leak:
1. **Page reload path**: `init()` calls `initAuth()` (reads real session) then `checkDemo()` which unconditionally overwrote `authState` with the demo session if `sessionStorage` had the flag set.
2. **In-app navigation path**: `App()` had no cleanup when the route changed from `demo` to anything else — demo signals and DB pointer persisted.

## Test plan
- [ ] Visit `/demo` — verify demo mode loads correctly
- [ ] Navigate from `/demo` to `/dashboard` — verify real user data appears (not demo data)
- [ ] While on `/demo`, reload the page — verify demo mode restores
- [ ] Visit `/demo`, then open a new tab to `/dashboard` — verify dashboard shows real data
- [ ] Visit `/demo`, close tab, open new tab to `/` — verify landing/dashboard shows real state

https://claude.ai/code/session_01JxR3YXxJYqUWtak6QgwU4e