### PR TITLE
Add loading overlay for smoother startup

### DIFF
--- a/activity.html
+++ b/activity.html
@@ -54,11 +54,16 @@
     <link rel="stylesheet" href="/app.css">
 </head>
 <body style="background: var(--bg); color: var(--text);">
-    <div id="app">
-        <div class="min-h-screen flex items-center justify-center">
-            <p style="color: var(--text-tertiary);">Loading...</p>
+    <div id="loading-overlay" style="position:fixed;inset:0;z-index:9999;background:var(--bg,#F6F3EE);display:flex;align-items:center;justify-content:center;transition:opacity 0.3s ease;">
+      <div style="text-align:center;">
+        <div style="font-family:'Instrument Serif',serif;font-size:1.5rem;color:var(--text,#1A1610);margin-bottom:0.5rem;">aeyu.io</div>
+        <div style="width:48px;height:3px;background:var(--border,#E5DFD4);border-radius:2px;margin:0 auto;overflow:hidden;">
+          <div style="width:40%;height:100%;background:var(--strava,#FC4C02);border-radius:2px;animation:loading-slide 1.2s ease-in-out infinite;"></div>
         </div>
+      </div>
     </div>
+    <style>@keyframes loading-slide{0%{transform:translateX(-100%)}50%{transform:translateX(150%)}100%{transform:translateX(-100%)}}</style>
+    <div id="app"></div>
     <script type="module" src="./src/app.js"></script>
     <script>
       // Register service worker
@@ -70,6 +75,13 @@
       // instead of silently failing with "Loading..." stuck on screen.
       window.__appModuleLoaded = false;
       window.__appRendered = false;
