### PR TITLE
Fix touch interaction on aerobic efficiency chart dots

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -688,7 +688,7 @@ export function Dashboard() {
                         ${pts.map((p) => {
                           const d = new Date(p.date);
                           const label = `${d.toLocaleDateString()}: EF ${p.ef.toFixed(2)}`;
-                          return html`<circle cx="${x(p.date)}" cy="${y(p.ef)}" r="2.5" fill="#4882A8" opacity="0.7"><title>${label}</title></circle>`;
+                          return html`<g><circle cx="${x(p.date)}" cy="${y(p.ef)}" r="8" fill="transparent" style="cursor: pointer;"><title>${label}</title></circle><circle cx="${x(p.date)}" cy="${y(p.ef)}" r="2.5" fill="#4882A8" opacity="0.7" style="pointer-events: none;" /></g>`;
                         })}
                       </svg>
                     `;

--- a/src/touch-tooltip.js
+++ b/src/touch-tooltip.js
@@ -13,6 +13,11 @@ let suppressContextMenu = false;
 function findTitled(el) {
   while (el && el !== document.body) {
     if (el.getAttribute && el.getAttribute("title")) return el;
+    // SVG elements use <title> child elements instead of title attributes
+    if (el.namespaceURI === "http://www.w3.org/2000/svg") {
+      const t = el.querySelector && el.querySelector("title");
+      if (t && t.textContent) return el;
+    }
     el = el.parentElement;
   }
   return null;
@@ -76,7 +81,9 @@ export function initTouchTooltips() {
     timer = setTimeout(() => {
       suppressContextMenu = true;
       pressTarget = null;
-      const text = target.getAttribute("title");
+      const text = target.getAttribute("title")
+        || (target.namespaceURI === "http://www.w3.org/2000/svg" && target.querySelector("title")?.textContent)
+        || null;
       if (text) show(text, startX, startY);
     }, 500);
   }, { passive: true });


### PR DESCRIPTION
## Summary
- Fixed `touch-tooltip.js` `findTitled()` to detect SVG `<title>` child elements (not just HTML `title` attributes), enabling long-press tooltips on SVG chart dots
- Added larger invisible touch targets (r=8) behind the visible dots (r=2.5) in the aerobic efficiency scatter plot for easier tapping on mobile

## Test plan
- [ ] On mobile/touch device, long-press a dot in the Aerobic Efficiency chart — should show date and EF value tooltip
- [ ] Verify desktop hover still shows native SVG title tooltips on dots
- [ ] Verify Performance Capacity bar tooltips still work (HTML title attributes, unchanged)

https://claude.ai/code/session_01S46gp8c6DdKVz6kw2EnFNi