### PR TITLE
Show heart rate in segment effort details

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -612,6 +612,7 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
 
   const metaParts = [formatDistance(effort.segment.distance), `${effort.segment.average_grade}% grade`, formatTime(effort.elapsed_time)];
   if (effort.device_watts && effort.average_watts) metaParts.push(formatPower(effort.average_watts));
+  if (effort.average_heartrate) metaParts.push(`${Math.round(effort.average_heartrate)} bpm`);
   tmpCtx.font = '400 30px "IBM Plex Mono", monospace';
   const metaText = metaParts.join("  ·  ");
   const metaLines = wrapText(tmpCtx, metaText, maxTextW);
@@ -1363,6 +1364,9 @@ export function ActivityDetail({ id }) {
               const effortPower = effort.device_watts && effort.average_watts
                 ? formatPower(effort.average_watts)
                 : null;
+              const effortHR = effort.average_heartrate
+                ? `${Math.round(effort.average_heartrate)} bpm`
+                : null;
               const hasAwards = segAwards.length > 0;
 
               return html`
@@ -1381,6 +1385,7 @@ export function ActivityDetail({ id }) {
                     · ${effort.segment.average_grade}% grade
                     · ${formatTime(effort.elapsed_time)}
                     ${effortPower ? ` · ${effortPower}` : ""}
+                    ${effortHR ? ` · ${effortHR}` : ""}
                     ${effortCount > 1 ? ` · ${effortCount} efforts` : ""}
                   </div>
                   ${effort.pr_rank && html`

--- a/src/components/_MAP.md
+++ b/src/components/_MAP.md
@@ -5,7 +5,7 @@
 
 ### ActivityDetail.js
 > Imports: `preact, signals, hooks, db.js, awards.js`...
-- **ActivityDetail** (f) `({ id })` :1047
+- **ActivityDetail** (f) `({ id })` :1048
 
 ### Dashboard.js
 > Imports: `preact, signals, hooks, auth.js, sync.js`...


### PR DESCRIPTION
Display average heart rate (bpm) in segment effort cards and share
cards, matching the existing pattern for power display.

https://claude.ai/code/session_01BLZGUveVAUKqWPwZn94s8n