### PR TITLE
Route-first clustering: seed from Strava routes, hybrid similarity

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -342,14 +342,16 @@ function renderRouteTrendChart(route) {
       `)}
       <path d="${spdPath}" fill="none" stroke="${spdColor}" stroke-width="1.5" stroke-linejoin="round" />
       ${speeds.map((s, i) => html`
-        <circle cx="${xPos(i)}" cy="${ySpd(s)}" r="${i === speeds.length - 1 ? 3 : 1.5}" fill="${spdColor}">
+        <circle cx="${xPos(i)}" cy="${ySpd(s)}" r="${i === speeds.length - 1 ? 3 : 1.5}" fill="${spdColor}"
+          style="cursor: pointer;" onclick=${() => { location.hash = '#/activity/' + rides[i].id; }}>
           <title>${new Date(rides[i].date).toLocaleDateString()}: ${s.toFixed(1)} ${speedUnit}</title>
         </circle>
       `)}
       ${powPathD && html`
         <path d="${powPathD}" fill="none" stroke="${powColor}" stroke-width="1.5" stroke-linejoin="round" stroke-dasharray="4,2" />
         ${rides.map((r, i) => r.average_watts ? html`
-          <circle cx="${xPos(i)}" cy="${yPow(powers[i])}" r="${i === rides.length - 1 ? 3 : 1.5}" fill="${powColor}">
+          <circle cx="${xPos(i)}" cy="${yPow(powers[i])}" r="${i === rides.length - 1 ? 3 : 1.5}" fill="${powColor}"
+            style="cursor: pointer;" onclick=${() => { location.hash = '#/activity/' + rides[i].id; }}>
             <title>${new Date(r.date).toLocaleDateString()}: ${Math.round(r.average_watts)}W</title>
           </circle>
         ` : null)}
@@ -426,7 +428,8 @@ function renderGroupRideTrendChart(group) {
       <!-- Speed line -->
       <path d="${spdPath}" fill="none" stroke="#4882A8" stroke-width="1.5" stroke-linejoin="round" />
       ${speeds.map((s, i) => html`
-        <circle cx="${xPos(i)}" cy="${ySpd(s)}" r="${i === speeds.length - 1 ? 3 : 1.5}" fill="#4882A8">
+        <circle cx="${xPos(i)}" cy="${ySpd(s)}" r="${i === speeds.length - 1 ? 3 : 1.5}" fill="#4882A8"
+          style="cursor: pointer;" onclick=${() => { location.hash = '#/activity/' + rides[i].id; }}>
           <title>${new Date(rides[i].date).toLocaleDateString()}: ${s.toFixed(1)} ${speedUnit}</title>
         </circle>
       `)}
@@ -434,7 +437,8 @@ function renderGroupRideTrendChart(group) {
       ${powPathD && html`
         <path d="${powPathD}" fill="none" stroke="#A05060" stroke-width="1.5" stroke-linejoin="round" stroke-dasharray="4,2" />
         ${rides.map((r, i) => r.average_watts ? html`
-          <circle cx="${xPos(i)}" cy="${yPow(powers[i])}" r="${i === rides.length - 1 ? 3 : 1.5}" fill="#A05060">
+          <circle cx="${xPos(i)}" cy="${yPow(powers[i])}" r="${i === rides.length - 1 ? 3 : 1.5}" fill="#A05060"
+            style="cursor: pointer;" onclick=${() => { location.hash = '#/activity/' + rides[i].id; }}>
             <title>${new Date(r.date).toLocaleDateString()}: ${Math.round(r.average_watts)}W</title>
           </circle>
         ` : null)}
@@ -471,7 +475,8 @@ function renderSpeedOnlyChart(rides, speeds, speedUnit, padSpd, pSpdRange) {
       `)}
       <path d="${spdPath}" fill="none" stroke="#4882A8" stroke-width="1.5" stroke-linejoin="round" />
       ${speeds.map((s, i) => html`
-        <circle cx="${xPos(i)}" cy="${ySpd(s)}" r="${i === speeds.length - 1 ? 3 : 1.5}" fill="#4882A8">
+        <circle cx="${xPos(i)}" cy="${ySpd(s)}" r="${i === speeds.length - 1 ? 3 : 1.5}" fill="#4882A8"
+          style="cursor: pointer;" onclick=${() => { location.hash = '#/activity/' + rides[i].id; }}>
           <title>${new Date(rides[i].date).toLocaleDateString()}: ${s.toFixed(1)} ${speedUnit}</title>
         </circle>
       `)}
@@ -756,21 +761,32 @@ export function Dashboard() {
                   ${filtered.map(r => {
                     const isActive = groupFilterIds.value && searchQuery.value === r.name;
                     return html`
-                      <button
-                        onClick=${() => {
-                          if (isActive) {
-                            groupFilterIds.value = null;
-                            searchQuery.value = "";
-                          } else {
-                            groupFilterIds.value = new Set(r.activityIds);
-                            searchQuery.value = r.name;
-                          }
-                        }}
-                        class="text-xs px-3 py-1 rounded-full"
-                        style="background: rgba(255,255,255,${isActive ? "0.35" : "0.15"}); color: white; border: 1px solid rgba(255,255,255,${isActive ? "0.4" : "0.2"}); font-family: var(--font-body); cursor: pointer;"
-                      >
-                        ${r.name} <span style="opacity: 0.6;">(${r.frequency})</span>
-                      </button>
+                      <span class="inline-flex items-center rounded-full" style="background: rgba(255,255,255,${isActive ? "0.35" : "0.15"}); border: 1px solid rgba(255,255,255,${isActive ? "0.4" : "0.2"});">
+                        <button
+                          onClick=${() => {
+                            if (isActive) {
+                              groupFilterIds.value = null;
+                              searchQuery.value = "";
+                            } else {
+                              groupFilterIds.value = new Set(r.activityIds);
+                              searchQuery.value = r.name;
+                            }
+                          }}
+                          class="text-xs px-3 py-1"
+                          style="color: white; font-family: var(--font-body); cursor: pointer; background: none; border: none;"
+                        >
+                          ${r.name} <span style="opacity: 0.6;">(${r.frequency})</span>
+                        </button>
+                        ${r.strava_id && html`
+                          <a href="https://www.strava.com/routes/${r.strava_id}" target="_blank" rel="noopener"
+                            onClick=${(e) => e.stopPropagation()}
+                            class="pr-2" style="color: rgba(255,255,255,0.5); display: flex; align-items: center;"
+                            title="View on Strava"
+                          >
+                            <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                          </a>
+                        `}
+                      </span>
                     `;
                   })}
                 </div>
@@ -1324,7 +1340,10 @@ export function Dashboard() {
             ? (() => {
                 const withEfforts = displayActivities.filter(a => a.has_efforts);
                 if (withEfforts.length < 4) return [];
-                const clusters = detectRoutes(withEfforts);
+                const stravaForClustering = dashboardRoutes.value
+                  .filter(r => r.strava_id)
+                  .map(r => ({ strava_id: r.strava_id, name: r.name, segments: r.segments }));
+                const clusters = detectRoutes(withEfforts, stravaForClustering);
                 return clusters
                   .filter(c => c.activityIds.length >= 2)
                   .sort((a, b) => b.frequency - a.frequency)

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,28 +1,29 @@
 /**
  * Route Detection via Segment Fingerprinting (#59)
  *
- * Groups activities into "routes" by comparing their segment ID sets
- * using Jaccard similarity. Activities sharing ≥70% of their segments
- * are considered the same route.
+ * Two-phase algorithm:
+ * 1. Seed routes from Strava-saved routes (fixed fingerprints)
+ * 2. Assign activities via hybrid similarity (Jaccard OR containment)
  *
- * When Strava-saved routes are available, their names take priority over
- * the most-frequent-activity-name heuristic.
- *
- * Excludes activities with fewer than 2 segments (too few to fingerprint).
+ * Strava-seeded routes keep their segment fingerprint fixed.
+ * Discovered routes grow by union (capped at 2x initial size).
  */
 
 /** Minimum Jaccard similarity to consider two activities the same route */
 const JACCARD_THRESHOLD = 0.7;
 
+/** Minimum containment to match (fraction of route's segments present in activity) */
+const CONTAINMENT_THRESHOLD = 0.8;
+
 /** Minimum segments an activity must have to participate in route detection */
 const MIN_SEGMENTS_FOR_ROUTE = 2;
+
+/** Max growth factor for discovered route segment sets */
+const MAX_GROWTH_FACTOR = 2;
 
 /**
  * Compute Jaccard similarity between two sets.
  * J(A,B) = |A ∩ B| / |A ∪ B|
- * @param {Set} a
- * @param {Set} b
- * @returns {number} 0–1
  */
 function jaccard(a, b) {
   if (a.size === 0 && b.size === 0) return 1;
@@ -35,9 +36,33 @@ function jaccard(a, b) {
 }
 
 /**
+ * Compute containment of route in activity.
+ * What fraction of the route's segments appear in the activity?
+ * containment(activity, route) = |A ∩ R| / |R|
+ */
+function containment(activitySet, routeSet) {
+  if (routeSet.size === 0) return 0;
+  let intersection = 0;
+  for (const item of routeSet) {
+    if (activitySet.has(item)) intersection++;
+  }
+  return intersection / routeSet.size;
+}
+
+/**
+ * Check if activity matches route using hybrid similarity:
+ * match if Jaccard >= threshold OR containment >= threshold.
+ * Returns the better of the two scores for ranking.
+ */
+function hybridSimilarity(activitySet, routeSet) {
+  const j = jaccard(activitySet, routeSet);
+  const c = containment(activitySet, routeSet);
+  const matches = j >= JACCARD_THRESHOLD || c >= CONTAINMENT_THRESHOLD;
+  return { matches, score: Math.max(j, c) };
+}
+
+/**
  * Extract segment ID set from an activity.
- * @param {Object} activity
- * @returns {Set<number>} segment IDs
  */
 function segmentIds(activity) {
   if (!activity.segment_efforts || activity.segment_efforts.length < MIN_SEGMENTS_FOR_ROUTE) {
@@ -47,90 +72,89 @@ function segmentIds(activity) {
 }
 
 /**
- * Try to match a detected cluster's segment set against Strava-saved routes.
- * Returns the Strava route name if any saved route has Jaccard ≥ threshold
- * with the cluster's segments, otherwise null.
- */
-function matchStravaRoute(clusterSegments, stravaRoutes) {
-  if (!stravaRoutes || stravaRoutes.length === 0) return null;
-
-  let best = null;
-  let bestSim = 0;
-
-  for (const sr of stravaRoutes) {
-    if (!sr.segments || sr.segments.length === 0) continue;
-    const srSet = new Set(sr.segments);
-    const sim = jaccard(clusterSegments, srSet);
-    if (sim >= JACCARD_THRESHOLD && sim > bestSim) {
-      bestSim = sim;
-      best = sr;
-    }
-  }
-
-  return best;
-}
-
-/**
- * Detect routes from a list of activities by clustering on segment fingerprints.
+ * Detect routes from activities by clustering on segment fingerprints.
  *
- * Algorithm: greedy single-pass clustering.
- * For each activity, compare its segment set against existing route fingerprints.
- * If Jaccard ≥ threshold with a route, merge into that route (union the fingerprint).
- * Otherwise, create a new route.
+ * Phase 1: Seed from Strava-saved routes (fixed fingerprints)
+ * Phase 2: Assign activities (Strava-seeded first, then discovered)
+ * Phase 3: Finalize names and filter
  *
  * @param {Array} activities — All activities (must have segment_efforts populated)
- * @param {Array} [stravaRoutes=[]] — Strava-saved routes with { name, segments: [id,...] }
- * @returns {Array<{ id: number, segments: number[], activityIds: number[], name: string, frequency: number, strava_route_name: string|null }>}
+ * @param {Array} [stravaRoutes=[]] — Strava-saved routes with { name, segments: [id,...], strava_id }
+ * @returns {Array<{ id: number, segments: number[], activityIds: number[], name: string, strava_route_name: string|null, strava_id: number|null, frequency: number }>}
  */
 export function detectRoutes(activities, stravaRoutes = []) {
-  const routes = []; // { segments: Set, activityIds: [], names: Map<string, count> }
+  // Phase 1: Seed from Strava routes
+  const routes = [];
+  for (const sr of stravaRoutes) {
+    if (!sr.segments || sr.segments.length === 0) continue;
+    routes.push({
+      segments: new Set(sr.segments),
+      initialSize: sr.segments.length,
+      activityIds: [],
+      names: new Map(),
+      isStravaSeeded: true,
+      strava_id: sr.strava_id || sr.id || null,
+      strava_name: sr.name || null,
+    });
+  }
 
-  for (const activity of activities) {
+  // Phase 2: Assign activities (oldest-first for stable cluster formation)
+  const sorted = [...activities].sort((a, b) =>
+    (a.start_date_local || "").localeCompare(b.start_date_local || "")
+  );
+
+  for (const activity of sorted) {
     const ids = segmentIds(activity);
     if (ids.size === 0) continue;
 
     let matched = null;
-    let bestSimilarity = 0;
+    let bestScore = 0;
 
+    // Check Strava-seeded routes first, then discovered
     for (const route of routes) {
-      const sim = jaccard(ids, route.segments);
-      if (sim >= JACCARD_THRESHOLD && sim > bestSimilarity) {
-        bestSimilarity = sim;
+      const { matches, score } = hybridSimilarity(ids, route.segments);
+      if (matches && score > bestScore) {
+        bestScore = score;
         matched = route;
       }
     }
 
     if (matched) {
-      // Merge: add activity, union segments
       matched.activityIds.push(activity.id);
-      for (const id of ids) matched.segments.add(id);
       const name = activity.name || "";
       matched.names.set(name, (matched.names.get(name) || 0) + 1);
+      // Discovered routes grow by union (capped); Strava-seeded stay fixed
+      if (!matched.isStravaSeeded && matched.segments.size < matched.initialSize * MAX_GROWTH_FACTOR) {
+        for (const id of ids) matched.segments.add(id);
+      }
     } else {
-      // New route
+      // New discovered route
       const name = activity.name || "";
       const names = new Map();
       names.set(name, 1);
       routes.push({
         segments: new Set(ids),
+        initialSize: ids.size,
         activityIds: [activity.id],
         names,
+        isStravaSeeded: false,
+        strava_id: null,
+        strava_name: null,
       });
     }
   }
 
-  // Only keep routes with 2+ activities (a single activity isn't really a "route")
-  const meaningful = routes.filter((r) => r.activityIds.length >= 2);
+  // Phase 3: Filter and finalize
+  // Strava-seeded routes: keep with 1+ activities
+  // Discovered routes: keep with 2+ activities
+  const meaningful = routes.filter((r) =>
+    r.isStravaSeeded ? r.activityIds.length >= 1 : r.activityIds.length >= 2
+  );
 
-  // Finalize: pick best name, assign IDs
   return meaningful.map((r, i) => {
-    // Check if a Strava-saved route matches this cluster
-    const stravaMatch = matchStravaRoute(r.segments, stravaRoutes);
-
-    // Strava route name wins; fall back to most-frequent activity name
     let bestName;
-    if (stravaMatch) {
-      bestName = stravaMatch.name;
+    if (r.isStravaSeeded && r.strava_name) {
+      bestName = r.strava_name;
     } else {
       bestName = "";
       let bestCount = 0;
@@ -147,7 +171,8 @@ export function detectRoutes(activities, stravaRoutes = []) {
       segments: [...r.segments],
       activityIds: r.activityIds,
       name: bestName,
-      strava_route_name: stravaMatch ? stravaMatch.name : null,
+      strava_route_name: r.strava_name || null,
+      strava_id: r.strava_id,
       frequency: r.activityIds.length,
     };
   });
@@ -155,22 +180,20 @@ export function detectRoutes(activities, stravaRoutes = []) {
 
 /**
  * Find the route that an activity belongs to.
- * @param {Object} activity — Activity with segment_efforts
- * @param {Array} routes — Routes from detectRoutes()
- * @returns {Object|null} — Matching route, or null
+ * Uses hybrid similarity (Jaccard OR containment).
  */
 export function findRouteForActivity(activity, routes) {
   const ids = segmentIds(activity);
   if (ids.size === 0) return null;
 
   let best = null;
-  let bestSim = 0;
+  let bestScore = 0;
 
   for (const route of routes) {
     const routeSet = new Set(route.segments);
-    const sim = jaccard(ids, routeSet);
-    if (sim >= JACCARD_THRESHOLD && sim > bestSim) {
-      bestSim = sim;
+    const { matches, score } = hybridSimilarity(ids, routeSet);
+    if (matches && score > bestScore) {
+      bestScore = score;
       best = route;
     }
   }


### PR DESCRIPTION
## Summary

- **Route-first seeding**: Clusters are now pre-seeded from Strava-saved routes with fixed segment fingerprints (no union drift), so routes like "G2" keep their authoritative name instead of being named after random ride titles like "Muggy Buggy RCP Solo 2O"
- **Hybrid similarity**: Activities match routes via Jaccard ≥ 0.7 OR containment ≥ 0.8 (fraction of route's segments in activity), so a long ride that includes a short route as a subset still matches correctly
- **Strava links**: Route pills now show an external-link icon that opens the Strava route page
- **Clickable chart points**: Trend chart datapoints navigate to the activity detail view on click
- **Search clustering**: Now passes Strava routes for consistent naming in search results

### Algorithm changes in `src/routes.js`

| Before | After |
|--------|-------|
| Single greedy loop, union-grows all clusters | Two-phase: seed from Strava routes (fixed), then assign activities |
| Jaccard-only matching | Hybrid: Jaccard OR containment |
| Post-hoc Strava name matching (often fails due to drift) | Strava names assigned at seed time |
| All routes need 2+ activities | Strava-seeded routes shown with 1+ activity |
| Unbounded segment growth | Discovered routes capped at 2x initial size |

## Test plan

- [ ] Sync routes, verify route pills show Strava route names (not ride names)
- [ ] Click external-link icon on route pill → opens Strava route page in new tab
- [ ] Click datapoint on trend chart → navigates to activity detail
- [ ] Search for a route name → cluster header shows correct Strava route name
- [ ] Verify discovered routes (no Strava match) still cluster and name correctly
- [ ] Verify long rides that include a route as subset still match the route

https://claude.ai/code/session_014Dx9H1F3NNF2UgqLdbBGK6