### PR TITLE
Fix long-press selecting text instead of showing tooltip

### DIFF
--- a/src/touch-tooltip.js
+++ b/src/touch-tooltip.js
@@ -7,6 +7,8 @@ let overlay = null;
 let timer = null;
 let startX = 0;
 let startY = 0;
+let pressTarget = null;
+let suppressContextMenu = false;
 
 function findTitled(el) {
   while (el && el !== document.body) {
@@ -56,6 +58,11 @@ function cancel() {
     clearTimeout(timer);
     timer = null;
   }
+  if (pressTarget) {
+    pressTarget.style.removeProperty("-webkit-user-select");
+    pressTarget.style.removeProperty("user-select");
+    pressTarget = null;
+  }
 }
 
 export function initTouchTooltips() {
@@ -68,7 +75,16 @@ export function initTouchTooltips() {
     startY = touch.clientY;
     const target = findTitled(e.target);
     if (!target) return;
+    pressTarget = target;
+    target.style.setProperty("-webkit-user-select", "none");
+    target.style.setProperty("user-select", "none");
     timer = setTimeout(() => {
+      suppressContextMenu = true;
+      if (pressTarget) {
+        pressTarget.style.removeProperty("-webkit-user-select");
+        pressTarget.style.removeProperty("user-select");
+        pressTarget = null;
+      }
       const text = target.getAttribute("title");
       if (text) show(text, startX, startY);
     }, 500);
@@ -84,7 +100,15 @@ export function initTouchTooltips() {
 
   document.addEventListener("touchend", () => {
     cancel();
+    setTimeout(() => { suppressContextMenu = false; }, 50);
   }, { passive: true });
+
+  document.addEventListener("contextmenu", (e) => {
+    if (suppressContextMenu) {
+      e.preventDefault();
+      suppressContextMenu = false;
+    }
+  });
 
   // Dismiss on any tap
   document.addEventListener("click", dismiss, { passive: true });


### PR DESCRIPTION
## Summary
- Fixes the long-press tooltip feature from #153 where the browser's native long-press behavior (text selection + context menu) fires alongside the 500ms tooltip timer, causing text to be selected instead of the tooltip appearing

## Changes
- Apply `user-select: none` on the target element immediately on `touchstart` to prevent text selection during the long-press gesture
- Suppress the browser context menu when the tooltip timer fires successfully
- Clean up `user-select` styles when the gesture is cancelled (drag, release) or after the tooltip is shown

## Test plan
- [ ] On a mobile/touch device, long-press an award pill — tooltip should appear without text selection
- [ ] Short taps should still work normally (no user-select interference)
- [ ] Dragging during a press should cancel the tooltip and restore normal selection behavior
- [ ] Context menu should only be suppressed when a tooltip fires, not on normal long-press elsewhere

https://claude.ai/code/session_019KvyB9rBsXyHcyRkiWC2Hv