### PR TITLE
Fix clipboard copy for AI Coach export

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1625,19 +1625,16 @@ export function Dashboard() {
                 onClick=${async () => {
                   exportStatus.value = "loading";
                   try {
-                    const ctx = await buildLLMContext({ days: parseInt(exportDays.value) });
-                    const text = exportFormat.value === "markdown" ? contextToMarkdown(ctx) : JSON.stringify(ctx, null, 2);
-                    try {
-                      await navigator.clipboard.writeText(text);
-                    } catch (_clipErr) {
-                      const ta = document.createElement("textarea");
-                      ta.value = text;
-                      ta.style.cssText = "position:fixed;opacity:0";
-                      document.body.appendChild(ta);
-                      ta.select();
-                      document.execCommand("copy");
-                      ta.remove();
-                    }
+                    const days = parseInt(exportDays.value);
+                    const fmt = exportFormat.value;
+                    // Pass a Promise to ClipboardItem so user activation is captured now,
+                    // even though buildLLMContext resolves later
+                    const textPromise = (async () => {
+                      const ctx = await buildLLMContext({ days });
+                      return fmt === "markdown" ? contextToMarkdown(ctx) : JSON.stringify(ctx, null, 2);
+                    })();
+                    const blobPromise = textPromise.then(t => new Blob([t], { type: "text/plain" }));
+                    await navigator.clipboard.write([new ClipboardItem({ "text/plain": blobPromise })]);
                     exportStatus.value = "copied";
                     setTimeout(() => { exportStatus.value = null; }, 3000);
                   } catch (e) {


### PR DESCRIPTION
## Summary
- PR #185 fixed the error thrown during clipboard copy, but the fallback `execCommand("copy")` also fails silently because user activation expires during the long `buildLLMContext()` computation
- Uses `ClipboardItem` with a Promise-based blob to capture user activation at click time, allowing the clipboard write to succeed even after the async computation completes
- Removes the broken textarea fallback

## Root Cause
`navigator.clipboard.writeText()` and `document.execCommand("copy")` both require a **transient user activation** (a recent user gesture like a click). The `buildLLMContext()` call takes several seconds, by which time the activation expires and both methods fail silently.

The [`ClipboardItem` constructor accepts a Promise](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem) — the browser captures the user activation at the time `clipboard.write()` is called, and resolves the content asynchronously.

## Test plan
- [ ] Click "Copy training data to clipboard" in AI Coach export section
- [ ] Wait for computation to complete
- [ ] Verify "Copied to clipboard!" appears
- [ ] Paste into a text editor and verify content is present

https://claude.ai/code/session_01JVH6AuMLK1GtWfiwS1muN4