### PR TITLE
Fix: display average speed on activity cards in Dashboard

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -43,6 +43,7 @@ import {
   formatTime,
   formatDateWeekday,
   formatElevation,
+  formatSpeed,
   formatPower,
 } from "../units.js";
 import { isDemo, exitDemo, startDemo } from "../demo.js";
@@ -800,6 +801,7 @@ export function Dashboard() {
                     ${formatDateWeekday(activity.start_date_local)}
                     · ${formatDistance(activity.distance)}
                     · ${formatTime(activity.moving_time)}
+                    ${activity.average_speed ? ` · ${formatSpeed(activity.average_speed)}` : ""}
                     ${activity.total_elevation_gain ? ` · ${formatElevation(activity.total_elevation_gain)}` : ""}
                     ${powerLabel ? ` · ${powerLabel}` : ""}
                   </div>


### PR DESCRIPTION
Added formatSpeed import and average_speed display to the recent
activities cards, shown between moving time and elevation.

https://claude.ai/code/session_01Pc1HzgVz7a1gkRUBHs3uaj