### PR TITLE
Fix avatar menu on activity detail page

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -14,6 +14,8 @@ import { resyncActivity } from "../sync.js";
 import { isDemo } from "../demo.js";
 import { navigate } from "../app.js";
 import {
+  unitSystem,
+  setUnitPreference,
   formatDistance,
   formatTime,
   formatDate,
@@ -1212,6 +1214,23 @@ export function ActivityDetail({ id }) {
         onBack=${() => navigate(isDemo.value ? "/demo" : "/dashboard")}
         backLabel="Dashboard"
         contextLabel=${act.name}
+        unitSystem=${unitSystem.value}
+        onUnitToggle=${async () => {
+          const next = unitSystem.value === "metric" ? "imperial" : "metric";
+          await setUnitPreference(next);
+          await loadActivity(id);
+        }}
+        menuItems=${[
+          ...(!isDemo.value ? [{
+            label: resyncing.value ? "Resyncing…" : "Resync activity",
+            onClick: handleResync,
+            hidden: resyncing.value,
+          }] : []),
+          {
+            label: "View on Strava",
+            onClick: () => window.open(`https://www.strava.com/activities/${act.id}`, "_blank"),
+          },
+        ]}
         rightSlot=${!isDemo.value && html`
           <button
             onClick=${handleResync}


### PR DESCRIPTION
## Summary
- The avatar in the activity detail header was clickable but opened an empty dropdown (just athlete name, no actions)
- Now includes the **unit toggle** (km/mi) matching the dashboard menu
- Adds context-appropriate menu items: **Resync activity** and **View on Strava**
- Unit toggle reloads the activity so formatted values update immediately

## Test plan
- [ ] Open an activity detail page, click the avatar — verify dropdown shows Units toggle, Resync activity, and View on Strava
- [ ] Toggle units — verify distance/elevation/speed values update
- [ ] Click "View on Strava" — verify it opens the correct Strava activity URL
- [ ] In demo mode, verify Resync is hidden and View on Strava still works

https://claude.ai/code/session_01NJLTpN2SxepxT4BuSu2PK2