### PR TITLE
Increase LLM export data limits for larger context windows

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1273,7 +1273,7 @@ export function Dashboard() {
                   <svg class="w-4 h-4 group-open:rotate-180 transition-transform flex-shrink-0 ml-2" style="color: var(--text-tertiary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
                 </summary>
                 <div class="pt-3 pb-1 space-y-2" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
-                  <p>Yes! Go to Settings and use "Export for AI Coach" to copy a compact summary of your recent training to the clipboard. It includes weekly volume rollups, monthly trends, fitness indicators, consistency streaks, and your last 10 rides — everything an LLM needs to give you coaching advice without overwhelming its context window.</p>
+                  <p>Yes! Go to Settings and use "Export for AI Coach" to copy a compact summary of your recent training to the clipboard. It includes weekly volume rollups, monthly trends, fitness indicators, consistency streaks, and your last 25 rides — everything an LLM needs to give you coaching advice.</p>
                   <p>You can also export a single ride from any Activity Detail page. The ride export includes all segment efforts with awards, and optionally your form context leading into the ride (training load from the preceding 7/14/30 days, recent rides, fitness indicators, and streaks).</p>
                   <p>Choose Markdown (best for chat) or JSON (best for structured prompts). Paste the result into ChatGPT, Claude, or any LLM and ask for training analysis.</p>
                 </div>

--- a/src/export-llm.js
+++ b/src/export-llm.js
@@ -2,7 +2,7 @@
  * LLM Export — Build a compact training context for AI coaching.
  *
  * Aggregates recent rides, pre-computed fitness trends, streak data,
- * and award distributions into a ~2-5KB JSON or markdown payload
+ * and award distributions into a compact JSON or markdown payload
  * that fits comfortably in any LLM context window.
  */
 
@@ -162,7 +162,7 @@ export async function buildLLMContext(options = {}) {
   const hasHR = sorted.some((a) => a.has_heartrate);
   const sportTypes = [...new Set(sorted.map((a) => a.sport_type))];
 
-  const recentDetail = recent.slice(-10).reverse().map(slimActivity);
+  const recentDetail = recent.slice(-25).reverse().map(slimActivity);
 
   return {
     generated_at: new Date().toISOString(),
@@ -336,7 +336,7 @@ function buildFormContext(allActivities, rideDate) {
     return out;
   };
 
-  const recent = last14.slice(0, 7).map(slimActivity);
+  const recent = last14.slice(0, 15).map(slimActivity);
 
   return {
     preceding_7_days: rollup(last14.filter(a => new Date(a.start_date).getTime() >= rideDateMs - 7 * 86400000)),


### PR DESCRIPTION
Training export: 10 → 25 recent rides. Single ride export: 7 → 15
preceding rides in form context. Updated FAQ to match.

https://claude.ai/code/session_01NoMQnCWj9HMHMUb5K6qbqM