### PR TITLE
Fix route search: show route pills when ride names match query

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -750,7 +750,8 @@ export function Dashboard() {
             ${dashboardRoutes.value.length > 0 && (() => {
               const q = searchQuery.value.trim().toLowerCase();
               const filtered = dashboardRoutes.value
-                .filter(r => !q || r.name.toLowerCase().includes(q))
+                .filter(r => !q || r.name.toLowerCase().includes(q) ||
+                  (r.rides && r.rides.some(ride => ride.name && ride.name.toLowerCase().includes(q))))
                 .sort((a, b) => b.frequency - a.frequency)
                 .slice(0, 8);
               if (filtered.length === 0) return null;


### PR DESCRIPTION
## Summary
- Route pills below the search bar only matched against the route's display name, missing routes whose constituent rides matched the search query
- Since routes are auto-named from the most common activity name in a cluster, routes with uniquely creative ride names (e.g. 34 different "Cappuccino" variations) would never show as a pill when searching "Cappuccino" — even though all rides matched
- Now also checks ride names within each route when filtering pills

## Test plan
- [ ] Search for a term that appears in ride names but not in the auto-assigned route name
- [ ] Verify that the route pill now appears and clicking it filters to those rides
- [ ] Verify existing route-name-based pill matching still works

https://claude.ai/code/session_0175W96NGXfourtDVsdsnJvV