### PR TITLE
Fix segment chart stretching on wide screens

### DIFF
--- a/src/components/SegmentSparkline.js
+++ b/src/components/SegmentSparkline.js
@@ -151,13 +151,12 @@ export function SegmentSparkline({ segment, currentEffortId }) {
   const finalTooltipY = (overlapAbove && fitsBelow) ? belowY : aboveY;
 
   return html`
-    <div style="margin-top: 6px;">
+    <div style="margin-top: 6px; max-width: 480px;">
       <svg
         ref=${svgRef}
         width="100%"
-        height=${h}
         viewBox="0 0 ${w} ${h}"
-        preserveAspectRatio="none"
+        preserveAspectRatio="xMidYMid meet"
         style="display: block; background: var(--bg, #faf9f7); border: 1px solid var(--border); border-radius: 6px; touch-action: none; cursor: crosshair;"
         onTouchStart=${onTouchStart}
         onTouchMove=${onTouchMove}


### PR DESCRIPTION
## Summary
- Cap segment sparkline container to `max-width: 480px` so charts don't stretch across full-width desktop layouts
- Change `preserveAspectRatio` from `"none"` to `"xMidYMid meet"` so the SVG scales uniformly instead of distorting
- Remove fixed `height` attribute (now derived from viewBox aspect ratio)

## Test plan
- [ ] Open an activity detail page with segment efforts on a wide desktop browser
- [ ] Verify the sparkline chart maintains its proportions and doesn't stretch horizontally
- [ ] Verify tooltips and hover/touch interactions still work correctly
- [ ] Check mobile layout is unaffected (container was already narrower than 480px)

https://claude.ai/code/session_018vUEsnZaFRG8t4fBrULLk7