### PR TITLE
Fix chart tooltip overlapping data points

### DIFF
--- a/src/components/SegmentSparkline.js
+++ b/src/components/SegmentSparkline.js
@@ -138,11 +138,15 @@ export function SegmentSparkline({ segment, currentEffortId }) {
   // Tooltip positioning: show above the point, centered horizontally
   const tooltipW = 110;
   const tooltipH = 28;
+  const pointR = 5;
+  const tooltipGap = 4;
   const tooltipX = active ? Math.max(2, Math.min(active.x - tooltipW / 2, w - tooltipW - 2)) : 0;
-  const tooltipY = active ? Math.max(2, active.y - tooltipH - 8) : 0;
-  // If tooltip would overlap point from above, flip below
-  const flipBelow = active && tooltipY < 2;
-  const finalTooltipY = flipBelow && active ? active.y + 10 : tooltipY;
+  const aboveY = active ? Math.max(2, active.y - tooltipH - pointR - tooltipGap) : 0;
+  // Flip below if tooltip above would overlap the point
+  const overlapAbove = active && (aboveY + tooltipH + tooltipGap > active.y - pointR);
+  const belowY = active ? active.y + pointR + tooltipGap : 0;
+  const fitsBelow = active && (belowY + tooltipH <= h - 2);
+  const finalTooltipY = (overlapAbove && fitsBelow) ? belowY : aboveY;
 
   return html`
     <div style="margin-top: 6px;">


### PR DESCRIPTION
## Summary
- Fix sparkline tooltip overlapping data points when they're near the top of the chart
- The old flip-below logic only checked if the tooltip went off-screen (`y < 2`), but after clamping the tooltip could still sit directly on top of the point
- New logic checks whether the clamped tooltip actually overlaps the point circle (using its radius + a gap constant) and flips below when it does, only if there's room below

## Test plan
- [ ] Open ActivityDetail for an activity with segment efforts
- [ ] Touch/hover data points near the top of the sparkline chart
- [ ] Verify tooltip appears below the point with clearance instead of overlapping it
- [ ] Verify points in the middle/bottom of chart still show tooltip above as before
- [ ] Test on mobile (touch) and desktop (hover)

https://claude.ai/code/session_01579duQGbQvb32FGjkWRhZ8