### PR TITLE
Fix awards missing on older search results

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -8,7 +8,7 @@
  */
 
 import { html } from "htm/preact";
-import { signal } from "@preact/signals";
+import { signal, effect } from "@preact/signals";
 import { useEffect } from "preact/hooks";
 import { authState, disconnect } from "../auth.js";
 import {
@@ -221,6 +221,34 @@ const exportStatus = signal(null); // null | "loading" | "copied" | "error"
 const activeChartHelp = signal(null);
 const disabledAwardTypes = signal(new Set());
 const settingsTransferStatus = signal(null); // null | "exported" | "imported" | "error"
+let searchAwardsTimer = null;
+effect(() => {
+  const query = searchQuery.value.trim().toLowerCase();
+  if (!query && !groupFilterIds.value) return;
+  clearTimeout(searchAwardsTimer);
+  searchAwardsTimer = setTimeout(async () => {
+    const all = allActivities.value;
+    if (!all.length) return;
+    const matched = groupFilterIds.value
+      ? all.filter((a) => groupFilterIds.value.has(a.id))
+      : all.filter((a) => {
+          if (a.name && a.name.toLowerCase().includes(query)) return true;
+          if (a.start_date_local && a.start_date_local.toLowerCase().includes(query)) return true;
+          try {
+            if (formatDateWeekday(a.start_date_local).toLowerCase().includes(query)) return true;
+          } catch (e) {}
+          return false;
+        });
+    const missing = matched.filter((a) => a.has_efforts && !activityAwards.value.has(a.id));
+    if (missing.length === 0) return;
+    const newAwards = await computeAwardsForActivities(missing, disabledAwardTypes.value);
+    const merged = new Map(activityAwards.value);
+    for (const [id, awards] of newAwards) {
+      merged.set(id, awards);
+    }
+    activityAwards.value = merged;
+  }, 300);
+});
 
 function ChartHelp({ id, children }) {
   const isOpen = activeChartHelp.value === id;
@@ -394,10 +422,12 @@ export function Dashboard() {
   async function handleUnitToggle() {
     const next = units === "metric" ? "imperial" : "metric";
     await setUnitPreference(next);
-    // Recompute awards to update formatted messages
-    const withEfforts = recentActivities.value.filter((a) => a.has_efforts);
-    if (withEfforts.length > 0) {
-      const awards = await computeAwardsForActivities(withEfforts, disabledAwardTypes.value);
+    // Recompute awards to update formatted messages for all computed activities
+    const computedIds = [...activityAwards.value.keys()];
+    const allActs = allActivities.value;
+    const toRecompute = allActs.filter((a) => a.has_efforts && computedIds.includes(a.id));
+    if (toRecompute.length > 0) {
+      const awards = await computeAwardsForActivities(toRecompute, disabledAwardTypes.value);
       activityAwards.value = awards;
     }
   }


### PR DESCRIPTION
## Summary
- Awards were only computed for the 20 most recent activities, so older activities found via search (e.g. searching "G2" returning 49 rides) showed no award pills
- Added a debounced `effect` that watches `searchQuery`/`groupFilterIds` and computes awards on-demand for any matched activities missing from the `activityAwards` map, merging results incrementally
- Also fixed `handleUnitToggle` to recompute awards for all previously computed activities (not just recent 20), preventing loss of search-computed awards on unit switch

Fixes #208

## Test plan
- [ ] Search for a term that matches older activities (beyond the 20 most recent) — verify award pills appear after a brief delay
- [ ] Verify the 20 most recent activities still show awards immediately on load
- [ ] Toggle units while search results are showing — verify awards persist
- [ ] Use group ride filter — verify awards appear for older grouped activities

https://claude.ai/code/session_01BR5Ek2LErsuRPeRLehDJ3t