### PR TITLE
Fix zoomed-in viewport on iOS app restore

### DIFF
--- a/activity.html
+++ b/activity.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
     <title>aeyu.io — Participation Awards</title>
     <meta name="description" content="Giving recognition for efforts where effort was given">
 

--- a/callback.html
+++ b/callback.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
     <title>aeyu.io — Connecting...</title>
 
     <!-- PWA -->

--- a/dashboard.html
+++ b/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
     <title>aeyu.io — Participation Awards</title>
     <meta name="description" content="Giving recognition for efforts where effort was given">
 

--- a/demo.html
+++ b/demo.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
     <title>aeyu.io — Participation Awards</title>
     <meta name="description" content="Giving recognition for efforts where effort was given">
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
     <title>aeyu.io — Participation Awards</title>
     <meta name="description" content="Giving recognition for efforts where effort was given">
 


### PR DESCRIPTION
## Summary
- Adds `maximum-scale=1.0` to the viewport meta tag on all 5 HTML pages
- Fixes iOS Safari bug where restoring a backgrounded tab retains a slightly zoomed state, causing content to bleed off the left/right edges

## Test plan
- [ ] Open the app on iOS Safari
- [ ] Switch to another app, then switch back — verify content is not zoomed/bleeding
- [ ] Verify pinch-to-zoom is disabled (expected tradeoff for a PWA)
- [ ] Check that form inputs don't trigger unwanted zoom (font-size >= 16px)

https://claude.ai/code/session_01HW5XRPZwD6EAzi9Y9LT1pV