### PR TITLE
Exclude virtual rides from route detection clustering

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -34,7 +34,10 @@ function medianDistance(distances) {
 }
 
 function distanceMatch(activityDistance, routeDistance) {
-  if (!routeDistance || !activityDistance) return true;
+  if (!routeDistance || !activityDistance) {
+    console.warn('[routes] missing distance data — skipping match', { activityDistance, routeDistance });
+    return false;
+  }
   const ratio = activityDistance / routeDistance;
   return ratio >= (1 - DISTANCE_TOLERANCE) && ratio <= (1 + DISTANCE_TOLERANCE);
 }
@@ -78,6 +81,7 @@ export function detectRoutes(activities, stravaRoutes = []) {
   );
 
   for (const activity of sorted) {
+    if (activity.sport_type === 'VirtualRide') continue;
     const ids = segmentIds(activity);
     if (ids.size === 0) continue;
 
@@ -157,6 +161,7 @@ export function detectRoutes(activities, stravaRoutes = []) {
  * Uses distance gate + Jaccard similarity.
  */
 export function findRouteForActivity(activity, routes) {
+  if (activity.sport_type === 'VirtualRide') return null;
   const ids = segmentIds(activity);
   if (ids.size === 0) return null;
 


### PR DESCRIPTION
## Summary
- Skip `VirtualRide` activities in `detectRoutes()` and `findRouteForActivity()` so Zwift/indoor rides never cluster with outdoor routes
- Tighten the distance gate in `distanceMatch()` to return `false` (with a `console.warn`) when distance data is missing, instead of silently matching everything

Closes #231

## Test plan
- [ ] Verify outdoor rides still cluster into routes as before
- [ ] Verify VirtualRide activities are excluded from all route clusters
- [ ] Verify `findRouteForActivity()` returns null for VirtualRide activities
- [ ] Verify activities with missing distance log a warning and don't match

https://claude.ai/code/session_01FcRNf3VGumseFeLZgNnn7d