### PR TITLE
Fix demo mode stuck on "Loading demo…" screen

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,7 +7,7 @@ import { html } from "htm/preact";
 import { render, Component } from "preact";
 import { signal, effect } from "@preact/signals";
 import { authState, initAuth } from "./auth.js";
-import { checkDemo, isDemo, startDemo, exitDemo } from "./demo.js";
+import { checkDemo, isDemo, startDemo, exitDemo, demoError } from "./demo.js";
 import { initInstallDetection } from "./install.js";
 import { initTouchTooltips } from "./touch-tooltip.js";
 import { Landing } from "./components/Landing.js";
@@ -108,7 +108,24 @@ function App() {
   // /demo is always accessible — start demo if needed
   if (currentRoute === "demo") {
     if (isDemo.value) return html`<${Dashboard} key="demo" />`;
-    startDemo().then(() => safeRender());
+    if (demoError.value) {
+      return html`<div class="min-h-screen flex flex-col items-center justify-center gap-4 px-4 text-center">
+        <p style="color: var(--text-secondary); font-family: var(--font-body);">
+          Failed to load demo.
+        </p>
+        <p style="color: var(--text-tertiary); font-family: var(--font-mono); font-size: 0.75rem; max-width: 400px; word-break: break-word;">
+          ${demoError.value}
+        </p>
+        <button
+          onClick=${() => { demoError.value = null; startDemo(); }}
+          style="background: var(--strava); color: white; padding: 0.5rem 1.5rem; border-radius: 0.5rem; border: none; cursor: pointer; font-family: var(--font-body);"
+        >Try Again</button>
+        <a href="/"
+          style="color: var(--text-tertiary); font-family: var(--font-body); font-size: 0.875rem;"
+        >Back to Home</a>
+      </div>`;
+    }
+    startDemo();
     return html`<div class="min-h-screen flex items-center justify-center"
       style="color: var(--text-secondary); font-family: var(--font-body);">Loading demo…</div>`;
   }
@@ -188,6 +205,7 @@ async function init() {
     const __ = route.value;
     const ___ = routeParams.value;
     const ____ = isDemo.value;
+    const _____ = demoError.value;
     safeRender();
   });
 }

--- a/src/demo.js
+++ b/src/demo.js
@@ -8,7 +8,9 @@ import { openDB, switchToDemoDB, switchToRealDB, deleteDemoDB, getAuth } from ".
 import { authState } from "./auth.js";
 
 export const isDemo = signal(false);
+export const demoError = signal(null);
 
+let demoStarting = false;
 const DEMO_DATA_URL = "./demo-data.json";
 const DEMO_ATHLETE = {
   id: 99999999,
@@ -48,58 +50,69 @@ export async function checkDemo() {
 
 /** Load demo data into a separate demo database. Real data is never touched. */
 export async function startDemo() {
-  const resp = await fetch(DEMO_DATA_URL);
-  if (!resp.ok) throw new Error("Failed to load demo data");
-  const data = await resp.json();
+  if (demoStarting) return;
+  demoStarting = true;
+  demoError.value = null;
+  try {
+    const resp = await fetch(DEMO_DATA_URL);
+    if (!resp.ok) throw new Error("Failed to load demo data");
+    const data = await resp.json();
 
-  // Switch to the isolated demo database
-  switchToDemoDB();
-  const db = await openDB();
+    // Switch to the isolated demo database
+    switchToDemoDB();
+    const db = await openDB();
 
-  // Set fake auth session
-  const session = {
-    access_token: "demo_token",
-    refresh_token: "demo_refresh",
-    expires_at: Math.floor(Date.now() / 1000) + 86400,
-    athlete: DEMO_ATHLETE,
-  };
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction("auth", "readwrite");
-    tx.objectStore("auth").put(session, "session");
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
+    // Set fake auth session
+    const session = {
+      access_token: "demo_token",
+      refresh_token: "demo_refresh",
+      expires_at: Math.floor(Date.now() / 1000) + 86400,
+      athlete: DEMO_ATHLETE,
+    };
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction("auth", "readwrite");
+      tx.objectStore("auth").put(session, "session");
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
 
-  // Store demo activities, segments, and sync state
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction(["activities", "segments", "sync_state"], "readwrite");
-    for (const act of data.activities) {
-      tx.objectStore("activities").put(act);
-    }
-    for (const seg of data.segments) {
-      tx.objectStore("segments").put(seg);
-    }
-    tx.objectStore("sync_state").put(
-      {
-        last_activity_fetch: new Date().toISOString(),
-        backfill_complete: true,
-        backfill_page: 1,
-        total_activities: data.activities.length,
-        fetched_activities: data.activities.length,
-        detailed_activities: data.activities.length,
-        last_sync: new Date().toISOString(),
-        power_backfill_complete: true,
-        schema_version: 2,
-      },
-      "state"
-    );
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
+    // Store demo activities, segments, and sync state
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(["activities", "segments", "sync_state"], "readwrite");
+      for (const act of data.activities) {
+        tx.objectStore("activities").put(act);
+      }
+      for (const seg of data.segments) {
+        tx.objectStore("segments").put(seg);
+      }
+      tx.objectStore("sync_state").put(
+        {
+          last_activity_fetch: new Date().toISOString(),
+          backfill_complete: true,
+          backfill_page: 1,
+          total_activities: data.activities.length,
+          fetched_activities: data.activities.length,
+          detailed_activities: data.activities.length,
+          last_sync: new Date().toISOString(),
+          power_backfill_complete: true,
+          schema_version: 2,
+        },
+        "state"
+      );
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
 
-  sessionStorage.setItem("aeyu_demo_active", "true");
-  authState.value = session;
-  isDemo.value = true;
+    sessionStorage.setItem("aeyu_demo_active", "true");
+    authState.value = session;
+    isDemo.value = true;
+  } catch (err) {
+    console.error("Demo start failed:", err);
+    switchToRealDB();
+    demoError.value = err.message || "Unknown error loading demo";
+  } finally {
+    demoStarting = false;
+  }
 }
 
 /** Exit demo — switch back to real DB, restore real auth if present, delete demo DB */


### PR DESCRIPTION
## Summary

- **Added error handling to `startDemo()`** — previously, if the fetch of `demo-data.json` or any IndexedDB operation failed, the promise rejection was silently swallowed and the user was stuck on "Loading demo…" forever. Now catches errors and shows a retry-able error screen.
- **Added a re-entry guard** (`demoStarting` flag) to prevent multiple concurrent `startDemo()` calls. Every signal-driven re-render while `isDemo` was still `false` would fire another `startDemo()`, creating racing IndexedDB transactions.
- **Added `demoError` signal** so the error state triggers a re-render showing the failure message, a "Try Again" button, and a "Back to Home" link.

## Root Cause

The `/demo` route handler in `App()` called `startDemo().then(() => safeRender())` as fire-and-forget with no `.catch()`. Since `window.__appRendered` was already `true` from the initial render, even the global `unhandledrejection` handler in the HTML couldn't display anything — `showLoadError()` bails early when `__appRendered` is set.

## Test plan

- [ ] Visit `/demo` on a clean browser — should load demo dashboard normally
- [ ] Simulate `demo-data.json` fetch failure (e.g., DevTools network block) — should show error screen with retry button
- [ ] Click "Try Again" after unblocking — should recover and load demo
- [ ] Click "Back to Home" — should navigate to landing page
- [ ] Visit `/demo` as an authenticated user — should still work

https://claude.ai/code/session_01DCEwVgqW4jPGaWDKjSNM7r