### PR TITLE
Fix poisoned power_curve:null entries never retried

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -406,7 +406,7 @@ async function fetchActivityDetails() {
 async function fetchPowerCurves() {
   const all = await getAllActivities();
   const pending = all.filter(
-    (a) => a.device_watts && a.has_efforts && !("power_curve" in a)
+    (a) => a.device_watts && a.has_efforts && a.power_curve !== false && !a.power_curve
   );
   if (pending.length === 0) return;
 
@@ -433,7 +433,8 @@ async function fetchPowerCurves() {
       );
       const watts = data.watts && data.watts.data ? data.watts.data : null;
       const curve = watts ? computePowerCurve(watts) : null;
-      await putActivity({ ...activity, power_curve: curve });
+      // Use false for permanent "no data" (streams exist but no watts), truthy curve for success
+      await putActivity({ ...activity, power_curve: curve || false });
     } catch (err) {
       if (err instanceof RateLimitError) {
         syncProgress.value = {
@@ -443,8 +444,9 @@ async function fetchPowerCurves() {
         break;
       }
       if (err.status === 404 || err.status === 403) {
-        // No streams available for this activity — mark permanently
-        await putActivity({ ...activity, power_curve: null });
+        // No streams available for this activity — mark permanently with false
+        // (null is reserved for retryable/legacy entries)
+        await putActivity({ ...activity, power_curve: false });
       } else {
         // Transient error (network, 500, etc.) — skip but leave for retry
         console.warn(`Power curve fetch failed for activity ${activity.id}:`, err.message);


### PR DESCRIPTION
## Summary

PR#173 introduced power curve fetching with a catch-all that marked **all** errors as `power_curve: null`. PR#174 fixed the error handling for future fetches, but activities already poisoned with `null` were permanently stuck — the `in` operator in `!("power_curve" in a)` returns `true` for `null` values, so they were never retried.

**Fix:** Use `false` as the permanent "no streams" sentinel (404/403), and switch the filter to truthiness-based so `null` entries from the old code get retried:
- `false` → permanent failure (404/403 or no watts data), never retried
- `null` → legacy/poisoned data, **retried** on next sync
- `undefined` → never attempted, picked up for first fetch
- `{5: 300, ...}` → valid curve, skipped

## Test plan
- [ ] After deploy, trigger sync and verify Power Curve section appears
- [ ] Check console for `Power curve fetch failed` warnings (transient errors being retried)
- [ ] Confirm activities without streams (404) get `false` and aren't retried indefinitely

https://claude.ai/code/session_01EiTzB7NPfUeuxVuYE1RonL