### PR TITLE
Add single-ride LLM export with optional form context

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -26,6 +26,7 @@ import { renderIconSVG, drawIcon } from "../icons.js";
 import { AWARD_LABELS, AWARD_COLORS } from "../award-config.js";
 import { StickyHeader } from "./StickyHeader.js";
 import { SegmentSparkline } from "./SegmentSparkline.js";
+import { buildRideExport, rideToMarkdown } from "../export-llm.js";
 
 const activity = signal(null);
 const awards = signal([]);
@@ -38,6 +39,9 @@ const resyncing = signal(false);
 const resyncError = signal(null);
 const sortColumn = signal(null); // null = activity order
 const sortDirection = signal("asc"); // "asc" or "desc"
+const llmExportStatus = signal(null); // null | "loading" | "copied" | "error"
+const llmExportFormat = signal("markdown");
+const llmIncludeForm = signal(true);
 
 function formatDateShort(isoString) {
   return new Date(isoString).toLocaleDateString("en-US", {
@@ -1356,9 +1360,62 @@ export function ActivityDetail({ id }) {
                   </button>
                 </div>
               `}
+
             </div>
           </div>
         `}
+
+        <!-- LLM Export — always visible -->
+        <div class="rounded-xl p-4 mb-6" style="background: var(--surface); border: 1px solid var(--border);">
+          <p class="text-xs font-medium mb-1" style="color: var(--text-secondary); font-family: var(--font-body);">Export for AI Coach</p>
+          <p class="text-xs mb-2" style="color: var(--border);">Copy this ride's data for use with an LLM.</p>
+          <div class="flex flex-wrap items-center gap-2 mb-2">
+            <select
+              value=${llmExportFormat.value}
+              onChange=${(e) => { llmExportFormat.value = e.target.value; llmExportStatus.value = null; }}
+              class="text-xs rounded px-2 py-1 focus:outline-none"
+              style="border: 1px solid var(--border); background: var(--bg-card); color: var(--text); font-family: var(--font-mono);"
+            >
+              <option value="markdown">Markdown</option>
+              <option value="json">JSON</option>
+            </select>
+            <label class="inline-flex items-center gap-1 text-xs cursor-pointer" style="color: var(--text-secondary); font-family: var(--font-body);">
+              <input
+                type="checkbox"
+                checked=${llmIncludeForm.value}
+                onChange=${(e) => { llmIncludeForm.value = e.target.checked; llmExportStatus.value = null; }}
+                class="rounded"
+                style="accent-color: var(--accent);"
+              />
+              Include form context
+            </label>
+          </div>
+          <button
+            onClick=${async () => {
+              llmExportStatus.value = "loading";
+              try {
+                const textPromise = (async () => {
+                  const ctx = await buildRideExport(act.id, { includeForm: llmIncludeForm.value });
+                  if (!ctx) throw new Error("Activity not found");
+                  return llmExportFormat.value === "markdown" ? rideToMarkdown(ctx) : JSON.stringify(ctx, null, 2);
+                })();
+                const blobPromise = textPromise.then(t => new Blob([t], { type: "text/plain" }));
+                await navigator.clipboard.write([new ClipboardItem({ "text/plain": blobPromise })]);
+                llmExportStatus.value = "copied";
+                setTimeout(() => { llmExportStatus.value = null; }, 3000);
+              } catch (e) {
+                console.error("Ride export failed:", e);
+                llmExportStatus.value = "error";
+                setTimeout(() => { llmExportStatus.value = null; }, 3000);
+              }
+            }}
+            disabled=${llmExportStatus.value === "loading"}
+            class="text-xs transition-colors"
+            style="color: var(--accent);"
+          >
+            ${llmExportStatus.value === "loading" ? "Building export..." : llmExportStatus.value === "copied" ? "Copied to clipboard!" : llmExportStatus.value === "error" ? "Export failed" : "Copy ride data to clipboard"}
+          </button>
+        </div>
 
         <!-- Segment efforts — summary cards with expandable detail (#88) -->
         ${act.has_efforts && act.segment_efforts && act.segment_efforts.length > 0 && html`

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1235,7 +1235,8 @@ export function Dashboard() {
                 </summary>
                 <div class="pt-3 pb-1 space-y-2" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
                   <p>Yes! Go to Settings and use "Export for AI Coach" to copy a compact summary of your recent training to the clipboard. It includes weekly volume rollups, monthly trends, fitness indicators, consistency streaks, and your last 10 rides — everything an LLM needs to give you coaching advice without overwhelming its context window.</p>
-                  <p>You can choose a time window (30 days to 1 year) and export as Markdown (best for chat) or JSON (best for structured prompts). Paste the result into ChatGPT, Claude, or any LLM and ask for training analysis.</p>
+                  <p>You can also export a single ride from any Activity Detail page. The ride export includes all segment efforts with awards, and optionally your form context leading into the ride (training load from the preceding 7/14/30 days, recent rides, fitness indicators, and streaks).</p>
+                  <p>Choose Markdown (best for chat) or JSON (best for structured prompts). Paste the result into ChatGPT, Claude, or any LLM and ask for training analysis.</p>
                 </div>
               </details>
 

--- a/src/export-llm.js
+++ b/src/export-llm.js
@@ -6,10 +6,11 @@
  * that fits comfortably in any LLM context window.
  */
 
-import { getAllActivities, getAllSegments } from "./db.js";
+import { getAllActivities, getAllSegments, getActivity, getSegment, getResetEvent, getUserConfig } from "./db.js";
 import { computeFitnessSummary } from "./fitness.js";
-import { computeStreakData, computeAwardsForActivities } from "./awards.js";
+import { computeStreakData, computeAwardsForActivities, computeAwards, computeRideLevelAwards } from "./awards.js";
 import { unitSystem } from "./units.js";
+import { AWARD_LABELS } from "./award-config.js";
 
 function filterByDays(activities, days) {
   const cutoff = Date.now() - days * 86400000;
@@ -276,6 +277,236 @@ export function contextToMarkdown(ctx) {
     for (const [type, count] of awardTypes) {
       md += `- ${type}: ${count}\n`;
     }
+    md += `\n`;
+  }
+
+  return md;
+}
+
+// ── Single Ride Export ──────────────────────────────────────────
+
+function slimEffort(e) {
+  const out = {
+    segment: e.segment?.name,
+    distance_km: +(e.segment?.distance / 1000).toFixed(2),
+    grade_pct: e.segment?.average_grade,
+    elapsed_time_s: e.elapsed_time,
+    moving_time_s: e.moving_time,
+  };
+  if (e.device_watts && e.average_watts) out.avg_watts = Math.round(e.average_watts);
+  if (e.average_heartrate) out.avg_hr = Math.round(e.average_heartrate);
+  if (e.average_cadence) out.avg_cadence = Math.round(e.average_cadence);
+  if (e.pr_rank) out.pr_rank = e.pr_rank;
+  return out;
+}
+
+function slimAward(a) {
+  const label = AWARD_LABELS[a.type]?.label || a.type;
+  const out = { type: a.type, label };
+  if (a.segment) out.segment = a.segment;
+  if (a.message) out.message = a.message;
+  if (a.delta != null) out.delta = a.delta;
+  return out;
+}
+
+function buildFormContext(allActivities, rideDate) {
+  const rideDateMs = new Date(rideDate).getTime();
+  const preceding = allActivities
+    .filter(a => new Date(a.start_date).getTime() < rideDateMs)
+    .sort((a, b) => (b.start_date_local || "").localeCompare(a.start_date_local || ""));
+
+  const last14 = preceding.slice(0, 14);
+  const last30 = preceding.slice(0, 30);
+
+  const rollup = (acts) => {
+    if (acts.length === 0) return null;
+    const totalDist = acts.reduce((s, a) => s + (a.distance || 0), 0);
+    const totalTime = acts.reduce((s, a) => s + (a.moving_time || 0), 0);
+    const totalElev = acts.reduce((s, a) => s + (a.total_elevation_gain || 0), 0);
+    const withPower = acts.filter(a => a.device_watts && a.weighted_average_watts);
+    const withHR = acts.filter(a => a.has_heartrate && a.average_heartrate);
+    const out = {
+      rides: acts.length,
+      distance_km: +(totalDist / 1000).toFixed(1),
+      moving_hrs: +(totalTime / 3600).toFixed(1),
+      elevation_m: Math.round(totalElev),
+    };
+    if (withPower.length > 0) out.avg_np = Math.round(withPower.reduce((s, a) => s + a.weighted_average_watts, 0) / withPower.length);
+    if (withHR.length > 0) out.avg_hr = Math.round(withHR.reduce((s, a) => s + a.average_heartrate, 0) / withHR.length);
+    return out;
+  };
+
+  const recent = last14.slice(0, 7).map(slimActivity);
+
+  return {
+    preceding_7_days: rollup(last14.filter(a => new Date(a.start_date).getTime() >= rideDateMs - 7 * 86400000)),
+    preceding_14_days: rollup(last14.filter(a => new Date(a.start_date).getTime() >= rideDateMs - 14 * 86400000)),
+    preceding_30_days: rollup(last30.filter(a => new Date(a.start_date).getTime() >= rideDateMs - 30 * 86400000)),
+    recent_rides_before: recent,
+  };
+}
+
+export async function buildRideExport(activityId, options = {}) {
+  const includeForm = options.includeForm !== false;
+  const act = await getActivity(Number(activityId));
+  if (!act) return null;
+
+  const allActivities = await getAllActivities();
+  const sorted = [...allActivities].sort((a, b) => (a.start_date_local || "").localeCompare(b.start_date_local || ""));
+
+  let rideAwards = [];
+  const segmentAwards = [];
+  if (act.has_efforts) {
+    const resetEvent = await getResetEvent();
+    const userConfig = await getUserConfig();
+    const refPoints = userConfig.referencePoints || [];
+    const segAwards = await computeAwards(act, resetEvent, refPoints);
+    segmentAwards.push(...segAwards);
+    rideAwards = computeRideLevelAwards(act, sorted, resetEvent);
+  }
+
+  const efforts = (act.segment_efforts || []).map(e => {
+    const slim = slimEffort(e);
+    const ea = segmentAwards.filter(a => a.segment_id === e.segment?.id);
+    if (ea.length > 0) slim.awards = ea.map(slimAward);
+    return slim;
+  });
+
+  const ride = {
+    name: act.name,
+    date: act.start_date_local?.slice(0, 10),
+    type: act.sport_type,
+    distance_km: +(act.distance / 1000).toFixed(1),
+    moving_time_min: Math.round(act.moving_time / 60),
+    elapsed_time_min: Math.round((act.elapsed_time || act.moving_time) / 60),
+    elevation_m: Math.round(act.total_elevation_gain || 0),
+    avg_speed_kph: +((act.average_speed || 0) * 3.6).toFixed(1),
+    max_speed_kph: +((act.max_speed || 0) * 3.6).toFixed(1),
+    trainer: act.trainer || false,
+  };
+  if (act.device_watts && act.average_watts) ride.avg_watts = Math.round(act.average_watts);
+  if (act.device_watts && act.weighted_average_watts) ride.np_watts = Math.round(act.weighted_average_watts);
+  if (act.kilojoules) ride.kj = Math.round(act.kilojoules);
+  if (act.has_heartrate && act.average_heartrate) {
+    ride.avg_hr = Math.round(act.average_heartrate);
+    ride.max_hr = Math.round(act.max_heartrate || 0);
+  }
+  if (act.suffer_score) ride.suffer_score = act.suffer_score;
+
+  const ctx = {
+    generated_at: new Date().toISOString(),
+    export_type: "single_ride",
+    ride,
+    ride_awards: rideAwards.map(slimAward),
+    segment_efforts: efforts,
+  };
+
+  if (includeForm) {
+    const [fitness, streakData] = await Promise.all([
+      computeFitnessSummary(),
+      Promise.resolve(computeStreakData(sorted)),
+    ]);
+    ctx.form_context = buildFormContext(sorted, act.start_date);
+    ctx.fitness = formatFitness(fitness);
+    ctx.streaks = formatStreaks(streakData);
+  }
+
+  return ctx;
+}
+
+export function rideToMarkdown(ctx) {
+  if (!ctx) return "";
+  const r = ctx.ride;
+  let md = `# Ride: ${r.name}\n`;
+  md += `Date: ${r.date} | Type: ${r.type}\n\n`;
+
+  md += `## Ride Summary\n`;
+  md += `- Distance: ${r.distance_km} km\n`;
+  md += `- Moving time: ${r.moving_time_min} min (elapsed: ${r.elapsed_time_min} min)\n`;
+  md += `- Elevation: ${r.elevation_m} m\n`;
+  md += `- Avg speed: ${r.avg_speed_kph} km/h, Max: ${r.max_speed_kph} km/h\n`;
+  if (r.np_watts) md += `- Normalized Power: ${r.np_watts} W`;
+  if (r.avg_watts) md += `${r.np_watts ? ", " : "- "}Avg Power: ${r.avg_watts} W`;
+  if (r.np_watts || r.avg_watts) md += `\n`;
+  if (r.kj) md += `- Energy: ${r.kj} kJ\n`;
+  if (r.avg_hr) md += `- Heart Rate: avg ${r.avg_hr}, max ${r.max_hr}\n`;
+  if (r.suffer_score) md += `- Suffer Score: ${r.suffer_score}\n`;
+  if (r.trainer) md += `- Indoor trainer ride\n`;
+  md += `\n`;
+
+  if (ctx.ride_awards.length > 0) {
+    md += `## Ride-Level Awards\n`;
+    for (const a of ctx.ride_awards) {
+      md += `- **${a.label}**${a.message ? ": " + a.message : ""}\n`;
+    }
+    md += `\n`;
+  }
+
+  if (ctx.segment_efforts.length > 0) {
+    md += `## Segment Efforts (${ctx.segment_efforts.length})\n`;
+    md += `| Segment | Dist (km) | Grade | Time (s) | Watts | HR | Awards |\n`;
+    md += `|---------|-----------|-------|----------|-------|----|--------|\n`;
+    for (const e of ctx.segment_efforts) {
+      const awardStr = (e.awards || []).map(a => a.label).join(", ") || "-";
+      md += `| ${e.segment} | ${e.distance_km} | ${e.grade_pct}% | ${e.elapsed_time_s} | ${e.avg_watts || "-"} | ${e.avg_hr || "-"} | ${awardStr} |\n`;
+    }
+    md += `\n`;
+  }
+
+  if (ctx.form_context) {
+    md += `## Form Leading Into This Ride\n`;
+    const windows = [
+      ["preceding_7_days", "Last 7 days"],
+      ["preceding_14_days", "Last 14 days"],
+      ["preceding_30_days", "Last 30 days"],
+    ];
+    for (const [key, label] of windows) {
+      const w = ctx.form_context[key];
+      if (w) {
+        md += `- **${label}**: ${w.rides} rides, ${w.distance_km} km, ${w.moving_hrs} hrs, ${w.elevation_m} m elev`;
+        if (w.avg_np) md += `, avg NP ${w.avg_np} W`;
+        if (w.avg_hr) md += `, avg HR ${w.avg_hr}`;
+        md += `\n`;
+      }
+    }
+    if (ctx.form_context.recent_rides_before?.length > 0) {
+      md += `\nRecent rides before this one:\n`;
+      for (const p of ctx.form_context.recent_rides_before) {
+        md += `- **${p.date}** ${p.name}: ${p.distance_km} km, ${p.moving_time_min} min, ${p.elevation_m} m`;
+        if (p.np_watts) md += `, NP ${p.np_watts} W`;
+        if (p.avg_hr) md += `, HR ${p.avg_hr}`;
+        if (p.trainer) md += ` [indoor]`;
+        md += `\n`;
+      }
+    }
+    md += `\n`;
+  }
+
+  if (ctx.fitness && (ctx.fitness.performance_capacity || ctx.fitness.aerobic_efficiency)) {
+    md += `## Current Fitness Indicators\n`;
+    if (ctx.fitness.performance_capacity) {
+      const pc = ctx.fitness.performance_capacity;
+      md += `- Performance Capacity: ${pc.score}/100`;
+      if (pc.trend != null) md += ` (trend: ${pc.trend > 0 ? "+" : ""}${pc.trend})`;
+      md += `\n`;
+    }
+    if (ctx.fitness.aerobic_efficiency) {
+      const ae = ctx.fitness.aerobic_efficiency;
+      md += `- Aerobic Efficiency (EF): ${ae.current_ef}`;
+      if (ae.trend_pct != null) md += ` (trend: ${ae.trend_pct > 0 ? "+" : ""}${ae.trend_pct}%)`;
+      md += `\n`;
+    }
+    if (ctx.fitness.interpretation) {
+      md += `- Interpretation: **${ctx.fitness.interpretation}**\n`;
+    }
+    md += `\n`;
+  }
+
+  if (ctx.streaks?.weekly_streak) {
+    const ws = ctx.streaks.weekly_streak;
+    md += `## Consistency\n`;
+    md += `- Current weekly streak: ${ws.current_weeks} weeks (longest: ${ws.longest_weeks})\n`;
+    if (ws.danger) md += `- Warning: ${ws.danger}\n`;
     md += `\n`;
   }
 


### PR DESCRIPTION
## Summary
- Adds "Export for AI Coach" section to Activity Detail page for exporting a single ride's data to clipboard
- Includes all segment efforts with awards, ride-level awards, and full ride metrics
- Toggle to include/exclude form context: preceding training load (7/14/30 day windows), recent rides before this one, fitness indicators, and consistency streaks
- Supports Markdown and JSON output formats, matching the aggregate export UX
- Updates FAQ to mention ride-level export capability

## Test plan
- [ ] Navigate to any Activity Detail page and verify the "Export for AI Coach" card appears below the awards section
- [ ] Test with Markdown format — verify clipboard contains structured ride data with segment table
- [ ] Test with JSON format — verify valid JSON with ride, segment_efforts, and ride_awards fields
- [ ] Toggle "Include form context" off and verify export omits form_context, fitness, and streaks sections
- [ ] Toggle it back on and verify preceding ride data and fitness indicators are included
- [ ] Test on a ride with no awards — verify the export section still appears and works
- [ ] Test on a ride with no segment efforts — verify export still works with empty segments

https://claude.ai/code/session_0192gUv34rmHwSjKrEWWjWNi