### PR TITLE
fix: exempt PR-related awards from high-variance filter

### DIFF
--- a/src/awards.js
+++ b/src/awards.js
@@ -70,9 +70,10 @@
  *     Season First and Milestone exempt.
  *   - Calendar gate: Year Best suppressed before March 1.
  *   - High-variance filter: segments with trimmed CV > 0.5 (≥5 efforts)
- *     are traffic-dominated — awards suppressed except Season First,
- *     Milestone, Closing In, and Matched PR. Trimmed CV drops the
- *     slowest 10% of efforts so occasional stops don't poison the metric.
+ *     are potentially traffic-dominated — awards suppressed except Season
+ *     First, Milestone, Closing In, and Matched PR. Power override: if
+ *     watts correlate with speed (R² > 0.3), variance is effort-driven
+ *     and the filter is skipped.
  *   - Power awards require device_watts === true (measured, not estimated).
  *   - Indoor awards require trainer === true && device_watts === true.
  *
@@ -365,6 +366,45 @@ function trimmedCv(values) {
   return stdev(trimmed) / m;
 }
 
+/** R² threshold above which power→speed correlation indicates effort-driven variance */
+const POWER_SPEED_R2_THRESHOLD = 0.3;
+
+/**
+ * Detect whether a segment's time variance is explained by effort variation
+ * rather than traffic. If power (recorded or estimated) correlates with speed
+ * (R² > threshold), the rider went fast because they pushed hard — not because
+ * traffic got out of their way.
+ *
+ * @param {Array} efforts — All efforts on this segment
+ * @param {number} distance — Segment distance in meters
+ * @returns {boolean} — true if variance is effort-driven
+ */
+function isEffortDrivenVariance(efforts, distance) {
+  if (!distance || distance <= 0) return false;
+  const powered = efforts.filter((e) => (e.average_watts || 0) > 0 && e.elapsed_time > 0);
+  if (powered.length < MIN_EFFORTS_FOR_CV) return false;
+
+  const watts = powered.map((e) => e.average_watts);
+  const speeds = powered.map((e) => distance / e.elapsed_time);
+
+  // Pearson R²
+  const n = watts.length;
+  const wm = watts.reduce((s, v) => s + v, 0) / n;
+  const sm = speeds.reduce((s, v) => s + v, 0) / n;
+  let sws = 0, sww = 0, sss = 0;
+  for (let i = 0; i < n; i++) {
+    const dw = watts[i] - wm;
+    const ds = speeds[i] - sm;
+    sws += dw * ds;
+    sww += dw * dw;
+    sss += ds * ds;
+  }
+  if (sww === 0 || sss === 0) return false;
+  const r2 = (sws * sws) / (sww * sss);
+
+  return r2 > POWER_SPEED_R2_THRESHOLD;
+}
+
 /** Format a number with ordinal suffix (1st, 2nd, 3rd, etc.) */
 function ordinal(n) {
   const s = ["th", "st", "nd", "rd"];
@@ -620,13 +660,16 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
     );
 
     // --- High-variance filter (#38) ---
-    // Segments with trimmed CV > 0.5 and ≥5 efforts are traffic-dominated.
-    // Uses trimmed CV (drops slowest 10%) so a few outliers from stopping
-    // or soft-pedaling don't suppress awards on effort-variable segments.
+    // Segments with high time CV are potentially traffic-dominated.
+    // Uses trimmed CV (drops slowest 10%) and power-based override:
+    // if watts correlate with speed (R² > 0.3), the variance is effort-
+    // driven (sprinting vs cruising), not traffic noise.
     // Season First, Milestone, Closing In, Matched PR are exempt.
-    const isHighVariance =
+    const highTimeCv =
       allEfforts.length >= MIN_EFFORTS_FOR_CV &&
       trimmedCv(allTimes) > HIGH_VARIANCE_CV_THRESHOLD;
+    const isHighVariance = highTimeCv &&
+      !isEffortDrivenVariance(allEfforts, segment.distance);
 
     // --- Comeback context (#60) ---
     const activityDate = new Date(activity.start_date_local);

--- a/src/awards.js
+++ b/src/awards.js
@@ -69,9 +69,10 @@
  *     Beat Median, Top Quartile, Monthly Best, YTD Best) require ≥3 total efforts.
  *     Season First and Milestone exempt.
  *   - Calendar gate: Year Best suppressed before March 1.
