### PR TITLE
Fix AI Coach export failing after clipboard timeout

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1627,7 +1627,17 @@ export function Dashboard() {
                   try {
                     const ctx = await buildLLMContext({ days: parseInt(exportDays.value) });
                     const text = exportFormat.value === "markdown" ? contextToMarkdown(ctx) : JSON.stringify(ctx, null, 2);
-                    await navigator.clipboard.writeText(text);
+                    try {
+                      await navigator.clipboard.writeText(text);
+                    } catch (_clipErr) {
+                      const ta = document.createElement("textarea");
+                      ta.value = text;
+                      ta.style.cssText = "position:fixed;opacity:0";
+                      document.body.appendChild(ta);
+                      ta.select();
+                      document.execCommand("copy");
+                      ta.remove();
+                    }
                     exportStatus.value = "copied";
                     setTimeout(() => { exportStatus.value = null; }, 3000);
                   } catch (e) {


### PR DESCRIPTION
## Summary
- The AI Coach export button shows "Building export..." then fails with "Export failed"
- Root cause: `buildLLMContext()` computes awards for all recent activities, which involves many IndexedDB lookups and can take several seconds
- The Clipboard API (`navigator.clipboard.writeText()`) requires transient user activation, which expires after the long computation
- Fix: wrap clipboard write in a try/catch and fall back to the classic textarea + `execCommand('copy')` method when the Clipboard API throws

## Test plan
- [ ] Click "Copy training data to clipboard" with a large dataset (90+ days)
- [ ] Verify the export completes with "Copied to clipboard!" instead of failing
- [ ] Paste the result into a text editor to confirm data was actually copied
- [ ] Test with both Markdown and JSON formats

https://claude.ai/code/session_01MoZuewci54gLe9onKpQPHB