### PR TITLE
Fix duplicate Season First badges + Strava route name matching + stable route IDs

### DIFF
--- a/src/award-config.js
+++ b/src/award-config.js
@@ -36,7 +36,8 @@ export const AWARD_LABELS = {
   comeback_endurance: { label: "Comeback Endurance",  tip: "Post-injury endurance record", dot: "#A05060", bg: "#F4E4E8", text: "#6E2E3C", border: "#DCC0C8" },
   reference_best:     { label: "Reference Best",     tip: "Best within a user-defined window", dot: "#6B6260", bg: "#ECEAE6", text: "#3E3A36", border: "#D4D0C8" },
   // Route-level Season First (#59)
-  route_season_first: { label: "Route Season First", tip: "First time riding this route this year", dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
+  route_season_first: { label: "Season First",       tip: "First time riding this route this year", dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
+  route_season_first_more: { label: "Season First",  tip: "More segments ridden for the first time on this route this year", dot: "#6A9E74", bg: "#EEF5EC", text: "#2E5E38", border: "#C8DCC2" },
   // Activity-level power awards (#45)
   season_first_power: { label: "First Power Ride",   tip: "First ride with power data this year", dot: "#3D7A4A", bg: "#E8F2E6", text: "#1E4D28", border: "#C0D8B8" },
   np_year_best:       { label: "NP Year Best",       tip: "Highest Normalized Power this year", dot: "#B8862E", bg: "#FBF0D8", text: "#6E5010", border: "#E8D4A0" },
@@ -102,6 +103,7 @@ export const AWARD_GROUPS = [
       { type: "segment_count", desc: "Most segments hit in a single ride this year." },
       { type: "endurance_record", desc: "Longest ride by moving time this year — your biggest endurance effort." },
       { type: "route_season_first", desc: "First time riding a known route this year." },
+      { type: "route_season_first_more", desc: "More segments ridden for the first time on a route you've already started this year." },
     ],
   },
   {

--- a/src/awards.js
+++ b/src/awards.js
@@ -227,6 +227,7 @@ const AWARD_TIER = {
   milestone:          1,
   recovery_milestone: 1,
   season_first:       1,
+  route_season_first_more: 1,
 };
 
 /**
@@ -604,9 +605,9 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
       cv(allTimes) > HIGH_VARIANCE_CV_THRESHOLD;
 
     // --- Comeback context (#60) ---
-    const activityDate_raw = new Date(activity.start_date_local);
+    const activityDate = new Date(activity.start_date_local);
     const comebackActive = resetEvent &&
-      activityDate_raw >= new Date(resetEvent.date) &&
+      activityDate >= new Date(resetEvent.date) &&
       (!resetEvent.sport_types || resetEvent.sport_types.includes(activity.sport_type));
     const comebackCtx = comebackActive
       ? computeComebackContext(effort, allEfforts, resetEvent)
@@ -651,8 +652,6 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
 
     // All remaining awards are suppressed on high-variance segments
     if (isHighVariance) continue;
-
-    const activityDate = new Date(activity.start_date_local);
 
     // --- Year Best ---
     const afterCalendarGate = (activityDate.getMonth() + 1) >= YEAR_BEST_CALENDAR_GATE_MONTH;
@@ -1863,7 +1862,15 @@ export async function computeAwardsForActivities(activities, disabledAwardTypes 
     await putRoutes(routes);
   }
 
-  for (const activity of activities) {
+  // Process activities chronologically so route_season_first is awarded
+  // to the first ride on a route this year; subsequent rides get the
+  // "more" variant instead of a duplicate badge.
+  const sortedActivities = [...activities].sort((a, b) =>
+    (a.start_date_local || "").localeCompare(b.start_date_local || "")
+  );
+  const routeSeasonFirstSeen = new Set(); // route IDs that already got route_season_first this year
+
+  for (const activity of sortedActivities) {
     const segmentAwards = await computeAwards(activity, resetEvent, referencePoints);
     const rideAwards = computeRideLevelAwards(activity, activities, resetEvent);
     let allAwards = [...segmentAwards, ...rideAwards];
@@ -1880,16 +1887,20 @@ export async function computeAwardsForActivities(activities, disabledAwardTypes 
       }
     }
 
-    // --- Route-level Season First collapse (#59) ---
+    // --- Route-level Season First collapse (#59, #route-season-dedup) ---
     // If this activity matches a known route and has 2+ season_first awards,
-    // collapse them into a single route_season_first award.
+    // collapse them. The first chronological ride on a route this year gets
+    // route_season_first; subsequent rides get route_season_first_more.
     const seasonFirsts = allAwards.filter((a) => a.type === "season_first");
     if (seasonFirsts.length >= 2) {
       const route = findRouteForActivity(activity, routes);
       if (route) {
         const nonSeasonFirsts = allAwards.filter((a) => a.type !== "season_first");
+        const isFirst = !routeSeasonFirstSeen.has(route.id);
+        routeSeasonFirstSeen.add(route.id);
+
         const routeAward = {
-          type: "route_season_first",
+          type: isFirst ? "route_season_first" : "route_season_first_more",
           segment: null,
           segment_id: null,
           time: null,
@@ -1897,10 +1908,13 @@ export async function computeAwardsForActivities(activities, disabledAwardTypes 
           comparison: null,
           delta: null,
           route_name: route.name,
+          route_id: route.id,
           route_frequency: route.frequency,
           collapsed_count: seasonFirsts.length,
           _collapsed_season_firsts: seasonFirsts,
-          message: `Season First on ${route.name}! First time this year on this route (${seasonFirsts.length} segments) — ${route.frequency} times total`,
+          message: isFirst
+            ? `Season First on ${route.name}! First time this year on this route (${seasonFirsts.length} segments)`
+            : `${seasonFirsts.length} more Season Firsts on ${route.name}`,
         };
         allAwards = [...nonSeasonFirsts, routeAward];
       }
@@ -1910,8 +1924,8 @@ export async function computeAwardsForActivities(activities, disabledAwardTypes 
     if (disabled.size > 0) {
       allAwards = allAwards.filter((a) => {
         if (disabled.has(a.type)) return false;
-        // route_season_first is derived from season_first — disable if season_first is disabled
-        if (a.type === "route_season_first" && disabled.has("season_first")) return false;
+        // route_season_first variants are derived from season_first — disable if season_first is disabled
+        if ((a.type === "route_season_first" || a.type === "route_season_first_more") && disabled.has("season_first")) return false;
         return true;
       });
     }

--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -113,12 +113,23 @@ async function loadActivity(id) {
         }
       }
 
-      // Route-level Season First collapse (#84)
+      // Route-level Season First collapse (#84, #route-season-dedup)
+      // Determine if this is the first ride on the route this year (route_season_first)
+      // or a subsequent ride with more new segments (route_season_first_more).
       const seasonFirsts = awardsList.filter(a => a.type === "season_first");
       if (seasonFirsts.length >= 2 && detectedRoute) {
         const nonSeasonFirsts = awardsList.filter(a => a.type !== "season_first");
+        const currentYear = new Date(act.start_date_local).getFullYear();
+        const earlierThisYear = (detectedRoute.activityIds || []).some(aid => {
+          const other = allActivities.find(a => a.id === aid);
+          return other &&
+            other.id !== act.id &&
+            new Date(other.start_date_local).getFullYear() === currentYear &&
+            other.start_date_local < act.start_date_local;
+        });
+        const awardType = earlierThisYear ? "route_season_first_more" : "route_season_first";
         const routeAward = {
-          type: "route_season_first",
+          type: awardType,
           segment: null,
           segment_id: null,
           time: null,
@@ -126,10 +137,13 @@ async function loadActivity(id) {
           comparison: null,
           delta: null,
           route_name: detectedRoute.name,
+          route_id: detectedRoute.id,
           route_frequency: detectedRoute.frequency,
           collapsed_count: seasonFirsts.length,
           _collapsed_season_firsts: seasonFirsts,
-          message: `Season First on ${detectedRoute.name}! First time this year on this route (${seasonFirsts.length} segments) — ${detectedRoute.frequency} times total`,
+          message: awardType === "route_season_first"
+            ? `Season First on ${detectedRoute.name}! First time this year on this route (${seasonFirsts.length} segments)`
+            : `${seasonFirsts.length} more Season Firsts on ${detectedRoute.name}`,
         };
         awardsList = [...nonSeasonFirsts, routeAward];
       }
@@ -157,7 +171,7 @@ async function loadActivity(id) {
       if (disabled.size > 0) {
         awardsList = awardsList.filter((a) => {
           if (disabled.has(a.type)) return false;
-          if (a.type === "route_season_first" && disabled.has("season_first")) return false;
+          if ((a.type === "route_season_first" || a.type === "route_season_first_more") && disabled.has("season_first")) return false;
           return true;
         });
       }
@@ -282,7 +296,7 @@ async function renderShareCard(canvas, act, awardsList) {
   const highlightAwards = buildShareCardHighlights(awardsList);
 
   const counts = {};
-  const pillOrder = ["route_season_first", "season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record", "season_first_power", "np_year_best", "np_recent_best", "work_year_best", "work_recent_best", "peak_power", "peak_power_recent", "watt_milestone", "kj_milestone", "power_progression", "power_consistency", "ftp_milestone", "curve_year_best", "curve_all_time", "indoor_np_year_best", "indoor_work_year_best", "trainer_streak", "indoor_vs_outdoor", "weekly_streak", "group_consistency", "reference_best", "comeback_pb", "recovery_milestone", "comeback_full", "comeback_distance", "comeback_elevation", "comeback_endurance"];
+  const pillOrder = ["route_season_first", "route_season_first_more", "season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record", "season_first_power", "np_year_best", "np_recent_best", "work_year_best", "work_recent_best", "peak_power", "peak_power_recent", "watt_milestone", "kj_milestone", "power_progression", "power_consistency", "ftp_milestone", "curve_year_best", "curve_all_time", "indoor_np_year_best", "indoor_work_year_best", "trainer_streak", "indoor_vs_outdoor", "weekly_streak", "group_consistency", "reference_best", "comeback_pb", "recovery_milestone", "comeback_full", "comeback_distance", "comeback_elevation", "comeback_endurance"];
   for (const a of awardsList) counts[a.type] = (counts[a.type] || 0) + 1;
   tmpCtx.font = '600 30px "DM Sans", sans-serif';
   const allPillRows = layoutPillRows(tmpCtx, counts, pillOrder, left, maxTextW);
@@ -890,7 +904,7 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
  */
 function buildShareCardHighlights(awardsList) {
   const TIER = {
-    route_season_first: 20, year_best: 18, ytd_best_time: 17, ytd_best_power: 17,
+    route_season_first: 20, route_season_first_more: 15, year_best: 18, ytd_best_time: 17, ytd_best_power: 17,
     np_year_best: 16, peak_power: 16, best_month_ever: 15, top_decile: 14,
     work_year_best: 13, improvement_streak: 12, comeback: 12, closing_in: 11,
     top_quartile: 10, recent_best: 9, np_recent_best: 9, monthly_best: 8,
@@ -1390,7 +1404,7 @@ export function ActivityDetail({ id }) {
                   ${rideAwards.map(award => {
                     const al = AWARD_LABELS[award.type];
                     // Route Season First with expandable segment list
-                    if (award.type === "route_season_first" && award._collapsed_season_firsts) {
+                    if ((award.type === "route_season_first" || award.type === "route_season_first_more") && award._collapsed_season_firsts) {
                       return html`
                         <div class="flex items-start gap-2 p-2 rounded-lg" style="background: var(--bg);">
                           ${al ? renderIconSVG(award.type, { size: 16, color: al.dot }) : null}

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1225,7 +1225,7 @@ export function Dashboard() {
               for (const a of awards) {
                 typeCounts.set(a.type, (typeCounts.get(a.type) || 0) + 1);
               }
-              const typeOrder = ["route_season_first", "season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "reference_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record", "weekly_streak", "group_consistency", "season_first_power", "np_year_best", "np_recent_best", "work_year_best", "work_recent_best", "peak_power", "peak_power_recent", "watt_milestone", "kj_milestone", "power_progression", "power_consistency", "ftp_milestone", "curve_year_best", "curve_all_time", "indoor_np_year_best", "indoor_work_year_best", "trainer_streak", "indoor_vs_outdoor", "comeback_pb", "recovery_milestone", "comeback_full", "comeback_distance", "comeback_elevation", "comeback_endurance"];
+              const typeOrder = ["route_season_first", "route_season_first_more", "season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "reference_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record", "weekly_streak", "group_consistency", "season_first_power", "np_year_best", "np_recent_best", "work_year_best", "work_recent_best", "peak_power", "peak_power_recent", "watt_milestone", "kj_milestone", "power_progression", "power_consistency", "ftp_milestone", "curve_year_best", "curve_all_time", "indoor_np_year_best", "indoor_work_year_best", "trainer_streak", "indoor_vs_outdoor", "comeback_pb", "recovery_milestone", "comeback_full", "comeback_distance", "comeback_elevation", "comeback_endurance"];
               const summary = typeOrder
                 .filter((t) => typeCounts.has(t))
                 .map((t) => ({ type: t, count: typeCounts.get(t) }));
@@ -1258,14 +1258,17 @@ export function Dashboard() {
                         (s) => {
                           const al = AWARD_LABELS[s.type];
                           const pillStyle = al ? `background: ${al.bg}; color: ${al.text}; border: 1px solid ${al.border};` : "background: #ECEAE6; color: #3E3A36;";
-                          if (s.type === "route_season_first") {
-                            const routeAward = awards.find((a) => a.type === "route_season_first");
+                          if (s.type === "route_season_first" || s.type === "route_season_first_more") {
+                            const routeAward = awards.find((a) => a.type === s.type);
                             const routeName = routeAward?.route_name || "Route";
-                            const freq = routeAward?.route_frequency;
+                            const count = routeAward?.collapsed_count;
+                            const label = s.type === "route_season_first"
+                              ? `Season First: ${routeName}`
+                              : `${count ? count + " more" : "More"} Season Firsts: ${routeName}`;
                             return html`
                               <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full cursor-help" style=${pillStyle} title=${al?.tip || ""}>
                                 ${al ? renderIconSVG(s.type, { size: 12, color: al.dot }) : null}
-                                Season First: ${routeName}${freq ? ` — ${freq} times` : ""}
+                                ${label}
                               </span>
                             `;
                           }

--- a/src/export-llm.js
+++ b/src/export-llm.js
@@ -264,6 +264,7 @@ function buildAwardHighlights(awardsMap) {
   // Season firsts
   if (counts.season_first) highlights.push(`First season rides on ${counts.season_first} segment${counts.season_first !== 1 ? "s" : ""}`);
   if (counts.route_season_first) highlights.push(`First season rides on ${counts.route_season_first} route${counts.route_season_first !== 1 ? "s" : ""}`);
+  if (counts.route_season_first_more) highlights.push(`More season firsts on ${counts.route_season_first_more} route${counts.route_season_first_more !== 1 ? "s" : ""}`);
 
   // Ride-level records
   const rideRecordTypes = ["distance_record", "elevation_record", "endurance_record", "speed_record"];

--- a/src/icons.js
+++ b/src/icons.js
@@ -341,6 +341,7 @@ const ICON_FALLBACKS = {
   reference_best: "closing_in",
   // Route-level (#59)
   route_season_first: "season_first",
+  route_season_first_more: "season_first",
   // Indoor training (#46) → indoor_power
   indoor_np_year_best: "indoor_power",
   indoor_work_year_best: "indoor_power",

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,14 +7,18 @@
  * segments.
  *
  * Strava-saved routes are matched to discovered clusters post-hoc using
- * containment (Strava segments ⊆ cluster segments) + distance gate.
- * The Strava API only returns a subset of a route's segments (~25 of 50+),
- * so Jaccard fails when seeding directly. Containment is safe here because
- * the Strava route is always the smaller set and we're checking if it fits
- * inside a larger organic cluster — the opposite of the problematic direction.
+ * containment (Strava segments ⊆ cluster's accumulated segment union) +
+ * distance gate. The Strava API only returns a subset of a route's segments
+ * (~25 of 50+), so Jaccard fails when seeding directly.
  *
- * All route fingerprints are frozen after initial formation.
- * Discovered routes use the segments from the first activity that seeds them.
+ * Route identity fingerprints (used for Jaccard matching) are frozen from
+ * the first activity that seeds a cluster. However, each cluster also tracks
+ * `allSeenSegments` — the union of segments across all matched activities —
+ * which is used for Strava containment matching. This fixes cases where the
+ * frozen set was too narrow for the Strava route's partial segment list.
+ *
+ * Route IDs are canonical hashes of the frozen segment set, stable across
+ * recomputation regardless of activity ordering.
  */
 
 const DISTANCE_TOLERANCE = 0.30;
@@ -71,6 +75,20 @@ function segmentIds(activity) {
 }
 
 /**
+ * Generate a stable canonical ID from a frozen segment set.
+ * Uses djb2 hash of sorted segment IDs — deterministic regardless of
+ * activity ordering or recomputation.
+ */
+function canonicalRouteId(segmentSet) {
+  const key = [...segmentSet].sort((a, b) => a - b).join(",");
+  let hash = 5381;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0;
+  }
+  return "route_" + (hash >>> 0).toString(36);
+}
+
+/**
  * Detect routes from activities by clustering on segment fingerprints.
  *
  * Phase 1: Organic clustering — group activities by segment overlap
@@ -114,12 +132,15 @@ export function detectRoutes(activities, stravaRoutes = []) {
       matched.distances.push(activity.distance);
       const name = activity.name || "";
       matched.names.set(name, (matched.names.get(name) || 0) + 1);
+      // Accumulate segments for richer Strava containment matching
+      for (const id of ids) matched.allSeenSegments.add(id);
     } else {
       const name = activity.name || "";
       const names = new Map();
       names.set(name, 1);
       routes.push({
         segments: new Set(ids),
+        allSeenSegments: new Set(ids),
         distance: activity.distance || 0,
         distances: [activity.distance || 0],
         activityIds: [activity.id],
@@ -132,9 +153,11 @@ export function detectRoutes(activities, stravaRoutes = []) {
 
   // --- Phase 2: Adopt Strava route names via containment ---
   // The Strava API returns only a subset of a route's segments, so Jaccard
-  // between the partial Strava set and the full organic cluster fails.
+  // between the partial Strava set and the frozen cluster fingerprint fails.
   // Instead: check if the Strava route's (partial) segments are mostly
-  // contained within a cluster's (full) segment set + distance gate.
+  // contained within the cluster's accumulated segment union (allSeenSegments).
+  // This is richer than the frozen fingerprint because it includes segments
+  // from all activities ever matched to the cluster.
   for (const sr of stravaRoutes) {
     if (!sr.segments || sr.segments.length === 0) continue;
     const stravaSegs = new Set(sr.segments);
@@ -148,7 +171,7 @@ export function detectRoutes(activities, stravaRoutes = []) {
       const routeDistance = medianDistance(route.distances);
       if (sr.distance && !distanceMatch(sr.distance, routeDistance)) continue;
 
-      const c = containment(stravaSegs, route.segments);
+      const c = containment(stravaSegs, route.allSeenSegments);
       if (c >= STRAVA_CONTAINMENT_THRESHOLD && c > bestContainment) {
         bestContainment = c;
         bestCluster = route;
@@ -164,7 +187,7 @@ export function detectRoutes(activities, stravaRoutes = []) {
   // --- Phase 3: Finalize ---
   const meaningful = routes.filter((r) => r.activityIds.length >= 2);
 
-  return meaningful.map((r, i) => {
+  return meaningful.map((r) => {
     // Prefer Strava name when available, fall back to most common activity name
     let bestName;
     if (r.strava_name) {
@@ -181,7 +204,7 @@ export function detectRoutes(activities, stravaRoutes = []) {
     }
 
     return {
-      id: i + 1,
+      id: canonicalRouteId(r.segments),
       segments: [...r.segments],
       activityIds: r.activityIds,
       name: bestName,

--- a/test/harness.py
+++ b/test/harness.py
@@ -11,7 +11,7 @@ Award coverage (34 types):
     top_quartile, top_decile, consistency, monthly_best, improvement_streak,
     comeback, milestone, best_month_ever, closing_in, anniversary,
     ytd_best_time, ytd_best_power
-  Route-level (#59): route_season_first
+  Route-level (#59): route_season_first, route_season_first_more
   Comeback: comeback_pb, recovery_milestone, comeback_full
   Ride-level: distance_record, elevation_record, segment_count,
     endurance_record, comeback_distance, comeback_elevation, comeback_endurance
@@ -611,7 +611,7 @@ AUDIT_JS = """(async () => {
         "improvement_streak", "comeback", "milestone",
         "best_month_ever", "closing_in", "anniversary",
         "ytd_best_time", "ytd_best_power",
-        "route_season_first",
+        "route_season_first", "route_season_first_more",
         "comeback_pb", "recovery_milestone", "comeback_full",
         "distance_record", "elevation_record", "segment_count",
         "endurance_record",


### PR DESCRIPTION
## What

Fixes three bugs and one code smell reported from the dashboard:

### 1. Duplicate Season First badges on same route (UX bug)
Two rides 9 days apart both showed identical "Season First: Chill RCP (mostly) — 4 times" badges. The collapse was running per-activity without tracking whether the route had already been "first'ed" this year.

**Fix**: `computeAwardsForActivities` now processes activities chronologically and tracks which routes have received `route_season_first`. First ride gets the full badge; subsequent rides with new segments get `route_season_first_more` with distinct messaging ("4 more Season Firsts on Chill RCP") and slightly muted styling.

Same logic applied to the ActivityDetail standalone collapse path, which checks for earlier activities on the same route this year.

### 2. Strava saved route names never matching (root cause fix)
The containment check `containment(stravaSegs, route.segments)` used the frozen fingerprint from the first seeding activity. A single ride typically has ~10-15 segments, while the Strava API returns ~25. Containment would compute e.g. 12/25 = 0.48, below the 0.70 threshold.

**Fix**: Each cluster now tracks `allSeenSegments` — the union of segments from ALL matched activities. Phase 2 containment uses this richer set instead of the frozen fingerprint. The frozen set still governs Jaccard-based route identity matching.

### 3. Fragile index-based route IDs
Route IDs were `i + 1` — regenerated on every `detectRoutes()` call. If activity ordering changed or new activities were added, IDs would shift.

**Fix**: `canonicalRouteId()` generates a djb2 hash of sorted frozen segment IDs, producing stable IDs like `route_1a2b3c` regardless of recomputation order.

### 4. Duplicate `activityDate` declaration (code smell)
`activityDate_raw` and `activityDate` in `computeAwards` were identical `new Date(activity.start_date_local)`. Consolidated to single declaration.

## Files changed
- `src/routes.js` — allSeenSegments accumulation, canonical IDs, updated comments
- `src/awards.js` — chronological processing, route_season_first_more, activityDate fix
- `src/award-config.js` — new type config + help entry
- `src/icons.js` — icon alias for new type
- `src/export-llm.js` — LLM export text for new type
- `src/components/ActivityDetail.js` — standalone collapse, pillOrder, TIER, disabled filter, detail rendering
- `src/components/Dashboard.js` — typeOrder, pill rendering
- `test/harness.py` — added new type to ALL_TYPES list
