### PR TITLE
Fix duplicate group ride names from route variants

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -2257,9 +2257,30 @@ export function detectGroupRides(allActivities, routes = []) {
     }
   }
 
+  // Merge groups with the same name (e.g., route variants that share a name)
+  const merged = [];
+  const nameIndex = new Map(); // name -> index in merged[]
+  for (const g of groups) {
+    const key = g.name;
+    if (nameIndex.has(key)) {
+      const existing = merged[nameIndex.get(key)];
+      existing.rides.push(...g.rides);
+      existing.totalRides += g.totalRides;
+      existing.attendanceStreak = Math.max(existing.attendanceStreak, g.attendanceStreak);
+      existing.attendanceMulligan = existing.attendanceMulligan || g.attendanceMulligan;
+      if (g.lastRideDate > existing.lastRideDate) {
+        existing.lastRideDate = g.lastRideDate;
+      }
+      existing.isGroupRide = existing.isGroupRide || g.isGroupRide;
+    } else {
+      nameIndex.set(key, merged.length);
+      merged.push({ ...g, rides: [...g.rides] });
+    }
+  }
+
   // Sort by total rides descending
-  groups.sort((a, b) => b.totalRides - a.totalRides);
-  return groups;
+  merged.sort((a, b) => b.totalRides - a.totalRides);
+  return merged;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes duplicate group ride names (e.g., "Tour de Kensington" appearing 3 times) caused by PRs #222/#223
- When `detectRoutes()` creates multiple route objects with the same name (slight segment variations), `splitByRoute()` made each a separate group — now they're merged post-clustering
- Merged groups combine rides, take the best attendance streak, and use the latest ride date

## Test plan
- [ ] Verify group rides with route variants now show as a single entry
- [ ] Check that ride counts are correct (sum of merged groups)
- [ ] Verify attendance streaks show the best streak across merged variants
- [ ] Confirm trend charts still work for merged groups

https://claude.ai/code/session_01CAUT3sQoiUGd7nvV8q4fQ4