### PR TITLE
Wire up power curve: sync integration + Dashboard display

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -49,6 +49,7 @@ import { isDemo, exitDemo, startDemo } from "../demo.js";
 import { renderIconSVG } from "../icons.js";
 import { AWARD_LABELS } from "../award-config.js";
 import { computeFitnessSummary } from "../fitness.js";
+import { getAllTimeBestCurve, estimateFTP, POWER_CURVE_DURATIONS, DURATION_LABELS } from "../power-curve.js";
 import { StickyHeader, headerCompact } from "./StickyHeader.js";
 
 const recentActivities = signal([]);
@@ -79,6 +80,7 @@ const refBirthday = signal("");
 const refAge = signal("40");
 const streakData = signal(null);
 const fitnessData = signal(null);
+const powerCurveData = signal(null);
 const syncWindowChoice = signal("5y"); // "2y" | "3y" | "5y" | "all" | "custom"
 const syncWindowCustomDate = signal("");
 const currentSyncAfterEpoch = signal(null);
@@ -104,6 +106,7 @@ async function loadDashboard() {
   stats.value = { segments: 0, awards: 0 };
   streakData.value = null;
   fitnessData.value = null;
+  powerCurveData.value = null;
   backfillComplete.value = false;
   pendingCount.value = 0;
   try {
@@ -176,6 +179,16 @@ async function loadDashboard() {
       fitnessData.value = await computeFitnessSummary();
     } catch (e) {
       console.warn("Fitness computation failed:", e);
+    }
+
+    // Load power curve data
+    try {
+      const bestCurve = await getAllTimeBestCurve();
+      if (Object.keys(bestCurve).length > 0) {
+        powerCurveData.value = { curve: bestCurve, ftp: estimateFTP(bestCurve) };
+      }
+    } catch (e) {
+      console.warn("Power curve computation failed:", e);
     }
   } finally {
     loading.value = false;
@@ -673,6 +686,41 @@ export function Dashboard() {
                 </span>
               </div>
             `}
+          </div>
+        `}
+
+        <!-- Power Curve -->
+        ${!loading.value && powerCurveData.value && html`
+          <div class="mb-6 rounded-xl p-5" style="background: var(--surface); border: 1px solid var(--border);">
+            <div class="flex items-center justify-between mb-3">
+              <h2 class="group relative inline-block cursor-help" style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text); margin: 0;">Power Curve
+                <span class="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 top-full mt-2 text-white text-xs rounded px-3 py-2 z-10" style="background: var(--text); font-family: var(--font-body); font-weight: 400; white-space: normal; width: 220px; text-align: center;">All-time best average power at each standard duration from your power meter data</span>
+              </h2>
+              ${powerCurveData.value.ftp && html`
+                <div class="flex items-center gap-1.5" title="Estimated FTP: 95% of 20-min best power">
+                  <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">est. FTP</span>
+                  <span style="font-family: var(--font-display); font-size: 1.25rem; color: var(--text);">${powerCurveData.value.ftp}</span>
+                  <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">W</span>
+                </div>
+              `}
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 6px;">
+              ${POWER_CURVE_DURATIONS.filter((dur) => powerCurveData.value.curve[dur]).map((dur) => {
+                const watts = powerCurveData.value.curve[dur];
+                const maxWatts = Math.max(...POWER_CURVE_DURATIONS.map((d) => powerCurveData.value.curve[d] || 0));
+                const pct = maxWatts > 0 ? Math.round((watts / maxWatts) * 100) : 0;
+                const labels = { 5: "Sprint", 30: "30s", 60: "1 min", 300: "VO\u2082max", 1200: "FTP", 3600: "60 min" };
+                return html`
+                  <div style="display: flex; align-items: center; gap: 6px;" title="${DURATION_LABELS[dur]} best: ${watts}W">
+                    <span style="font-size: 0.6875rem; color: var(--text-secondary); width: 52px; flex-shrink: 0; text-align: right;">${labels[dur]}</span>
+                    <div style="flex: 1; height: 14px; background: var(--border); border-radius: 3px; overflow: hidden;">
+                      <div style="height: 100%; width: ${pct}%; background: #4882A8; border-radius: 3px; transition: width 0.3s;"></div>
+                    </div>
+                    <span style="font-family: var(--font-mono); font-size: 0.6875rem; color: var(--text); min-width: 2.5rem; text-align: right;">${watts}W</span>
+                  </div>
+                `;
+              })}
+            </div>
           </div>
         `}
 

--- a/src/power-curve.js
+++ b/src/power-curve.js
@@ -1,8 +1,8 @@
 /**
- * Power Curve — Stream fetching and duration-based power bests (#48)
+ * Power Curve — duration-based power bests (#48)
  *
- * Fetches second-by-second power data via the Strava Streams API and computes
- * best average power over standard durations (the "power curve").
+ * Computes best average power over standard durations (the "power curve")
+ * from per-second power data fetched by the sync engine.
  *
  * Standard durations:
  *   5s   — peak sprint
@@ -16,10 +16,7 @@
  * Only available for activities with device_watts === true.
  */
 
-import { STRAVA_API_BASE } from "./config.js";
-import { getValidToken } from "./auth.js";
-import { getActivity, putActivity, getAllActivities } from "./db.js";
-import { signal } from "@preact/signals";
+import { getAllActivities } from "./db.js";
 
 /** Standard power curve durations in seconds */
 export const POWER_CURVE_DURATIONS = [5, 30, 60, 300, 1200, 3600];
@@ -34,19 +31,8 @@ export const DURATION_LABELS = {
   3600: "60min",
 };
 
-/** Sync progress for power curve fetching */
-export const powerCurveProgress = signal({
-  phase: "idle", // idle | fetching | done | error
-  current: 0,
-  total: 0,
-  message: "",
-});
-
 /**
  * Compute best average power for each standard duration using a sliding window.
- * Returns { 5: number, 30: number, 60: number, 300: number, 1200: number, 3600: number }
- * or null if watts array is too short for any computation.
- *
  * @param {number[]} watts — Per-second power values
  * @returns {Object|null} Power curve bests
  */
@@ -54,7 +40,6 @@ export function computePowerCurve(watts) {
   if (!watts || watts.length < 5) return null;
 
   const curve = {};
-  // Build prefix sum for efficient sliding window
   const prefixSum = new Float64Array(watts.length + 1);
   for (let i = 0; i < watts.length; i++) {
     prefixSum[i + 1] = prefixSum[i] + watts[i];
@@ -81,97 +66,6 @@ export function computePowerCurve(watts) {
 export function estimateFTP(powerCurve) {
   if (!powerCurve || !powerCurve[1200]) return null;
   return Math.round(powerCurve[1200] * 0.95);
-}
-
-/**
- * Fetch power stream for a single activity from Strava API.
- * Returns array of per-second watts, or null if unavailable.
- *
- * @param {number} activityId — Strava activity ID
- * @returns {number[]|null} Watts array
- */
-async function fetchPowerStream(activityId) {
-  const token = await getValidToken();
-  const url = `${STRAVA_API_BASE}/activities/${activityId}/streams?keys=watts,time&key_by_type=true`;
-  const response = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-
-  if (response.status === 404 || response.status === 403) {
-    // No streams available for this activity
-    return null;
-  }
-
-  if (response.status === 429) {
-    const retryAfter = parseInt(response.headers.get("Retry-After") || "900");
-    throw new RateLimitError(retryAfter);
-  }
-
-  if (!response.ok) {
-    throw new Error(`Strava Streams API error: ${response.status}`);
-  }
-
-  const data = await response.json();
-
-  // Streams API returns { watts: { data: [...] }, time: { data: [...] } }
-  if (!data.watts || !data.watts.data) return null;
-
-  return data.watts.data;
-}
-
-class RateLimitError extends Error {
-  constructor(retryAfter) {
-    super(`Rate limited. Retry after ${retryAfter}s`);
-    this.retryAfter = retryAfter;
-  }
-}
-
-/**
- * Fetch power stream and compute power curve for a single activity.
- * Stores the result on the activity object in IndexedDB.
- * No-ops if the activity already has a power_curve or lacks device_watts.
- *
- * @param {number} activityId — Activity ID
- * @returns {Object|null} Power curve, or null if unavailable
- */
-export async function fetchAndComputePowerCurve(activityId) {
-  const activity = await getActivity(activityId);
-  if (!activity) return null;
-
-  // Already computed
-  if (activity.power_curve !== undefined) return activity.power_curve;
-
-  // No power meter
-  if (!activity.device_watts) {
-    await putActivity({ ...activity, power_curve: null });
-    return null;
-  }
-
-  try {
-    const watts = await fetchPowerStream(activityId);
-    const curve = watts ? computePowerCurve(watts) : null;
-    await putActivity({ ...activity, power_curve: curve });
-    return curve;
-  } catch (err) {
-    if (err instanceof RateLimitError) throw err;
-    console.warn(`Failed to fetch power stream for activity ${activityId}:`, err);
-    // Mark as attempted but failed — store null so we don't retry
-    await putActivity({ ...activity, power_curve: null });
-    return null;
-  }
-}
-
-/**
- * Get all activities that need power curve computation.
- * These are activities with device_watts === true but no power_curve field.
- *
- * @returns {Array} Activities needing power curves
- */
-export async function getActivitiesNeedingPowerCurves() {
-  const all = await getAllActivities();
-  return all.filter(
-    (a) => a.device_watts && a.has_efforts && !("power_curve" in a)
-  );
 }
 
 /**

--- a/src/sync.js
+++ b/src/sync.js
@@ -10,6 +10,7 @@ import {
   putActivities,
   putActivity,
   getActivity,
+  getAllActivities,
   getActivitiesWithoutEfforts,
   getActivitiesWithoutPower,
   getActivitiesWithoutHeartRate,
@@ -18,6 +19,7 @@ import {
   appendEffort,
   removeEffortsForActivity,
 } from "./db.js";
+import { computePowerCurve } from "./power-curve.js";
 
 // --- Signals ---
 
@@ -397,6 +399,59 @@ async function fetchActivityDetails() {
   return detailed;
 }
 
+// --- Power Curve Fetching ---
+
+async function fetchPowerCurves() {
+  const all = await getAllActivities();
+  const pending = all.filter(
+    (a) => a.device_watts && a.has_efforts && !("power_curve" in a)
+  );
+  if (pending.length === 0) return;
+
+  syncProgress.value = {
+    ...syncProgress.value,
+    phase: "detail",
+    message: `Fetching power curves: 0/${pending.length}`,
+  };
+
+  let completed = 0;
+
+  for (const activity of pending) {
+    if (isRateLimited()) {
+      syncProgress.value = {
+        ...syncProgress.value,
+        message: `Power curves paused (rate limit) — ${completed}/${pending.length} done.`,
+      };
+      break;
+    }
+
+    try {
+      const data = await stravaFetch(
+        `/activities/${activity.id}/streams?keys=watts,time&key_by_type=true`
+      );
+      const watts = data.watts && data.watts.data ? data.watts.data : null;
+      const curve = watts ? computePowerCurve(watts) : null;
+      await putActivity({ ...activity, power_curve: curve });
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        syncProgress.value = {
+          ...syncProgress.value,
+          message: `Power curves paused (rate limit) — ${completed}/${pending.length} done.`,
+        };
+        break;
+      }
+      // 404/403 means no streams available — mark as null so we don't retry
+      await putActivity({ ...activity, power_curve: null });
+    }
+
+    completed++;
+    syncProgress.value = {
+      ...syncProgress.value,
+      message: `Fetching power curves: ${completed}/${pending.length}`,
+    };
+  }
+}
+
 // --- Phase 3: Power Fields Migration ---
 
 /**
@@ -569,6 +624,7 @@ export async function startBackfill(onProgress) {
       await runPowerMigration();
       await runHeartRateMigration();
       await fetchActivityDetails();
+      if (!isRateLimited()) await fetchPowerCurves();
     } else {
       // Set full sync window default if not yet chosen by user
       if (state.sync_after_epoch === null && !state.initial_backfill_complete) {
@@ -619,6 +675,7 @@ export async function startBackfill(onProgress) {
         await runPowerMigration();
         await runHeartRateMigration();
         await fetchActivityDetails();
+        if (!isRateLimited()) await fetchPowerCurves();
       }
     }
 
@@ -695,6 +752,9 @@ export async function incrementalSync() {
       };
       await fetchActivityDetails();
     }
+
+    // Fetch power curves for activities with power meters
+    if (!isRateLimited()) await fetchPowerCurves();
 
     const stillPending = await getActivitiesWithoutEfforts();
     syncProgress.value = {


### PR DESCRIPTION
power-curve.js was fully implemented but never imported anywhere —
the sync never fetched power streams and no UI displayed the data.

- sync.js: Add fetchPowerCurves() phase that fetches Strava Streams API
  for activities with device_watts, computes power curve via sliding
  window, stores on activity. Runs after detail fetch in both backfill
  and incremental sync, respects rate limits.
- power-curve.js: Remove orphaned fetch/signal code (now handled by
  sync.js), keep pure computation functions (computePowerCurve,
  estimateFTP, getAllTimeBestCurve).
- Dashboard.js: Add Power Curve card showing all-time bests at each
  standard duration as horizontal bars, with estimated FTP display.
  Loads data alongside fitness indicators.

https://claude.ai/code/session_01VjGVqhUUq61E88Dp1b5h5v