### PR TITLE
Limit initial backfill to 13 months, filter cycling-only activities

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -26,6 +26,7 @@ import {
   getAllSegments,
   getActivitiesWithoutEfforts,
   getSyncState,
+  updateSyncState,
   clearAllData,
   getResetEvent,
   setResetEvent,
@@ -77,9 +78,11 @@ const refBirthday = signal("");
 const refAge = signal("40");
 const streakData = signal(null);
 const fitnessData = signal(null);
-const syncWindowChoice = signal("3y"); // "2y" | "3y" | "4y" | "all" | "custom"
+const syncWindowChoice = signal("5y"); // "2y" | "3y" | "5y" | "all" | "custom"
 const syncWindowCustomDate = signal("");
 const currentSyncAfterEpoch = signal(null);
+const showFirstSyncPrompt = signal(false);
+const firstSyncChoice = signal("5y");
 
 async function loadDashboard() {
   loading.value = true;
@@ -121,7 +124,7 @@ async function loadDashboard() {
       const diffYears = (now - state.sync_after_epoch) / (365.25 * 24 * 3600);
       if (Math.abs(diffYears - 2) < 0.1) syncWindowChoice.value = "2y";
       else if (Math.abs(diffYears - 3) < 0.1) syncWindowChoice.value = "3y";
-      else if (Math.abs(diffYears - 4) < 0.1) syncWindowChoice.value = "4y";
+      else if (Math.abs(diffYears - 5) < 0.1) syncWindowChoice.value = "5y";
       else {
         syncWindowChoice.value = "custom";
         syncWindowCustomDate.value = new Date(state.sync_after_epoch * 1000).toISOString().slice(0, 10);
@@ -176,10 +179,15 @@ export function Dashboard() {
   useEffect(() => {
     loadDashboard();
 
-    // Start automatic background sync — handles backfill, incremental,
-    // rate limit cooldowns, and periodic checks for new activities.
+    // Check if this is a first-time sync — prompt user for data window
     if (!isDemo.value) {
-      startAutoSync(() => loadDashboard());
+      getSyncState().then((state) => {
+        if (!state.last_sync && !state.backfill_complete && !state.initial_backfill_complete && state.sync_after_epoch === null) {
+          showFirstSyncPrompt.value = true;
+        } else {
+          startAutoSync(() => loadDashboard());
+        }
+      });
     }
 
     return () => stopAutoSync();
@@ -778,6 +786,60 @@ export function Dashboard() {
         <img src="assets/strava/api_logo_pwrdBy_strava_horiz_orange.svg" alt="Powered by Strava" style="height: 18px; display: inline-block; opacity: 0.6;" />
       </footer>
 
+      <!-- First Sync Data Window Prompt -->
+      ${showFirstSyncPrompt.value && html`
+        <div
+          class="fixed inset-0 z-50 flex items-start justify-center bg-black/40 backdrop-blur-sm overflow-y-auto p-4 pt-16 sm:pt-24"
+        >
+          <div class="rounded-xl shadow-xl w-full max-w-md p-6 my-4" style="background: var(--surface); border: 1px solid var(--border);">
+            <h2 style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text); margin-bottom: 0.5rem;">How far back should we sync?</h2>
+            <p class="text-xs mb-3" style="color: var(--text-tertiary);">
+              We'll fetch your last 13 months of rides first for quick results, then backfill to your chosen window. Only cycling activities are synced.
+            </p>
+
+            <div class="flex flex-wrap gap-1.5 mb-3">
+              ${["2y", "3y", "5y", "all"].map((opt) => {
+                const labels = { "2y": "Last 2 years", "3y": "Last 3 years", "5y": "Last 5 years", "all": "All time" };
+                const descs = { "2y": "Fastest sync", "3y": "", "5y": "Recommended", "all": "May take several sessions" };
+                const isActive = firstSyncChoice.value === opt;
+                return html`
+                  <button
+                    key=${opt}
+                    onClick=${() => { firstSyncChoice.value = opt; }}
+                    class="text-xs px-2.5 py-1.5 rounded-lg transition-colors"
+                    style=${isActive
+                      ? "background: var(--text); color: var(--surface); font-family: var(--font-body);"
+                      : "border: 1px solid var(--border); color: var(--text-secondary); font-family: var(--font-body);"}
+                  >
+                    ${labels[opt]}${descs[opt] ? html` <span class="opacity-60">(${descs[opt]})</span>` : ""}
+                  </button>
+                `;
+              })}
+            </div>
+
+            <button
+              onClick=${async () => {
+                const now = Date.now() / 1000;
+                let epoch = null;
+                if (firstSyncChoice.value === "2y") epoch = Math.floor(now - 2 * 365.25 * 24 * 3600);
+                else if (firstSyncChoice.value === "3y") epoch = Math.floor(now - 3 * 365.25 * 24 * 3600);
+                else if (firstSyncChoice.value === "5y") epoch = Math.floor(now - 5 * 365.25 * 24 * 3600);
+                // null = all time
+                await updateSyncState({ sync_after_epoch: epoch });
+                currentSyncAfterEpoch.value = epoch;
+                syncWindowChoice.value = firstSyncChoice.value;
+                showFirstSyncPrompt.value = false;
+                startAutoSync(() => loadDashboard());
+              }}
+              class="text-xs px-4 py-2 rounded font-medium transition-colors w-full"
+              style="background: var(--strava); color: white;"
+            >
+              Start Syncing
+            </button>
+          </div>
+        </div>
+      `}
+
       <!-- FAQ Modal Overlay -->
       ${showFaq.value && html`
         <div
@@ -996,8 +1058,9 @@ export function Dashboard() {
                   <svg class="w-4 h-4 group-open:rotate-180 transition-transform flex-shrink-0 ml-2" style="color: var(--text-tertiary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
                 </summary>
                 <div class="pt-3 pb-1 space-y-2" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
-                  <p>After connecting Strava, the app fetches your activity list and then detail-fetches each activity for segment efforts. This happens in the background and is <strong>resumable</strong> — if you close the browser or hit a rate limit, sync picks up where it left off next time.</p>
-                  <p>Strava enforces API rate limits (per 15-minute window and daily). The app tracks usage and pauses automatically when limits are approached. You can configure the <strong>sync window</strong> in settings (default 2 years, or 3y/4y/all/custom date).</p>
+                  <p>After connecting Strava, the app fetches your <strong>cycling activities</strong> only (rides, virtual rides, gravel, MTB, e-bike) and detail-fetches each for segment efforts. Non-cycling activities (runs, walks, swims, etc.) are excluded.</p>
+                  <p>Sync uses a <strong>two-phase approach</strong>: your last 13 months are fetched first so you get usable data quickly, then the app backfills to your full sync window (default 5 years, configurable in settings). This is <strong>resumable</strong> — if you close the browser or hit a rate limit, sync picks up where it left off.</p>
+                  <p>Strava enforces API rate limits (per 15-minute window and daily). The app tracks usage and pauses automatically when limits are approached.</p>
                 </div>
               </details>
 
@@ -1065,11 +1128,11 @@ export function Dashboard() {
               <!-- Sync Window Settings (#111) -->
               <div>
                 <p class="text-xs font-medium mb-1.5" style="color: var(--text-secondary); font-family: var(--font-body);">Sync Window</p>
-                <p class="text-xs mb-2" style="color: var(--text-tertiary);">How far back to sync activities from Strava. Shorter windows sync faster and use less storage.</p>
+                <p class="text-xs mb-2" style="color: var(--text-tertiary);">How far back to sync cycling activities from Strava. The last 13 months sync first, then historical data fills in.</p>
 
                 <div class="flex flex-wrap gap-1.5 mb-2">
-                  ${["2y", "3y", "4y", "all"].map((opt) => {
-                    const labels = { "2y": "Last 2 years", "3y": "Last 3 years", "4y": "Last 4 years", "all": "All time" };
+                  ${["2y", "3y", "5y", "all"].map((opt) => {
+                    const labels = { "2y": "Last 2 years", "3y": "Last 3 years", "5y": "Last 5 years", "all": "All time" };
                     const isActive = syncWindowChoice.value === opt;
                     return html`
                       <button
@@ -1111,7 +1174,7 @@ export function Dashboard() {
                     const now = Date.now() / 1000;
                     if (syncWindowChoice.value === "2y") epoch = Math.floor(now - 2 * 365.25 * 24 * 3600);
                     else if (syncWindowChoice.value === "3y") epoch = Math.floor(now - 3 * 365.25 * 24 * 3600);
-                    else if (syncWindowChoice.value === "4y") epoch = Math.floor(now - 4 * 365.25 * 24 * 3600);
+                    else if (syncWindowChoice.value === "5y") epoch = Math.floor(now - 5 * 365.25 * 24 * 3600);
                     else if (syncWindowChoice.value === "custom" && syncWindowCustomDate.value) {
                       epoch = Math.floor(new Date(syncWindowCustomDate.value).getTime() / 1000);
                     }

--- a/src/db.js
+++ b/src/db.js
@@ -427,6 +427,7 @@ const DEFAULT_SYNC_STATE = {
   power_backfill_complete: false,
   schema_version: 0,
   sync_after_epoch: null, // Unix timestamp — limits how far back to sync (#111)
+  initial_backfill_complete: false, // true once the 13-month priority window is done
 };
 
 export async function getSyncState() {

--- a/src/sync.js
+++ b/src/sync.js
@@ -43,6 +43,16 @@ const BATCH_SIZE = 80;
 const RATE_LIMIT_THRESHOLD = 0.8;
 const LIST_PAGE_SIZE = 100; // Smaller pages for interleaved list+detail sync
 
+// Cycling-related sport types — filter out walks, runs, swims, etc.
+const CYCLING_SPORT_TYPES = new Set([
+  "Ride", "VirtualRide", "MountainBikeRide", "GravelRide", "EBikeRide",
+  "EMountainBikeRide", "Velomobile", "Handcycle",
+]);
+
+function isCyclingActivity(activity) {
+  return CYCLING_SPORT_TYPES.has(activity.sport_type);
+}
+
 // --- Rate Limit Tracking ---
 
 function parseRateLimits(response) {
@@ -167,8 +177,12 @@ async function fetchActivityListPage(page, { afterEpoch = null, cutoffEpoch = nu
     hitCutoff = filtered.length < activities.length;
   }
 
+  // Filter to cycling activities only
+  filtered = filtered.filter(isCyclingActivity);
+
   if (filtered.length === 0) {
-    return { summaries: [], hasMore: false, newestDate: null, hitCutoff: true };
+    // If we had activities but all were non-cycling, there may be more pages
+    return { summaries: [], hasMore: activities.length >= LIST_PAGE_SIZE && !hitCutoff, newestDate: null, hitCutoff };
   }
 
   const summaries = filtered.map(toActivitySummary);
@@ -204,15 +218,15 @@ async function fetchAllNewActivities(lastActivityDate) {
 
   while (true) {
     const result = await fetchActivityListPage(page, { afterEpoch });
-    if (result.summaries.length === 0) break;
 
-    allNew.push(...result.summaries);
-
-    syncProgress.value = {
-      ...syncProgress.value,
-      fetched: syncProgress.value.fetched + result.summaries.length,
-      message: `Found ${syncProgress.value.fetched + result.summaries.length} new activities...`,
-    };
+    if (result.summaries.length > 0) {
+      allNew.push(...result.summaries);
+      syncProgress.value = {
+        ...syncProgress.value,
+        fetched: syncProgress.value.fetched + result.summaries.length,
+        message: `Found ${syncProgress.value.fetched + result.summaries.length} new activities...`,
+      };
+    }
 
     if (!result.hasMore) break;
     page++;
@@ -449,11 +463,85 @@ async function runHeartRateMigration() {
 
 // --- Public API ---
 
+// 13-month priority window — gives users a full year of context quickly
+const INITIAL_WINDOW_MONTHS = 13;
+const INITIAL_WINDOW_SECONDS = INITIAL_WINDOW_MONTHS * 30.44 * 24 * 3600;
+
+// Default full sync window when user hasn't chosen (5 years)
+const DEFAULT_SYNC_WINDOW_YEARS = 5;
+
 /**
- * Start full backfill — interleaves activity list and detail fetching.
- * Fetches one page of activities (~100), then their details, then the next page.
- * This gives users visible data much faster than loading all activities first.
- * Resumable: checks has_efforts flag and sync_state on restart.
+ * Run one pass of interleaved list+detail backfill within a cutoff window.
+ * Returns true if completed (all pages fetched), false if interrupted (rate limit).
+ */
+async function runBackfillPass(cutoffEpoch, startPage, onProgress) {
+  let page = startPage;
+  let lastActivityDate = (await getSyncState()).last_activity_fetch;
+  let totalFetched = 0;
+
+  const windowLabel = cutoffEpoch
+    ? `since ${new Date(cutoffEpoch * 1000).toLocaleDateString("en-US", { month: "short", year: "numeric" })}`
+    : "all time";
+
+  while (true) {
+    syncProgress.value = {
+      ...syncProgress.value,
+      phase: "list",
+      message: `Fetching rides ${windowLabel} (page ${page})...`,
+    };
+
+    const result = await fetchActivityListPage(page, { cutoffEpoch });
+
+    if (result.summaries.length > 0) {
+      totalFetched += result.summaries.length;
+
+      if (result.newestDate && (!lastActivityDate || result.newestDate > lastActivityDate)) {
+        lastActivityDate = result.newestDate;
+      }
+
+      syncProgress.value = {
+        ...syncProgress.value,
+        fetched: totalFetched,
+        message: `Fetched ${totalFetched} rides. Loading details...`,
+      };
+
+      await updateSyncState({
+        backfill_page: page + 1,
+        fetched_activities: (await getSyncState()).fetched_activities + result.summaries.length,
+        last_activity_fetch: lastActivityDate,
+      });
+
+      await fetchActivityDetails();
+      if (onProgress) onProgress();
+    }
+
+    if (!result.hasMore) return true; // completed
+
+    if (isRateLimited()) {
+      syncProgress.value = {
+        ...syncProgress.value,
+        message: `Rate limit approaching — pausing after ${totalFetched} rides.`,
+      };
+      return false; // interrupted
+    }
+
+    page++;
+  }
+}
+
+/**
+ * Start full backfill — two-phase approach for API rate limit efficiency.
+ *
+ * Phase 1: Fetch the last 13 months of cycling activities. This gives users
+ * a full year of segment history quickly (enough for year-best, season-first,
+ * median/quartile awards).
+ *
+ * Phase 2: Once the 13-month window is complete, extend backfill to the full
+ * sync window (default 5 years, configurable in settings).
+ *
+ * Only cycling activities are synced (Ride, VirtualRide, MountainBikeRide, etc.).
+ * Resumable: checks sync_state on restart.
+ *
  * @param {Function} [onProgress] - called after each page+detail cycle so the UI can refresh
  */
 export async function startBackfill(onProgress) {
@@ -478,82 +566,54 @@ export async function startBackfill(onProgress) {
       await runHeartRateMigration();
       await fetchActivityDetails();
     } else {
-      // Interleaved backfill: fetch page → detail → fetch page → detail
-      let page = state.backfill_page || 1;
-      let lastActivityDate = state.last_activity_fetch;
-      let totalFetched = 0;
-
-      // Apply sync window cutoff (#111) — used as client-side filter (not Strava `after` param)
-      // so that Strava returns newest activities first. Default to 3 years on first backfill.
-      let syncAfterEpoch = state.sync_after_epoch;
-      if (syncAfterEpoch === null && page === 1) {
-        syncAfterEpoch = Math.floor(Date.now() / 1000 - 3 * 365.25 * 24 * 3600);
-        await updateSyncState({ sync_after_epoch: syncAfterEpoch });
+      // Set full sync window default if not yet chosen by user
+      if (state.sync_after_epoch === null && !state.initial_backfill_complete) {
+        const defaultEpoch = Math.floor(Date.now() / 1000 - DEFAULT_SYNC_WINDOW_YEARS * 365.25 * 24 * 3600);
+        await updateSyncState({ sync_after_epoch: defaultEpoch });
       }
 
-      // Show sync window in progress messages
-      const windowLabel = syncAfterEpoch
-        ? `since ${new Date(syncAfterEpoch * 1000).toLocaleDateString("en-US", { month: "short", year: "numeric" })}`
-        : "all time";
+      const fullSyncEpoch = (await getSyncState()).sync_after_epoch;
 
-      while (true) {
-        // Fetch one page of activity summaries
-        syncProgress.value = {
-          ...syncProgress.value,
-          phase: "list",
-          message: `Fetching activities ${windowLabel} (page ${page})...`,
-        };
+      // --- Phase 1: 13-month priority window ---
+      if (!state.initial_backfill_complete) {
+        const initialCutoff = Math.floor(Date.now() / 1000 - INITIAL_WINDOW_SECONDS);
+        // Use the later of (13-month cutoff, full sync window) so we don't
+        // exceed the user's chosen window if it's shorter than 13 months
+        const phase1Cutoff = fullSyncEpoch ? Math.max(initialCutoff, fullSyncEpoch) : initialCutoff;
 
-        const result = await fetchActivityListPage(page, { cutoffEpoch: syncAfterEpoch });
+        const page = state.backfill_page || 1;
+        const completed = await runBackfillPass(phase1Cutoff, page, onProgress);
 
-        if (result.summaries.length === 0) break;
+        if (completed && !isRateLimited()) {
+          await updateSyncState({ initial_backfill_complete: true, backfill_page: 1 });
 
-        totalFetched += result.summaries.length;
-
-        // Track newest activity date
-        if (result.newestDate && (!lastActivityDate || result.newestDate > lastActivityDate)) {
-          lastActivityDate = result.newestDate;
+          // If the full window is the same as phase 1, skip phase 2
+          if (fullSyncEpoch && fullSyncEpoch >= phase1Cutoff) {
+            await updateSyncState({ backfill_complete: true });
+          }
         }
-
-        syncProgress.value = {
-          ...syncProgress.value,
-          fetched: totalFetched,
-          message: `Fetched ${totalFetched} activities. Loading details...`,
-        };
-
-        // Save progress so we can resume if interrupted
-        await updateSyncState({
-          backfill_page: page + 1,
-          fetched_activities: (await getSyncState()).fetched_activities + result.summaries.length,
-          last_activity_fetch: lastActivityDate,
-        });
-
-        // Detail-fetch everything pending (includes this page + any prior)
-        await fetchActivityDetails();
-
-        // Notify UI so dashboard refreshes with newly synced activities
-        if (onProgress) onProgress();
-
-        if (!result.hasMore) break;
-
-        // Check rate limit before continuing to next page
-        if (isRateLimited()) {
-          syncProgress.value = {
-            ...syncProgress.value,
-            message: `Rate limit approaching — pausing after ${totalFetched} activities.`,
-          };
-          break;
-        }
-
-        page++;
       }
 
-      // If we got through all pages without being rate-limited, mark complete
-      if (!isRateLimited()) {
-        await updateSyncState({ backfill_complete: true });
+      // --- Phase 2: Full sync window (historical backfill) ---
+      const refreshedState = await getSyncState();
+      if (refreshedState.initial_backfill_complete && !refreshedState.backfill_complete && !isRateLimited()) {
+        syncProgress.value = {
+          ...syncProgress.value,
+          message: "Expanding to full history...",
+        };
+
+        const page = refreshedState.backfill_page || 1;
+        const completed = await runBackfillPass(fullSyncEpoch, page, onProgress);
+
+        if (completed && !isRateLimited()) {
+          await updateSyncState({ backfill_complete: true });
+        }
+      }
+
+      // Run migrations after full backfill completes
+      if ((await getSyncState()).backfill_complete && !isRateLimited()) {
         await runPowerMigration();
         await runHeartRateMigration();
-        // Final detail pass for any remaining from migration
         await fetchActivityDetails();
       }
     }
@@ -561,10 +621,16 @@ export async function startBackfill(onProgress) {
     const remaining = await getActivitiesWithoutEfforts();
 
     if (remaining.length === 0) {
+      const s = await getSyncState();
+      const phaseMsg = s.backfill_complete
+        ? "Sync complete!"
+        : s.initial_backfill_complete
+          ? "Recent history synced! Historical backfill continues in background."
+          : "Sync paused.";
       syncProgress.value = {
         ...syncProgress.value,
         phase: "done",
-        message: "Backfill complete!",
+        message: phaseMsg,
       };
       await updateSyncState({ last_sync: new Date().toISOString() });
     } else {


### PR DESCRIPTION
Two-phase backfill: fetch last 13 months first for quick results, then
expand to full sync window (default 5 years, was 3). Only cycling sport
types are synced (Ride, VirtualRide, MountainBikeRide, GravelRide,
EBikeRide, etc.) — non-cycling activities like walks and runs are
filtered out during list fetch.

New first-sync prompt asks users how far back to sync before starting.
Sync window presets updated from 2y/3y/4y to 2y/3y/5y. FAQ updated to
explain cycling-only filtering and two-phase approach.

https://claude.ai/code/session_01YPMU4fu8j6cUWaouKdCQh3