### PR TITLE
Add speed to ride summary and share card

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -134,6 +134,7 @@ function buildSummary(act, awardsList) {
   const lines = [];
   lines.push(act.name);
   let meta = `${formatDateShort(act.start_date_local)} · ${formatDistance(act.distance)} · ${formatTime(act.moving_time)}`;
+  if (act.average_speed) meta += ` · ${formatSpeed(act.average_speed)}`;
   if (act.total_elevation_gain) meta += ` · ${formatElevation(act.total_elevation_gain)}`;
   if (act.device_watts && act.average_watts) meta += ` · ${formatPower(act.average_watts)}`;
   lines.push(meta);
@@ -219,6 +220,7 @@ async function renderShareCard(canvas, act, awardsList) {
   const nameLines = wrapText(tmpCtx, act.name, maxTextW);
 
   const metaParts = [formatDateShort(act.start_date_local), formatDistance(act.distance), formatTime(act.moving_time)];
+  if (act.average_speed) metaParts.push(formatSpeed(act.average_speed));
   if (act.total_elevation_gain) metaParts.push(formatElevation(act.total_elevation_gain));
   if (act.device_watts && act.average_watts) metaParts.push(formatPower(act.average_watts));
   tmpCtx.font = '400 34px "IBM Plex Mono", monospace';
@@ -1227,6 +1229,7 @@ export function ActivityDetail({ id }) {
             ${formatDateFull(act.start_date_local)}
             · ${formatDistance(act.distance)}
             · ${formatTime(act.moving_time)}
+            ${act.average_speed ? ` · ${formatSpeed(act.average_speed)}` : ""}
             ${act.total_elevation_gain ? ` · ${formatElevation(act.total_elevation_gain)} elevation` : ""}
             ${ridePower ? ` · ${ridePower} avg` : ""}
           </p>


### PR DESCRIPTION
## Summary

- PR #170 added speed display to segment efforts but missed three ride-level locations
- Adds `formatSpeed(act.average_speed)` to the text summary (copy-to-clipboard), Canvas share card, and HTML activity header
- Speed appears after time and before elevation, consistent with segment effort ordering

## Test plan

- [ ] Open an activity detail page and verify speed shows in the header stats line
- [ ] Copy the text summary and verify speed is included
- [ ] Generate a share card and verify speed appears in the meta line
- [ ] Confirm activities without `average_speed` don't show a broken entry

https://claude.ai/code/session_01NEDMfinNJQSgEDeg8nVfCv