### PR TITLE
Widen group ride time matching to ±90min for seasonal shifts

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -2088,7 +2088,7 @@ export function computeWeeklyStreaks(allActivities) {
 /**
  * Detect recurring group rides by clustering activities by:
  *   - Day of week
- *   - Similar start time (±1hr)
+ *   - Similar start time (±90min)
  *   - Similar start location (within 1km)
  *   - Activity name patterns
  *
@@ -2125,9 +2125,9 @@ export function detectGroupRides(allActivities, routes = []) {
 
       let matched = false;
       for (const cluster of clusters) {
-        // Check time proximity (within 60 min)
+        // Check time proximity (within 90 min to accommodate seasonal start time shifts)
         const timeDiff = Math.abs(cluster.avgMinute - minuteOfDay);
-        if (timeDiff > 60) continue;
+        if (timeDiff > 90) continue;
 
         // Check location proximity (within 1km) if both have coords
         if (cluster.latlng && latlng) {


### PR DESCRIPTION
## Summary
- Widened group ride time clustering window from ±60min to ±90min in `detectGroupRides()`
- Fixes rides like the G2 group ride being missed when seasonal start times shift (5:30-6:30 PM with sunset changes)
- ±90min is still narrow enough to keep morning/afternoon rides distinct (typically 4+ hours apart)

## Test plan
- [ ] Verify G2 group ride now matches rides across the full 5:30-6:30 PM seasonal range
- [ ] Confirm morning and afternoon rides on the same day of week remain separate clusters
- [ ] Check that existing group ride detection isn't disrupted (same clusters, just more inclusive)

https://claude.ai/code/session_011JXMQYBTJnDfkLALa91QDd