### PR TITLE
Add per-segment LLM export for effort history analysis

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -26,7 +26,7 @@ import { renderIconSVG, drawIcon } from "../icons.js";
 import { AWARD_LABELS, AWARD_COLORS } from "../award-config.js";
 import { StickyHeader } from "./StickyHeader.js";
 import { SegmentSparkline } from "./SegmentSparkline.js";
-import { buildRideExport, rideToMarkdown } from "../export-llm.js";
+import { buildRideExport, rideToMarkdown, buildSegmentExport, segmentToMarkdown } from "../export-llm.js";
 
 const activity = signal(null);
 const awards = signal([]);
@@ -42,6 +42,7 @@ const sortDirection = signal("asc"); // "asc" or "desc"
 const llmExportStatus = signal(null); // null | "loading" | "copied" | "error"
 const llmExportFormat = signal("markdown");
 const llmIncludeForm = signal(true);
+const segmentLlmExportStatus = signal(null); // null | { segmentId, state: "loading"|"copied"|"error" }
 
 function formatDateShort(isoString) {
   return new Date(isoString).toLocaleDateString("en-US", {
@@ -1531,6 +1532,41 @@ export function ActivityDetail({ id }) {
                         Share Segment
                       </button>
                     </div>
+                  `}
+                  ${effortCount >= 2 && html`
+                    <button
+                      onClick=${async (e) => {
+                        e.stopPropagation();
+                        const sid = effort.segment.id;
+                        segmentLlmExportStatus.value = { segmentId: sid, state: "loading" };
+                        try {
+                          const textPromise = (async () => {
+                            const ctx = await buildSegmentExport(sid);
+                            if (!ctx) throw new Error("Segment not found");
+                            return llmExportFormat.value === "markdown" ? segmentToMarkdown(ctx) : JSON.stringify(ctx, null, 2);
+                          })();
+                          const blobPromise = textPromise.then(t => new Blob([t], { type: "text/plain" }));
+                          await navigator.clipboard.write([new ClipboardItem({ "text/plain": blobPromise })]);
+                          segmentLlmExportStatus.value = { segmentId: sid, state: "copied" };
+                          setTimeout(() => { segmentLlmExportStatus.value = null; }, 3000);
+                        } catch (err) {
+                          console.error("Segment export failed:", err);
+                          segmentLlmExportStatus.value = { segmentId: sid, state: "error" };
+                          setTimeout(() => { segmentLlmExportStatus.value = null; }, 3000);
+                        }
+                      }}
+                      disabled=${segmentLlmExportStatus.value?.segmentId === effort.segment.id && segmentLlmExportStatus.value?.state === "loading"}
+                      class="inline-flex items-center gap-1 text-xs mt-2 transition-colors"
+                      style="color: var(--accent); font-family: var(--font-body);"
+                      title="Export this segment's effort history for LLM analysis"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/>
+                      </svg>
+                      ${segmentLlmExportStatus.value?.segmentId === effort.segment.id
+                        ? segmentLlmExportStatus.value.state === "loading" ? "Exporting..." : segmentLlmExportStatus.value.state === "copied" ? "Copied!" : "Export failed"
+                        : "Export for AI"}
+                    </button>
                   `}
                 </div>
               `;

--- a/src/export-llm.js
+++ b/src/export-llm.js
@@ -512,3 +512,118 @@ export function rideToMarkdown(ctx) {
 
   return md;
 }
+
+// ── Single Segment Export ──────────────────────────────────────
+
+function slimSegmentEffort(e, actMap) {
+  const out = {
+    date: e.start_date_local?.slice(0, 10),
+    elapsed_time_s: e.elapsed_time,
+    moving_time_s: e.moving_time,
+  };
+  if (e.device_watts && e.average_watts) out.avg_watts = Math.round(e.average_watts);
+  if (e.average_heartrate) out.avg_hr = Math.round(e.average_heartrate);
+  if (e.max_heartrate) out.max_hr = Math.round(e.max_heartrate);
+  if (e.average_cadence) out.avg_cadence = Math.round(e.average_cadence);
+  if (e.pr_rank) out.pr_rank = e.pr_rank;
+  if (actMap && e.activity_id) {
+    const act = actMap.get(e.activity_id);
+    if (act) out.ride_name = act.name;
+  }
+  return out;
+}
+
+export async function buildSegmentExport(segmentId) {
+  const seg = await getSegment(Number(segmentId));
+  if (!seg || !seg.efforts || seg.efforts.length === 0) return null;
+
+  const allActs = await getAllActivities();
+  const actMap = new Map(allActs.map(a => [a.id, a]));
+
+  const efforts = [...seg.efforts]
+    .sort((a, b) => (a.start_date_local || "").localeCompare(b.start_date_local || ""))
+    .map(e => slimSegmentEffort(e, actMap));
+
+  const times = seg.efforts.map(e => e.elapsed_time).filter(t => t > 0);
+  const sortedTimes = [...times].sort((a, b) => a - b);
+  const best = sortedTimes[0];
+  const worst = sortedTimes[sortedTimes.length - 1];
+  const median = sortedTimes[Math.floor(sortedTimes.length / 2)];
+  const mean = Math.round(times.reduce((s, t) => s + t, 0) / times.length);
+
+  const withPower = seg.efforts.filter(e => e.device_watts && e.average_watts);
+  const withHR = seg.efforts.filter(e => e.average_heartrate);
+
+  const stats = {
+    total_efforts: seg.efforts.length,
+    best_time_s: best,
+    worst_time_s: worst,
+    median_time_s: median,
+    mean_time_s: mean,
+  };
+  if (withPower.length > 0) {
+    const powers = withPower.map(e => Math.round(e.average_watts));
+    stats.best_power_w = Math.max(...powers);
+    stats.avg_power_w = Math.round(powers.reduce((s, p) => s + p, 0) / powers.length);
+  }
+  if (withHR.length > 0) {
+    const hrs = withHR.map(e => Math.round(e.average_heartrate));
+    stats.avg_hr = Math.round(hrs.reduce((s, h) => s + h, 0) / hrs.length);
+  }
+
+  return {
+    generated_at: new Date().toISOString(),
+    export_type: "segment_history",
+    segment: {
+      id: seg.id,
+      name: seg.name,
+      distance_km: +(seg.distance / 1000).toFixed(2),
+      average_grade_pct: seg.average_grade,
+      elevation_gain_m: Math.round((seg.elevation_high || 0) - (seg.elevation_low || 0)),
+      climb_category: seg.climb_category,
+    },
+    stats,
+    efforts,
+  };
+}
+
+export function segmentToMarkdown(ctx) {
+  if (!ctx) return "";
+  const s = ctx.segment;
+  let md = `# Segment: ${s.name}\n`;
+  md += `Distance: ${s.distance_km} km · Grade: ${s.average_grade_pct}% · Elevation gain: ${s.elevation_gain_m} m`;
+  if (s.climb_category > 0) md += ` · Cat ${s.climb_category}`;
+  md += `\n\n`;
+
+  const st = ctx.stats;
+  md += `## Summary Statistics (${st.total_efforts} efforts)\n`;
+  md += `- Best time: ${st.best_time_s}s · Worst: ${st.worst_time_s}s · Median: ${st.median_time_s}s · Mean: ${st.mean_time_s}s\n`;
+  if (st.best_power_w) md += `- Best power: ${st.best_power_w} W · Avg power: ${st.avg_power_w} W\n`;
+  if (st.avg_hr) md += `- Avg HR: ${st.avg_hr} bpm\n`;
+  md += `\n`;
+
+  md += `## All Efforts\n`;
+  md += `| Date | Time (s) | Moving (s) |`;
+  const hasPower = ctx.efforts.some(e => e.avg_watts);
+  const hasHR = ctx.efforts.some(e => e.avg_hr);
+  const hasCadence = ctx.efforts.some(e => e.avg_cadence);
+  if (hasPower) md += ` Watts |`;
+  if (hasHR) md += ` HR |`;
+  if (hasCadence) md += ` Cadence |`;
+  md += ` Ride |\n`;
+  md += `|------|----------|------------|`;
+  if (hasPower) md += `-------|`;
+  if (hasHR) md += `-----|`;
+  if (hasCadence) md += `---------|`;
+  md += `------|\n`;
+  for (const e of ctx.efforts) {
+    md += `| ${e.date} | ${e.elapsed_time_s} | ${e.moving_time_s} |`;
+    if (hasPower) md += ` ${e.avg_watts || "-"} |`;
+    if (hasHR) md += ` ${e.avg_hr || "-"} |`;
+    if (hasCadence) md += ` ${e.avg_cadence || "-"} |`;
+    md += ` ${e.ride_name || "-"} |\n`;
+  }
+  md += `\n`;
+
+  return md;
+}


### PR DESCRIPTION
## Summary
- Adds `buildSegmentExport()` and `segmentToMarkdown()` to `export-llm.js` — exports a segment's full effort history with metadata, summary stats (best/worst/median times, power, HR), and chronological effort table with ride names
- Adds an "Export for AI" button on each segment card in ActivityDetail (visible when 2+ efforts exist) that copies the export to clipboard in the user's chosen format (markdown or JSON)
- Reuses the existing ride-level format toggle (`llmExportFormat` signal) so the user's preference applies to both ride and segment exports

## Test plan
- [ ] Open an activity detail page with segment efforts
- [ ] Verify "Export for AI" button appears on segments with 2+ efforts
- [ ] Click the button and confirm data is copied to clipboard
- [ ] Paste into an LLM and verify the markdown table renders correctly with effort history
- [ ] Toggle format to JSON and verify JSON export works
- [ ] Verify button shows loading/copied/error states correctly
- [ ] Verify segments with only 1 effort do not show the button

https://claude.ai/code/session_01Gvwg6FWEsPybCHbaE7fpVw