### PR TITLE
Fix streak mulligan: limit to one per streak

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -2035,8 +2035,8 @@ export function computeWeeklyStreaks(allActivities) {
       consecutiveMisses = 0;
     } else {
       consecutiveMisses++;
-      if (consecutiveMisses === 1 && currentStreak > 0) {
-        // First miss — use mulligan
+      if (consecutiveMisses === 1 && currentStreak > 0 && !currentMulligan) {
+        // First miss — use mulligan (one per streak)
         currentStreak++;
         currentMulligan = true;
       } else {
@@ -2218,7 +2218,7 @@ export function detectGroupRides(allActivities) {
             misses = 0;
           } else {
             misses++;
-            if (misses === 1 && attendanceStreak > 0) {
+            if (misses === 1 && attendanceStreak > 0 && !attendanceMulligan) {
               attendanceStreak++;
               attendanceMulligan = true;
             } else {


### PR DESCRIPTION
## Summary
- The mulligan (forgive one missed week) could be used unlimited times per streak — every non-consecutive missed week got its own mulligan, allowing a 147-week streak to survive multiple single-week gaps over the years
- Now a streak gets exactly **one** mulligan. Any second missed week (even non-consecutive) breaks the streak
- Same fix applied to group ride attendance streaks

## Test plan
- [ ] Verify a streak with one missed week still gets the mulligan and continues
- [ ] Verify a streak with two non-consecutive missed weeks now breaks at the second miss
- [ ] Verify the danger banner still shows correctly when the single mulligan is used
- [ ] Verify group ride attendance streaks behave the same way

https://claude.ai/code/session_01FU3RRjByQM6PistwexPpBq