### PR TITLE
Fix demo mode: clicking a ride no longer exits to landing page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -98,16 +98,21 @@ function App() {
   const auth = authState.value;
   const currentRoute = route.value;
 
-  // If demo is active but user navigated away from /demo, exit demo mode
-  // and let the app re-render with the real auth state.
-  if (currentRoute !== "demo" && isDemo.value) {
+  // Demo mode routing — allow /demo and /activity while demo is active
+  if (isDemo.value) {
+    if (currentRoute === "activity") {
+      return html`<${ActivityDetail} id=${routeParams.value.id} />`;
+    }
+    if (currentRoute === "demo") {
+      return html`<${Dashboard} key="demo" />`;
+    }
+    // Navigated away from demo-compatible routes — exit demo
     exitDemo();
     return null;
   }
 
   // /demo is always accessible — start demo if needed
   if (currentRoute === "demo") {
-    if (isDemo.value) return html`<${Dashboard} key="demo" />`;
     if (demoError.value) {
       return html`<div class="min-h-screen flex flex-col items-center justify-center gap-4 px-4 text-center">
         <p style="color: var(--text-secondary); font-family: var(--font-body);">

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -1093,7 +1093,7 @@ export function ActivityDetail({ id }) {
       <div class="min-h-screen flex items-center justify-center" style="background: var(--bg);">
         <div class="text-center">
           <p style="color: var(--text-secondary);">Activity not found</p>
-          <button onClick=${() => navigate("/dashboard")} class="mt-4" style="color: var(--accent);">
+          <button onClick=${() => navigate(isDemo.value ? "/demo" : "/dashboard")} class="mt-4" style="color: var(--accent);">
             Back to dashboard
           </button>
         </div>
@@ -1208,7 +1208,7 @@ export function ActivityDetail({ id }) {
   return html`
     <div class="min-h-screen" style="background: var(--bg);">
       <${StickyHeader}
-        onBack=${() => navigate("/dashboard")}
+        onBack=${() => navigate(isDemo.value ? "/demo" : "/dashboard")}
         backLabel="Dashboard"
         contextLabel=${act.name}
         rightSlot=${!isDemo.value && html`

--- a/src/demo.js
+++ b/src/demo.js
@@ -26,7 +26,7 @@ export async function checkDemo() {
   // Without this, a logged-in user who previously visited /demo would get
   // demo data on every page load because the sessionStorage flag persists.
   const path = window.location.pathname.replace(/\.html$/, "").replace(/^\//, "") || "";
-  if (path !== "demo") {
+  if (path !== "demo" && path !== "activity") {
     sessionStorage.removeItem("aeyu_demo_active");
     return;
   }


### PR DESCRIPTION
## Summary
- Fixed the router so that navigating to `/activity?id=...` while in demo mode renders the activity detail instead of exiting demo and redirecting to the landing page
- Updated ActivityDetail back buttons to navigate to `/demo` instead of `/dashboard` when in demo mode
- Updated `checkDemo()` to preserve demo session on the `/activity` route (not just `/demo`)

## Root cause
The `App()` function had a guard that exited demo mode whenever `currentRoute !== "demo"`. Clicking any ride navigated to `/activity?id=...`, which triggered `exitDemo()` → cleared auth → showed the landing page.

## Test plan
- [ ] Go to aeyu.io/demo, wait for demo to load
- [ ] Click any ride in the activity list
- [ ] Verify the activity detail page loads with awards
- [ ] Click back button — verify it returns to `/demo` dashboard
- [ ] Refresh page on activity detail — verify demo session persists
- [ ] Navigate to `/` from demo — verify demo exits cleanly

https://claude.ai/code/session_01XQtcWgQ9rLbe5WAgGqtDAT