+
+      window.dismissLoadingOverlay = function() {
+        var overlay = document.getElementById("loading-overlay");
+        if (!overlay) return;
+        overlay.style.opacity = "0";
+        setTimeout(function() { overlay.remove(); }, 300);
+      };
 
       window.onerror = function(msg, url, line, col, error) {
         console.error("Global error:", msg, url, line, col, error);
@@ -104,6 +116,8 @@
       function showLoadError(detail) {
         // Don't overwrite if app has successfully rendered
         if (window.__appRendered) return;
+        var overlay = document.getElementById("loading-overlay");
+        if (overlay) overlay.remove();
         var app = document.getElementById("app");
         if (!app) return;
         app.innerHTML =

--- a/dashboard.html
+++ b/dashboard.html
@@ -54,11 +54,16 @@
     <link rel="stylesheet" href="/app.css">
 </head>
 <body style="background: var(--bg); color: var(--text);">
-    <div id="app">
-        <div class="min-h-screen flex items-center justify-center">
-            <p style="color: var(--text-tertiary);">Loading...</p>
+    <div id="loading-overlay" style="position:fixed;inset:0;z-index:9999;background:var(--bg,#F6F3EE);display:flex;align-items:center;justify-content:center;transition:opacity 0.3s ease;">
+      <div style="text-align:center;">
+        <div style="font-family:'Instrument Serif',serif;font-size:1.5rem;color:var(--text,#1A1610);margin-bottom:0.5rem;">aeyu.io</div>
+        <div style="width:48px;height:3px;background:var(--border,#E5DFD4);border-radius:2px;margin:0 auto;overflow:hidden;">
+          <div style="width:40%;height:100%;background:var(--strava,#FC4C02);border-radius:2px;animation:loading-slide 1.2s ease-in-out infinite;"></div>
         </div>
+      </div>
     </div>
+    <style>@keyframes loading-slide{0%{transform:translateX(-100%)}50%{transform:translateX(150%)}100%{transform:translateX(-100%)}}</style>
+    <div id="app"></div>
     <script type="module" src="./src/app.js"></script>
     <script>
       // Register service worker
@@ -70,6 +75,13 @@
       // instead of silently failing with "Loading..." stuck on screen.
       window.__appModuleLoaded = false;
       window.__appRendered = false;
+
+      window.dismissLoadingOverlay = function() {
+        var overlay = document.getElementById("loading-overlay");
+        if (!overlay) return;
+        overlay.style.opacity = "0";
+        setTimeout(function() { overlay.remove(); }, 300);
+      };
 
       window.onerror = function(msg, url, line, col, error) {
         console.error("Global error:", msg, url, line, col, error);
@@ -104,6 +116,8 @@
       function showLoadError(detail) {
         // Don't overwrite if app has successfully rendered
         if (window.__appRendered) return;
+        var overlay = document.getElementById("loading-overlay");
+        if (overlay) overlay.remove();
         var app = document.getElementById("app");
         if (!app) return;
         app.innerHTML =

--- a/demo.html
+++ b/demo.html
@@ -54,11 +54,16 @@
     <link rel="stylesheet" href="/app.css">
 </head>
 <body style="background: var(--bg); color: var(--text);">
-    <div id="app">
-        <div class="min-h-screen flex items-center justify-center">
-            <p style="color: var(--text-tertiary);">Loading...</p>
+    <div id="loading-overlay" style="position:fixed;inset:0;z-index:9999;background:var(--bg,#F6F3EE);display:flex;align-items:center;justify-content:center;transition:opacity 0.3s ease;">
+      <div style="text-align:center;">
+        <div style="font-family:'Instrument Serif',serif;font-size:1.5rem;color:var(--text,#1A1610);margin-bottom:0.5rem;">aeyu.io</div>
+        <div style="width:48px;height:3px;background:var(--border,#E5DFD4);border-radius:2px;margin:0 auto;overflow:hidden;">
+          <div style="width:40%;height:100%;background:var(--strava,#FC4C02);border-radius:2px;animation:loading-slide 1.2s ease-in-out infinite;"></div>
         </div>
+      </div>
     </div>
+    <style>@keyframes loading-slide{0%{transform:translateX(-100%)}50%{transform:translateX(150%)}100%{transform:translateX(-100%)}}</style>
+    <div id="app"></div>
     <script type="module" src="./src/app.js"></script>
     <script>
       // Register service worker
@@ -70,6 +75,13 @@
       // instead of silently failing with "Loading..." stuck on screen.
       window.__appModuleLoaded = false;
       window.__appRendered = false;
+
+      window.dismissLoadingOverlay = function() {
+        var overlay = document.getElementById("loading-overlay");
+        if (!overlay) return;
+        overlay.style.opacity = "0";
+        setTimeout(function() { overlay.remove(); }, 300);
+      };
 
       window.onerror = function(msg, url, line, col, error) {
         console.error("Global error:", msg, url, line, col, error);
@@ -104,6 +116,8 @@
       function showLoadError(detail) {
         // Don't overwrite if app has successfully rendered
         if (window.__appRendered) return;
+        var overlay = document.getElementById("loading-overlay");
+        if (overlay) overlay.remove();
         var app = document.getElementById("app");
         if (!app) return;
         app.innerHTML =

--- a/index.html
+++ b/index.html
@@ -54,11 +54,16 @@
     <link rel="stylesheet" href="/app.css">
 </head>
 <body style="background: var(--bg); color: var(--text);">
-    <div id="app">
-        <div class="min-h-screen flex items-center justify-center">
-            <p style="color: var(--text-tertiary);">Loading...</p>
+    <div id="loading-overlay" style="position:fixed;inset:0;z-index:9999;background:var(--bg,#F6F3EE);display:flex;align-items:center;justify-content:center;transition:opacity 0.3s ease;">
+      <div style="text-align:center;">
+        <div style="font-family:'Instrument Serif',serif;font-size:1.5rem;color:var(--text,#1A1610);margin-bottom:0.5rem;">aeyu.io</div>
+        <div style="width:48px;height:3px;background:var(--border,#E5DFD4);border-radius:2px;margin:0 auto;overflow:hidden;">
+          <div style="width:40%;height:100%;background:var(--strava,#FC4C02);border-radius:2px;animation:loading-slide 1.2s ease-in-out infinite;"></div>
         </div>
+      </div>
     </div>
+    <style>@keyframes loading-slide{0%{transform:translateX(-100%)}50%{transform:translateX(150%)}100%{transform:translateX(-100%)}}</style>
+    <div id="app"></div>
     <script type="module" src="./src/app.js"></script>
     <script>
       // Register service worker
@@ -70,6 +75,13 @@
       // instead of silently failing with "Loading..." stuck on screen.
       window.__appModuleLoaded = false;
       window.__appRendered = false;
+
+      window.dismissLoadingOverlay = function() {
+        var overlay = document.getElementById("loading-overlay");
+        if (!overlay) return;
+        overlay.style.opacity = "0";
+        setTimeout(function() { overlay.remove(); }, 300);
+      };
 
       window.onerror = function(msg, url, line, col, error) {
         console.error("Global error:", msg, url, line, col, error);
@@ -104,6 +116,8 @@
       function showLoadError(detail) {
         // Don't overwrite if app has successfully rendered
         if (window.__appRendered) return;
+        var overlay = document.getElementById("loading-overlay");
+        if (overlay) overlay.remove();
         var app = document.getElementById("app");
         if (!app) return;
         app.innerHTML =

--- a/src/app.js
+++ b/src/app.js
@@ -114,6 +114,7 @@ function App() {
   // /demo is always accessible — start demo if needed
   if (currentRoute === "demo") {
     if (demoError.value) {
+      if (window.dismissLoadingOverlay) window.dismissLoadingOverlay();
       return html`<div class="min-h-screen flex flex-col items-center justify-center gap-4 px-4 text-center">
         <p style="color: var(--text-secondary); font-family: var(--font-body);">
           Failed to load demo.

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -139,6 +139,7 @@ async function loadActivity(id) {
     }
   } finally {
     loading.value = false;
+    if (window.dismissLoadingOverlay) window.dismissLoadingOverlay();
   }
 }
 

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -229,6 +229,7 @@ async function loadDashboard() {
     }
   } finally {
     loading.value = false;
+    if (window.dismissLoadingOverlay) window.dismissLoadingOverlay();
   }
 }
 

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -65,6 +65,7 @@ function AwardPill({ type, label }) {
 }
 
 export function Landing() {
+  if (window.dismissLoadingOverlay) window.dismissLoadingOverlay();
   return html`
     <div class="min-h-screen" style="background: var(--bg);">
       <!-- Hero -->


### PR DESCRIPTION
## Summary

- Replaces the plain "Loading..." text with a branded loading overlay that covers the full page until data is ready
- Overlay shows the aeyu.io wordmark and an animated Strava-orange progress bar, then fades out with a 300ms transition
- Each page type dismisses at the right moment: Landing immediately, Dashboard after `loadDashboard()`, ActivityDetail after `loadActivity()`, demo error on render

## How it works

A `#loading-overlay` div with `position:fixed; z-index:9999` sits on top of `#app` in all HTML entry points. A global `dismissLoadingOverlay()` function fades it out and removes it from the DOM. Components call this when their data is loaded, so the user sees a polished loading screen → fully populated UI with no intermediate empty-shell flash.

## Test plan

- [ ] Visit `/` (unauthenticated) — overlay appears briefly, Landing renders without flash
- [ ] Visit `/dashboard` (authenticated) — overlay stays until activities/awards load, then fades out
- [ ] Visit `/activity?id=...` — overlay stays until activity data loads
- [ ] Visit `/demo` — overlay stays through demo data injection until Dashboard renders
- [ ] Trigger a load error (e.g. delete vendor file) — overlay is removed and error screen shows
- [ ] Subsequent navigation (e.g. click activity from dashboard) — no overlay (already removed)

https://claude.ai/code/session_01YVGUMMMvi3fAmb6q1SpGn6