### PR TITLE
Add aeyu FAQ, wordmark tooltip, fix tooltip persistence

### DIFF
--- a/src/_MAP.md
+++ b/src/_MAP.md
@@ -133,7 +133,7 @@
 - **resyncActivity** (f) `(activityId)` :858
 
 ### touch-tooltip.js
-- **initTouchTooltips** (f) `()` :64
+- **initTouchTooltips** (f) `()` :62
 
 ### units.js
 > Imports: `signals, db.js`

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -71,6 +71,7 @@ const referencePoints = signal([]);
 const showRefForm = signal(false);
 const refType = signal("since_date");
 const pendingCount = signal(0);
+const steepestClimbName = signal(null);
 const refLabel = signal("");
 const refDate = signal("");
 const refCount = signal("10");
@@ -83,6 +84,16 @@ const syncWindowCustomDate = signal("");
 const currentSyncAfterEpoch = signal(null);
 const showFirstSyncPrompt = signal(false);
 const firstSyncChoice = signal("5y");
+
+function pickSteepestClimb(segments) {
+  let best = null;
+  for (const seg of segments) {
+    if ((seg.average_grade || 0) >= 5 && (!best || seg.average_grade > best.average_grade)) {
+      best = seg;
+    }
+  }
+  steepestClimbName.value = best ? best.name : null;
+}
 
 async function loadDashboard() {
   loading.value = true;
@@ -152,10 +163,12 @@ async function loadDashboard() {
       }
       const segments = await getAllSegments();
       stats.value = { segments: segments.length, awards: totalAwards };
+      pickSteepestClimb(segments);
     } else {
       activityAwards.value = new Map();
       const segments = await getAllSegments();
       stats.value = { segments: segments.length, awards: 0 };
+      pickSteepestClimb(segments);
     }
 
     // Compute form indicators (#106)
@@ -1109,6 +1122,17 @@ export function Dashboard() {
                 </summary>
                 <div class="pt-3 pb-1" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
                   The app uses a service worker to work offline, which can sometimes serve cached files after an update. Go to Settings and tap "Clear cached code and reload" to force a fresh download. This only clears app code — your activity data is not affected.
+                </div>
+              </details>
+
+              <details class="group py-3">
+                <summary class="flex items-center justify-between cursor-pointer" style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: var(--text);">
+                  What does "aeyu" mean?
+                  <svg class="w-4 h-4 group-open:rotate-180 transition-transform flex-shrink-0 ml-2" style="color: var(--text-tertiary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                </summary>
+                <div class="pt-3 pb-1 space-y-2" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
+                  <p>It's the sound you make at the top of ${steepestClimbName.value ? steepestClimbName.value : "the climb"}.</p>
+                  <p>Really though, it was a URL that was short and available. The letters are the vowels from left to right on the keyboard — which is how you'll remember it.</p>
                 </div>
               </details>
             </div>

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -279,6 +279,17 @@ export function Landing() {
               effort recognized.
             </p>
           <//>
+
+          <${FaqItem} q="What does 'aeyu' mean?">
+            <p class="mb-2">
+              It's the sound you make at the top of the climb.
+            </p>
+            <p>
+              Really though, it was a URL that was short and available. The
+              letters are the vowels from left to right on the keyboard —
+              which is how you'll remember it.
+            </p>
+          <//>
         </div>
       </div>
     </div>

--- a/src/components/StickyHeader.js
+++ b/src/components/StickyHeader.js
@@ -78,7 +78,7 @@ export function StickyHeader({
             <img src="icons/icon-192.png" alt="aeyu.io" style="height: 44px; width: 44px; border-radius: 8px;" />
           `}
           <div>
-            <h1 style="font-family: var(--font-display); font-size: 1.75rem; color: var(--text-on-dark); line-height: 1.1; white-space: nowrap;">
+            <h1 style="font-family: var(--font-display); font-size: 1.75rem; color: var(--text-on-dark); line-height: 1.1; white-space: nowrap;" title="The sound you make at the top of the climb">
               aeyu<span style="color: var(--accent);">.io</span>
             </h1>
             <p style="font-family: var(--font-body); font-size: 0.7rem; color: rgba(255,255,255,0.6); letter-spacing: 0.04em; margin-top: 1px;">
@@ -169,7 +169,7 @@ export function StickyHeader({
           ` : html`
             <img src="icons/icon-192.png" alt="aeyu.io" style="height: 24px; width: 24px; border-radius: 4px;" />
           `}
-          <span style="font-family: var(--font-display); font-size: 1rem; color: var(--text-on-dark); white-space: nowrap;">
+          <span style="font-family: var(--font-display); font-size: 1rem; color: var(--text-on-dark); white-space: nowrap;" title=${onBack && contextLabel ? null : "The sound you make at the top of the climb"}>
             ${onBack && contextLabel ? contextLabel : "aeyu.io"}
           </span>
           ${syncing && !onBack && html`

--- a/src/components/_MAP.md
+++ b/src/components/_MAP.md
@@ -9,7 +9,7 @@
 
 ### Dashboard.js
 > Imports: `preact, signals, hooks, auth.js, sync.js`...
-- **Dashboard** (f) `()` :172
+- **Dashboard** (f) `()` :185
 
 ### InstallBanner.js
 > Imports: `preact, install.js`

--- a/src/touch-tooltip.js
+++ b/src/touch-tooltip.js
@@ -42,8 +42,6 @@ function show(text, x, y) {
   overlay.style.top = top + "px";
   // Fade in
   requestAnimationFrame(() => { if (overlay) overlay.style.opacity = "1"; });
-  // Auto-dismiss after 3s
-  setTimeout(dismiss, 3000);
 }
 
 function dismiss() {
@@ -66,6 +64,7 @@ export function initTouchTooltips() {
 
   document.addEventListener("touchstart", (e) => {
     cancel();
+    dismiss();
     const touch = e.touches[0];
     startX = touch.clientX;
     startY = touch.clientY;


### PR DESCRIPTION
## Summary
- Add "What does 'aeyu' mean?" FAQ entry to both Landing.js and Dashboard.js — "the sound you make at the top of the climb" + the real story (short URL, vowels left-to-right on keyboard)
- Easter egg: in the Dashboard FAQ, "the climb" is dynamically replaced with the user's steepest segment name (>=5% avg grade) when they have segment data
- Add tooltip on the aeyu.io wordmark in both full and compact sticky headers
- Fix touch tooltips: removed 3-second auto-dismiss so tooltips persist until the user taps elsewhere

## Test plan
- [ ] Verify Landing.js FAQ shows the new "What does aeyu mean?" entry
- [ ] Verify Dashboard FAQ shows the entry, with segment name substitution when segments exist
- [ ] Hover/long-press the aeyu.io wordmark to see the tooltip
- [ ] Long-press an award pill on mobile — confirm tooltip stays visible until you tap away
- [ ] Test demo mode to verify segment name easter egg works with demo data

https://claude.ai/code/session_01PDAwSCcMfpB8Y3sLfgWsGL