### PR TITLE
Freeze discovered route fingerprints after formation

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -5,14 +5,14 @@
  * Containment was removed — it's one-directional and caused short rides
  * to match long routes when they shared a subset of segments.
  *
- * Strava-seeded routes keep their segment fingerprint fixed.
- * Discovered routes grow by union (capped at 1.3x initial size).
+ * All route fingerprints are frozen after initial formation.
+ * Strava-seeded routes use their saved segments; discovered routes
+ * use the segments from the first activity that seeds them.
  */
 
 const DISTANCE_TOLERANCE = 0.30;
 const JACCARD_THRESHOLD = 0.50;
 const MIN_SEGMENTS_FOR_ROUTE = 2;
-const MAX_SEGMENT_GROWTH = 1.3;
 
 function jaccard(a, b) {
   if (a.size === 0 && b.size === 0) return 1;
@@ -63,7 +63,6 @@ export function detectRoutes(activities, stravaRoutes = []) {
     if (!sr.segments || sr.segments.length === 0) continue;
     routes.push({
       segments: new Set(sr.segments),
-      initialSize: sr.segments.length,
       distance: sr.distance || 0,
       distances: [],
       activityIds: [],
@@ -104,16 +103,12 @@ export function detectRoutes(activities, stravaRoutes = []) {
       matched.distances.push(activity.distance);
       const name = activity.name || "";
       matched.names.set(name, (matched.names.get(name) || 0) + 1);
-      if (!matched.isStravaSeeded && matched.segments.size < matched.initialSize * MAX_SEGMENT_GROWTH) {
-        for (const id of ids) matched.segments.add(id);
-      }
     } else {
       const name = activity.name || "";
       const names = new Map();
       names.set(name, 1);
       routes.push({
         segments: new Set(ids),
-        initialSize: ids.size,
         distance: activity.distance || 0,
         distances: [activity.distance || 0],
         activityIds: [activity.id],


### PR DESCRIPTION
## Summary
- Removes the union growth block that expanded discovered routes' segment sets with each matched activity (capped at 1.3x)
- Discovered route fingerprints are now frozen at creation, matching the existing behavior for Strava-seeded routes
- Removes dead `MAX_SEGMENT_GROWTH` constant and `initialSize` tracking

This prevents fingerprint drift on overlapping routes (e.g. Rock Creek Park rides drifting into G2/Cappuccino clusters). The Jaccard threshold + distance gate remain sufficient for matching without segment set expansion.

Fixes #230

## Test plan
- [ ] Verify discovered routes match activities using only their original segment set
- [ ] Verify two routes sharing <50% segments never merge into the same cluster
- [ ] Verify a ride sharing 4-5 segments with a 12+ segment route does not incorrectly match
- [ ] Verify Strava-seeded route behavior is unchanged

https://claude.ai/code/session_01ShyghJXLeonodsv1URi8zy