### PR TITLE
Fix scroll broken after long-press tooltip

### DIFF
--- a/src/touch-tooltip.js
+++ b/src/touch-tooltip.js
@@ -46,8 +46,10 @@ function show(text, x, y) {
 
 function dismiss() {
   if (overlay) {
-    overlay.remove();
+    const el = overlay;
     overlay = null;
+    el.style.opacity = "0";
+    setTimeout(() => el.remove(), 200);
   }
 }
 
@@ -89,6 +91,7 @@ export function initTouchTooltips() {
 
   document.addEventListener("touchend", () => {
     cancel();
+    if (overlay) setTimeout(dismiss, 1500);
     setTimeout(() => { suppressContextMenu = false; }, 50);
   }, { passive: true });
 


### PR DESCRIPTION
## Summary
- **Defer DOM removal in `dismiss()`**: Instead of synchronously removing the tooltip element during `touchstart`, fade it out first then remove after 200ms. Synchronous removal of a `position:fixed` element during a touch event handler was causing mobile browsers to cancel the touch gesture, breaking scroll.
- **Auto-dismiss tooltip after touchend**: Tooltip now fades out 1.5s after the finger lifts, preventing it from lingering as a fixed-position overlay that interferes with subsequent touch interactions.

## Test plan
- [ ] On a touch device, long-press an award pill to show tooltip
- [ ] Lift finger — tooltip should remain visible briefly then fade out after ~1.5s
- [ ] Immediately after lifting finger, try scrolling — should work normally
- [ ] Tap elsewhere while tooltip is visible — should dismiss immediately
- [ ] Verify tooltip still shows correctly on long-press (position, content, fade-in)

https://claude.ai/code/session_015SdFji3vpgRD3pPbQfC1sy