### PR TITLE
Fix search and naming to treat Strava route names as authoritative

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -2182,10 +2182,12 @@ export function detectGroupRides(allActivities, routes = []) {
           }, 0) / sub.rides.length
         );
 
-        // Name: use route name if this sub-cluster has one, else fall back to activity names
+        // Name: Strava route name is authoritative; then route name; then activity name heuristic
         const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
         let groupName;
-        if (sub.route) {
+        if (sub.route && sub.route.strava_route_name) {
+          groupName = sub.route.strava_route_name;
+        } else if (sub.route) {
           groupName = sub.route.name;
         } else {
           const nameCounts = {};

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -244,6 +244,11 @@ effect(() => {
           try {
             if (formatDateWeekday(a.start_date_local).toLowerCase().includes(query)) return true;
           } catch (e) {}
+          for (const route of dashboardRoutes.value) {
+            if (route.activityIds.includes(a.id) &&
+              (route.name.toLowerCase().includes(query) ||
+               (route.strava_route_name && route.strava_route_name.toLowerCase().includes(query)))) return true;
+          }
           return false;
         });
     const missing = matched.filter((a) => a.has_efforts && !activityAwards.value.has(a.id));
@@ -751,6 +756,7 @@ export function Dashboard() {
               const q = searchQuery.value.trim().toLowerCase();
               const filtered = dashboardRoutes.value
                 .filter(r => !q || r.name.toLowerCase().includes(q) ||
+                  (r.strava_route_name && r.strava_route_name.toLowerCase().includes(q)) ||
                   (r.rides && r.rides.some(ride => ride.name && ride.name.toLowerCase().includes(q))))
                 .sort((a, b) => b.frequency - a.frequency)
                 .slice(0, 8);
@@ -1329,9 +1335,11 @@ export function Dashboard() {
                   if (al && al.label.toLowerCase().includes(query)) return true;
                   if (award.segment_name && award.segment_name.toLowerCase().includes(query)) return true;
                 }
-                // Search by route name
+                // Search by route name (including Strava route names)
                 for (const route of dashboardRoutes.value) {
-                  if (route.name.toLowerCase().includes(query) && route.activityIds.includes(activity.id)) return true;
+                  if (route.activityIds.includes(activity.id) &&
+                    (route.name.toLowerCase().includes(query) ||
+                     (route.strava_route_name && route.strava_route_name.toLowerCase().includes(query)))) return true;
                 }
                 return false;
               })


### PR DESCRIPTION
## Summary
- Search now surfaces rides by Strava route name (e.g. searching "Goon" finds all rides on any Goon-named Strava route, even if the activity was named "Saturday Morning Ride")
- Awards pre-computation effect includes route name matching so awards display correctly for route-name search results
- Route pills filter includes `strava_route_name` matching
- `detectGroupRides` explicitly prefers `strava_route_name` over `route.name` for group naming, enforcing Strava route name precedence

## Changes
- `src/components/Dashboard.js`: Added route name matching (including `strava_route_name`) to three search paths: awards pre-computation effect, display activity filter, and route pills filter
- `src/awards.js`: `detectGroupRides()` now checks `strava_route_name` first when naming a group, before falling back to `route.name` or activity name heuristics

## Test plan
- [ ] Search for a Strava route name (e.g. "Goon") — all matching rides should appear regardless of activity name
- [ ] Verify route pills appear when searching by Strava route name
- [ ] Verify group ride names use Strava route names when available
- [ ] Verify existing search by activity name, date, and award labels still works

Fixes #232

https://claude.ai/code/session_016Bt8VqPeso8wtuLeYPwqxM