### PR TITLE
Add route search via clickable chips in search bar

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -97,6 +97,7 @@ const exportFormat = signal("markdown");
 const exportStatus = signal(null); // null | "loading" | "copied" | "error"
 const activeChartHelp = signal(null);
 const disabledAwardTypes = signal(new Set());
+const dashboardRoutes = signal([]);
 const settingsTransferStatus = signal(null); // null | "exported" | "imported" | "error"
 
 function ChartHelp({ id, children }) {
@@ -166,6 +167,7 @@ async function loadDashboard() {
     // Compute streak data (#58) — uses all activities, not just recent 20
     if (activities.length > 0) {
       const routes = await getAllRoutes();
+      dashboardRoutes.value = routes;
       streakData.value = computeStreakData(activities, routes);
     }
 
@@ -364,6 +366,34 @@ export function Dashboard() {
                 </button>
               `}
             </div>
+            ${dashboardRoutes.value.length > 0 && (() => {
+              const q = searchQuery.value.trim().toLowerCase();
+              const filtered = dashboardRoutes.value
+                .filter(r => !q || r.name.toLowerCase().includes(q))
+                .sort((a, b) => b.frequency - a.frequency)
+                .slice(0, 8);
+              if (filtered.length === 0) return null;
+              return html`
+                <div class="flex flex-wrap gap-2 mt-2">
+                  <span style="font-family: var(--font-body); font-size: 0.6875rem; color: rgba(255,255,255,0.5); align-self: center;">Routes</span>
+                  ${filtered.map(r => {
+                    const isActive = groupFilterIds.value && searchQuery.value === r.name;
+                    return html`
+                      <button
+                        onClick=${() => {
+                          groupFilterIds.value = new Set(r.activityIds);
+                          searchQuery.value = r.name;
+                        }}
+                        class="text-xs px-3 py-1 rounded-full"
+                        style="background: rgba(255,255,255,${isActive ? "0.35" : "0.15"}); color: white; border: 1px solid rgba(255,255,255,${isActive ? "0.4" : "0.2"}); font-family: var(--font-body); cursor: pointer;"
+                      >
+                        ${r.name} <span style="opacity: 0.6;">(${r.frequency})</span>
+                      </button>
+                    `;
+                  })}
+                </div>
+              `;
+            })()}
           </div>
         </div>
       `}
@@ -868,6 +898,10 @@ export function Dashboard() {
                   if (al && al.label.toLowerCase().includes(query)) return true;
                   if (award.segment_name && award.segment_name.toLowerCase().includes(query)) return true;
                 }
+                // Search by route name
+                for (const route of dashboardRoutes.value) {
+                  if (route.name.toLowerCase().includes(query) && route.activityIds.includes(activity.id)) return true;
+                }
                 return false;
               })
             : sourceActivities;
@@ -1264,7 +1298,7 @@ export function Dashboard() {
                   <svg class="w-4 h-4 group-open:rotate-180 transition-transform flex-shrink-0 ml-2" style="color: var(--text-tertiary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
                 </summary>
                 <div class="pt-3 pb-1" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
-                  The app automatically detects recurring routes by comparing which segments appear on each ride. If two activities share 70%+ of their segments, they're considered the same route. This powers the Route Season First award — rather than listing a Season First for every segment on a familiar ride, it collapses them into a single route-level award.
+                  The app automatically detects recurring routes by comparing which segments appear on each ride. If two activities share 70%+ of their segments, they're considered the same route. This powers the Route Season First award — rather than listing a Season First for every segment on a familiar ride, it collapses them into a single route-level award. You can also find all rides for a route by opening search — detected routes appear as clickable chips below the search bar.
                 </div>
               </details>
 


### PR DESCRIPTION
## Summary
- When opening search, detected routes appear as clickable chips below the search input
- Clicking a route chip filters the activity list to all rides on that route (reuses the existing `groupFilterIds` pattern from group rides)
- Route names also work in free-text search — typing a route name matches activities belonging to that route
- Active chip gets a highlighted style for visual feedback
- FAQ entry updated to mention the route search feature

## Details
All changes in `src/components/Dashboard.js` only. Routes are already detected via segment fingerprinting and stored in IndexedDB — this just surfaces them in the search UI. Chips show route name and ride count, sorted by frequency, capped at 8.

## Test plan
- [ ] Open search — route chips should appear below the input
- [ ] Click a route chip — activity list filters to that route's rides with count
- [ ] Type a route name — chips filter and text search matches route activities
- [ ] Clear search / press Escape — returns to normal view
- [ ] Verify group ride click-to-filter still works
- [ ] Check demo mode shows route chips (demo data has recurring routes)

https://claude.ai/code/session_01XgRwkghpxtGSYAGNkTftcf