### PR TITLE
Fix aerobic efficiency chart to include VirtualRide power data

### DIFF
--- a/src/fitness.js
+++ b/src/fitness.js
@@ -219,11 +219,13 @@ export async function computePerformanceCapacity() {
 export async function computeAerobicEfficiency() {
   const allActivities = await getAllActivities();
 
-  // Filter to cycling activities with power meter + HR data + minimum duration
+  // Filter to cycling activities with power + HR data + minimum duration
+  // VirtualRide always has real power from the trainer — don't require device_watts
   const eligible = allActivities.filter((a) =>
     a.has_heartrate &&
     a.average_heartrate > 0 &&
-    a.device_watts &&
+    (a.device_watts || a.sport_type === "VirtualRide") &&
+    a.average_watts > 0 &&
     a.moving_time >= MIN_EF_MOVING_TIME &&
     (a.sport_type === "Ride" || a.sport_type === "VirtualRide" || a.sport_type === "MountainBikeRide")
   );


### PR DESCRIPTION
## Summary
- **VirtualRide power now counted**: Virtual rides (Zwift, etc.) always have real power from the trainer, but Strava doesn't always set `device_watts: true` for them. The filter now trusts power data from VirtualRide activities without requiring that flag.
- **Fixes stale chart**: Recent virtual rides were being excluded, causing the aerobic efficiency chart to show outdated data instead of the most recent rides.
- Added explicit `average_watts > 0` guard for safety.

## Test plan
- [ ] Verify aerobic efficiency chart shows data from recent VirtualRide activities
- [ ] Confirm outdoor rides with power meters still appear correctly
- [ ] Check that the EF current value and recent ride count update accordingly
- [ ] Verify demo mode still works (demo data uses Ride sport_type)

https://claude.ai/code/session_018x2cFg2XjdnUscDioPdmjD