- *   - High-variance filter: segments with CV > 0.5 (≥5 efforts) are
- *     traffic-dominated — all awards suppressed except Season First,
- *     Milestone, Closing In, and Matched PR.
+ *   - High-variance filter: segments with trimmed CV > 0.5 (≥5 efforts)
+ *     are traffic-dominated — awards suppressed except Season First,
+ *     Milestone, Closing In, and Matched PR. Trimmed CV drops the
+ *     slowest 10% of efforts so occasional stops don't poison the metric.
  *   - Power awards require device_watts === true (measured, not estimated).
  *   - Indoor awards require trainer === true && device_watts === true.
  *
@@ -348,6 +349,22 @@ function cv(values) {
   return stdev(values) / m;
 }
 
+/**
+ * Trimmed coefficient of variation — drops the slowest 10% of times before
+ * computing CV. Prevents a few outliers (stopped briefly, soft-pedaling through)
+ * from flagging a segment as "traffic-dominated" when the core distribution is
+ * legitimate effort variation.
+ */
+function trimmedCv(values) {
+  if (values.length < 5) return cv(values);
+  const sorted = [...values].sort((a, b) => a - b);
+  const trim = Math.max(1, Math.floor(sorted.length * 0.1));
+  const trimmed = sorted.slice(0, sorted.length - trim); // drop slowest
+  const m = mean(trimmed);
+  if (m === 0) return 0;
+  return stdev(trimmed) / m;
+}
+
 /** Format a number with ordinal suffix (1st, 2nd, 3rd, etc.) */
 function ordinal(n) {
   const s = ["th", "st", "nd", "rd"];
@@ -603,11 +620,13 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
     );
 
     // --- High-variance filter (#38) ---
-    // Segments with CV > 0.5 and ≥5 efforts are traffic-dominated.
-    // Only Season First passes through; all other awards are suppressed.
+    // Segments with trimmed CV > 0.5 and ≥5 efforts are traffic-dominated.
+    // Uses trimmed CV (drops slowest 10%) so a few outliers from stopping
+    // or soft-pedaling don't suppress awards on effort-variable segments.
+    // Season First, Milestone, Closing In, Matched PR are exempt.
     const isHighVariance =
       allEfforts.length >= MIN_EFFORTS_FOR_CV &&
-      cv(allTimes) > HIGH_VARIANCE_CV_THRESHOLD;
+      trimmedCv(allTimes) > HIGH_VARIANCE_CV_THRESHOLD;
 
     // --- Comeback context (#60) ---
     const activityDate = new Date(activity.start_date_local);

--- a/src/awards.js
+++ b/src/awards.js
@@ -70,7 +70,8 @@
  *     Season First and Milestone exempt.
  *   - Calendar gate: Year Best suppressed before March 1.
  *   - High-variance filter: segments with CV > 0.5 (≥5 efforts) are
- *     traffic-dominated — all awards suppressed except Season First and Milestone.
+ *     traffic-dominated — all awards suppressed except Season First,
+ *     Milestone, Closing In, and Matched PR.
  *   - Power awards require device_watts === true (measured, not estimated).
  *   - Indoor awards require trainer === true && device_watts === true.
  *
@@ -654,6 +655,46 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
       continue; // Season first — no other awards possible
     }
 
+    // --- Closing In on PR / Matched PR (#28) — exempt from CV filter ---
+    // PR-related awards are meaningful even on traffic-affected segments.
+    if (allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
+      const allTimeBest = Math.min(...allTimes);
+      if (effort.elapsed_time > allTimeBest) {
+        const gap = (effort.elapsed_time - allTimeBest) / allTimeBest;
+        if (gap <= 0.05) {
+          const pctLabel = gap <= 0.02 ? "2%" : "5%";
+          awards.push({
+            type: "closing_in",
+            segment: segment.name,
+            segment_id: segment.id,
+            time: effort.elapsed_time,
+            power: effort.average_watts || null,
+            comparison: null,
+            delta: effort.elapsed_time - allTimeBest,
+            message: `Within ${pctLabel} of your PR on ${segment.name}! ${formatTime(effort.elapsed_time)} — just ${formatTime(effort.elapsed_time - allTimeBest)} off your best`,
+          });
+        }
+      } else if (effort.elapsed_time === allTimeBest) {
+        // Matched PR: tied all-time best (requires a prior effort at the same time)
+        const priorMatchingPR = allEfforts.some(
+          (e) => e.effort_id !== effort.id && e.elapsed_time === allTimeBest
+        );
+        if (priorMatchingPR) {
+          const matchCount = allEfforts.filter((e) => e.elapsed_time === allTimeBest).length;
+          awards.push({
+            type: "matched_pr",
+            segment: segment.name,
+            segment_id: segment.id,
+            time: effort.elapsed_time,
+            power: effort.average_watts || null,
+            comparison: null,
+            delta: 0,
+            message: `Matched your PR on ${segment.name}! ${formatTime(effort.elapsed_time)} — tied your all-time best${matchCount > 2 ? ` (${ordinal(matchCount)} time at this pace)` : ""}`,
+          });
+        }
+      }
+    }
+
     // All remaining awards are suppressed on high-variance segments
     if (isHighVariance) continue;
 
@@ -921,46 +962,6 @@ export async function computeAwards(activity, resetEvent = null, referencePoints
               message: `Best ${monthName} ever on ${segment.name}! ${formatTime(effort.elapsed_time)} — fastest across ${yearsSpanned} years`,
             });
           }
-        }
-      }
-    }
-
-    // --- Closing In on PR (#28) ---
-    // Within 5% of all-time best (but not the best itself)
-    if (allEfforts.length >= MIN_EFFORTS_FOR_AWARDS) {
-      const allTimeBest = Math.min(...allTimes);
-      if (effort.elapsed_time > allTimeBest) {
-        const gap = (effort.elapsed_time - allTimeBest) / allTimeBest;
-        if (gap <= 0.05) {
-          const pctLabel = gap <= 0.02 ? "2%" : "5%";
-          awards.push({
-            type: "closing_in",
-            segment: segment.name,
-            segment_id: segment.id,
-            time: effort.elapsed_time,
-            power: effort.average_watts || null,
-            comparison: null,
-            delta: effort.elapsed_time - allTimeBest,
-            message: `Within ${pctLabel} of your PR on ${segment.name}! ${formatTime(effort.elapsed_time)} — just ${formatTime(effort.elapsed_time - allTimeBest)} off your best`,
-          });
-        }
-      } else if (effort.elapsed_time === allTimeBest) {
-        // Matched PR: tied all-time best (requires a prior effort at the same time)
-        const priorMatchingPR = allEfforts.some(
-          (e) => e.effort_id !== effort.id && e.elapsed_time === allTimeBest
-        );
-        if (priorMatchingPR) {
-          const matchCount = allEfforts.filter((e) => e.elapsed_time === allTimeBest).length;
-          awards.push({
-            type: "matched_pr",
-            segment: segment.name,
-            segment_id: segment.id,
-            time: effort.elapsed_time,
-            power: effort.average_watts || null,
-            comparison: null,
-            delta: 0,
-            message: `Matched your PR on ${segment.name}! ${formatTime(effort.elapsed_time)} — tied your all-time best${matchCount > 2 ? ` (${ordinal(matchCount)} time at this pace)` : ""}`,
-          });
         }
       }
     }


### PR DESCRIPTION
## Problem

Beach Drive – Wexford S. to the tunnel: tied all-time PR (27s), zero awards. The high-variance filter (`CV > 0.5`) classified the segment as traffic-dominated, but the variance is from effort variation (33mph sprint vs 16mph cruise).

## Three-layer fix

### 1. Exempt PR-related awards from CV filter

Moved `closing_in` and `matched_pr` above `if (isHighVariance) continue`. Tying your all-time best is meaningful regardless of segment variance.

### 2. Trimmed CV

`trimmedCv()` drops the slowest 10% before computing. A few outlier stops don't poison the metric.

### 3. Power-based override (this commit)

`isEffortDrivenVariance()` computes Pearson R² between `average_watts` and speed (`distance / elapsed_time`). If R² > 0.3, power explains the speed variance → it's effort, not traffic → skip the filter.

```
isHighVariance = highTimeCv && !isEffortDrivenVariance(efforts, distance)
```

Uses all efforts with power data (recorded or estimated). Falls back to trimmedCv alone when power isn't available.

### Flow after fix

```
for each segment effort:
  1. milestone          ← exempt from CV
  2. season_first       ← exempt, then continue
  3. closing_in         ← exempt from CV
  4. matched_pr         ← exempt from CV
  5. highTimeCv = trimmedCv > 0.5
  6. isHighVariance = highTimeCv && !isEffortDrivenVariance()
  7. if (isHighVariance) continue
  8. year_best, beat_median, top_quartile, ...
```
