### PR TITLE
feat(gear-stats): hours per bike + four totals-based awards (#204)

### DIFF
--- a/src/gear-stats.js
+++ b/src/gear-stats.js
@@ -1,0 +1,160 @@
+/**
+ * Pure aggregation functions for gear-level stats and awards.
+ *
+ * No IndexedDB dependencies — operates on data passed in. Caller is
+ * responsible for fetching activities + gears (typically from the
+ * existing IndexedDB stores) and feeding them through.
+ *
+ * Companion to src/awards.js (segment- and ride-level awards). Gear
+ * awards are a separate axis: per-bike totals across the whole history.
+ */
+
+const CYCLING_TYPES = new Set([
+  'Ride', 'VirtualRide', 'EBikeRide', 'GravelRide', 'MountainBikeRide',
+]);
+
+const METERS_PER_MILE = 1609.344;
+const SECONDS_PER_HOUR = 3600;
+
+const UNASSIGNED_KEY = '__unassigned__';
+
+/**
+ * @typedef {Object} BikeStat
+ * @property {string|null} gear_id
+ * @property {string} name
+ * @property {string|null} brand_name
+ * @property {string|null} model_name
+ * @property {boolean} retired
+ * @property {number} moving_seconds  - sum of moving_time across rides (s)
+ * @property {number} distance_meters - sum of distance across rides (m)
+ * @property {number} elevation_meters - sum of total_elevation_gain (m)
+ * @property {number} rides           - count of cycling activities
+ * @property {string|null} first_used - ISO date of earliest ride
+ * @property {string|null} last_used  - ISO date of latest ride
+ * @property {number} hours           - convenience: moving_seconds / 3600
+ * @property {number} miles           - convenience: distance_meters / 1609.344
+ */
+
+/**
+ * Aggregate cycling activities by gear.
+ *
+ * Cycling-only: filters out Run, Swim, Walk, etc. by `type`. Activities
+ * without a `gear_id` are bucketed under an "Unassigned" pseudo-bike
+ * (gear_id: null) so the caller can show users what's slipping through.
+ *
+ * @param {Array} activities
+ * @param {Array} gears
+ * @returns {Array<BikeStat>} sorted by moving_seconds desc
+ */
+export function bikeStats(activities, gears) {
+  const gearById = new Map((gears || []).map(g => [g.id, g]));
+  const buckets = new Map();
+
+  for (const a of activities || []) {
+    if (!CYCLING_TYPES.has(a?.type)) continue;
+
+    const gearId = a.gear_id || null;
+    const key = gearId || UNASSIGNED_KEY;
+
+    let b = buckets.get(key);
+    if (!b) {
+      const g = gearId ? gearById.get(gearId) : null;
+      const name = gearId
+        ? (g?.name || `Unknown gear ${gearId}`)
+        : 'Unassigned';
+      b = {
+        gear_id: gearId,
+        name,
+        brand_name: g?.brand_name ?? null,
+        model_name: g?.model_name ?? null,
+        retired: g?.retired ?? false,
+        moving_seconds: 0,
+        distance_meters: 0,
+        elevation_meters: 0,
+        rides: 0,
+        first_used: null,
+        last_used: null,
+      };
+      buckets.set(key, b);
+    }
+
+    b.moving_seconds   += a.moving_time           || 0;
+    b.distance_meters  += a.distance              || 0;
+    b.elevation_meters += a.total_elevation_gain  || 0;
+    b.rides            += 1;
+
+    const date = a.start_date_local || a.start_date || null;
+    if (date) {
+      if (!b.first_used || date < b.first_used) b.first_used = date;
+      if (!b.last_used  || date > b.last_used)  b.last_used  = date;
+    }
+  }
+
+  return Array.from(buckets.values())
+    .map(b => ({
+      ...b,
+      hours: b.moving_seconds / SECONDS_PER_HOUR,
+      miles: b.distance_meters / METERS_PER_MILE,
+    }))
+    .sort((x, y) => y.moving_seconds - x.moving_seconds);
+}
+
+/**
+ * @typedef {Object} GearAward
+ * @property {string} type    - one of: gear_workhorse, gear_long_hauler,
+ *                              gear_daily_driver, gear_climber
+ * @property {string} gear_id
+ * @property {string} name
+ * @property {number} value   - the metric the award was won on
+ */
+
+/**
+ * Compute totals-based gear awards from BikeStat array.
+ *
+ * Currently issued (one award per category, ties broken alphabetically
+ * by name):
+ *   - gear_workhorse:    most moving_seconds
+ *   - gear_long_hauler:  most distance_meters
+ *   - gear_daily_driver: most rides
+ *   - gear_climber:      most elevation_meters
+ *
+ * Skipped:
+ *   - Categories where the best value is zero (no climber on flat-only
+ *     fleet; no workhorse if all bikes have 0 moving time).
+ *   - The "Unassigned" pseudo-bike — never wins; it's a data-quality
+ *     bucket, not a real piece of gear.
+ *
+ * @param {Array<BikeStat>} stats
+ * @returns {Array<GearAward>}
+ */
+export function gearAwards(stats) {
+  const candidates = (stats || []).filter(b => b.rides > 0 && b.gear_id);
+  if (candidates.length === 0) return [];
+
+  const winnerOf = (key) => {
+    let best = null;
+    for (const b of candidates) {
+      if (best === null
+          || b[key] > best[key]
+          || (b[key] === best[key] && b.name < best.name)) {
+        best = b;
+      }
+    }
+    return best;
+  };
+
+  const awards = [];
+  const issue = (type, key) => {
+    const w = winnerOf(key);
+    if (w && w[key] > 0) {
+      awards.push({ type, gear_id: w.gear_id, name: w.name, value: w[key] });
+    }
+  };
+
+  issue('gear_workhorse',    'moving_seconds');
+  issue('gear_long_hauler',  'distance_meters');
+  issue('gear_daily_driver', 'rides');
+  issue('gear_climber',      'elevation_meters');
+
+  return awards;
+}

--- a/test/gear-stats.test.js
+++ b/test/gear-stats.test.js
@@ -1,0 +1,259 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { bikeStats, gearAwards } from '../src/gear-stats.js';
+
+// ─── Builders ─────────────────────────────────────────────
+
+const activity = (overrides = {}) => ({
+  type: 'Ride',
+  gear_id: 'b1',
+  moving_time: 3600,            // 1 hour
+  distance: 16093.44,           // 10 miles
+  total_elevation_gain: 100,
+  start_date: '2026-04-01T10:00:00Z',
+  start_date_local: '2026-04-01T10:00:00',
+  ...overrides,
+});
+
+const gear = (overrides = {}) => ({
+  id: 'b1',
+  name: 'Tarmac SL7',
+  brand_name: 'Specialized',
+  model_name: 'Tarmac SL7',
+  retired: false,
+  distance: 0,
+  ...overrides,
+});
+
+// ─── bikeStats: shape ─────────────────────────────────────
+
+test('bikeStats: empty inputs return empty array', () => {
+  assert.deepEqual(bikeStats([], []), []);
+  assert.deepEqual(bikeStats(undefined, undefined), []);
+});
+
+test('bikeStats: aggregates moving_time and distance per gear', () => {
+  const acts = [
+    activity({ gear_id: 'b1', moving_time: 3600, distance: 16093.44 }),
+    activity({ gear_id: 'b1', moving_time: 1800, distance: 8000 }),
+    activity({ gear_id: 'b2', moving_time: 7200, distance: 30000 }),
+  ];
+  const gears = [gear({ id: 'b1' }), gear({ id: 'b2', name: 'Roubaix' })];
+  const stats = bikeStats(acts, gears);
+  assert.equal(stats.length, 2);
+
+  const b1 = stats.find(s => s.gear_id === 'b1');
+  assert.equal(b1.rides, 2);
+  assert.equal(b1.moving_seconds, 5400);
+  assert.equal(b1.hours, 1.5);
+  assert.ok(Math.abs(b1.distance_meters - 24093.44) < 1e-6,
+    `distance ${b1.distance_meters} ≉ 24093.44`);
+
+  const b2 = stats.find(s => s.gear_id === 'b2');
+  assert.equal(b2.rides, 1);
+  assert.equal(b2.moving_seconds, 7200);
+});
+
+test('bikeStats: results sorted by moving_seconds descending', () => {
+  const acts = [
+    activity({ gear_id: 'b1', moving_time: 1800 }),
+    activity({ gear_id: 'b2', moving_time: 7200 }),
+    activity({ gear_id: 'b3', moving_time: 3600 }),
+  ];
+  const gears = [gear({ id: 'b1' }), gear({ id: 'b2' }), gear({ id: 'b3' })];
+  const stats = bikeStats(acts, gears);
+  assert.deepEqual(stats.map(s => s.gear_id), ['b2', 'b3', 'b1']);
+});
+
+test('bikeStats: sums elevation_gain in meters', () => {
+  const acts = [
+    activity({ total_elevation_gain: 250 }),
+    activity({ total_elevation_gain: 175 }),
+  ];
+  const stats = bikeStats(acts, [gear()]);
+  assert.equal(stats[0].elevation_meters, 425);
+});
+
+// ─── bikeStats: filtering ─────────────────────────────────
+
+test('bikeStats: filters out non-cycling activities', () => {
+  const acts = [
+    activity({ type: 'Ride', moving_time: 3600 }),
+    activity({ type: 'Run', moving_time: 1800 }),
+    activity({ type: 'Swim', moving_time: 1800 }),
+    activity({ type: 'Walk', moving_time: 1800 }),
+  ];
+  const stats = bikeStats(acts, [gear()]);
+  assert.equal(stats.length, 1);
+  assert.equal(stats[0].rides, 1);
+});
+
+test('bikeStats: includes Virtual / EBike / Gravel / MTB rides', () => {
+  const acts = [
+    activity({ type: 'Ride', gear_id: 'b1' }),
+    activity({ type: 'VirtualRide', gear_id: 'b1' }),
+    activity({ type: 'EBikeRide', gear_id: 'b1' }),
+    activity({ type: 'GravelRide', gear_id: 'b1' }),
+    activity({ type: 'MountainBikeRide', gear_id: 'b1' }),
+  ];
+  const stats = bikeStats(acts, [gear()]);
+  assert.equal(stats[0].rides, 5);
+});
+
+// ─── bikeStats: unit conversions ──────────────────────────
+
+test('bikeStats: distance converts meters → miles correctly', () => {
+  const acts = [activity({ distance: 1609.344 })]; // exactly 1 mile
+  const stats = bikeStats(acts, [gear()]);
+  assert.ok(Math.abs(stats[0].miles - 1) < 1e-6, `got ${stats[0].miles}`);
+});
+
+test('bikeStats: moving_seconds converts to hours correctly', () => {
+  const acts = [activity({ moving_time: 5400 })]; // 1.5h
+  const stats = bikeStats(acts, [gear()]);
+  assert.equal(stats[0].hours, 1.5);
+});
+
+// ─── bikeStats: dates ─────────────────────────────────────
+
+test('bikeStats: tracks first_used and last_used across rides', () => {
+  const acts = [
+    activity({ start_date: '2026-01-15T10:00:00Z', start_date_local: '2026-01-15T10:00:00' }),
+    activity({ start_date: '2026-04-01T10:00:00Z', start_date_local: '2026-04-01T10:00:00' }),
+    activity({ start_date: '2026-02-20T10:00:00Z', start_date_local: '2026-02-20T10:00:00' }),
+  ];
+  const stats = bikeStats(acts, [gear()]);
+  assert.equal(stats[0].first_used, '2026-01-15T10:00:00');
+  assert.equal(stats[0].last_used,  '2026-04-01T10:00:00');
+});
+
+// ─── bikeStats: edge cases ────────────────────────────────
+
+test('bikeStats: groups unassigned activities under null gear_id', () => {
+  const acts = [
+    activity({ gear_id: null }),
+    activity({ gear_id: undefined }),
+    activity({ gear_id: 'b1' }),
+  ];
+  const stats = bikeStats(acts, [gear()]);
+  const unassigned = stats.find(s => s.gear_id === null);
+  assert.ok(unassigned, 'expected an unassigned bucket');
+  assert.equal(unassigned.rides, 2);
+  assert.equal(unassigned.name, 'Unassigned');
+});
+
+test('bikeStats: handles unknown gear_id (not in gears list)', () => {
+  const acts = [activity({ gear_id: 'b99' })];
+  const stats = bikeStats(acts, []);
+  assert.equal(stats.length, 1);
+  assert.equal(stats[0].gear_id, 'b99');
+  assert.match(stats[0].name, /Unknown gear/);
+});
+
+test('bikeStats: handles activities missing optional fields', () => {
+  const acts = [{ type: 'Ride', gear_id: 'b1' }]; // no moving_time, distance, elevation
+  const stats = bikeStats(acts, [gear()]);
+  assert.equal(stats[0].moving_seconds, 0);
+  assert.equal(stats[0].distance_meters, 0);
+  assert.equal(stats[0].elevation_meters, 0);
+  assert.equal(stats[0].rides, 1);
+});
+
+test('bikeStats: surfaces gear metadata (brand, model, retired)', () => {
+  const acts = [activity({ gear_id: 'b1' })];
+  const gears = [gear({ id: 'b1', brand_name: 'Trek', model_name: 'Domane', retired: true })];
+  const stats = bikeStats(acts, gears);
+  assert.equal(stats[0].brand_name, 'Trek');
+  assert.equal(stats[0].model_name, 'Domane');
+  assert.equal(stats[0].retired, true);
+});
+
+// ─── gearAwards ───────────────────────────────────────────
+
+test('gearAwards: empty input → empty awards', () => {
+  assert.deepEqual(gearAwards([]), []);
+  assert.deepEqual(gearAwards(undefined), []);
+});
+
+test('gearAwards: workhorse → bike with most moving_seconds', () => {
+  const stats = [
+    { gear_id: 'b1', name: 'A', rides: 10, moving_seconds: 36000, distance_meters: 0, elevation_meters: 0 },
+    { gear_id: 'b2', name: 'B', rides: 5,  moving_seconds: 50000, distance_meters: 0, elevation_meters: 0 },
+  ];
+  const w = gearAwards(stats).find(a => a.type === 'gear_workhorse');
+  assert.equal(w.gear_id, 'b2');
+  assert.equal(w.value, 50000);
+});
+
+test('gearAwards: long_hauler → bike with most distance_meters', () => {
+  const stats = [
+    { gear_id: 'b1', name: 'A', rides: 1, moving_seconds: 1, distance_meters: 50000, elevation_meters: 0 },
+    { gear_id: 'b2', name: 'B', rides: 1, moving_seconds: 1, distance_meters: 30000, elevation_meters: 0 },
+  ];
+  assert.equal(gearAwards(stats).find(a => a.type === 'gear_long_hauler').gear_id, 'b1');
+});
+
+test('gearAwards: daily_driver → bike with most rides', () => {
+  const stats = [
+    { gear_id: 'b1', name: 'A', rides: 5,  moving_seconds: 1, distance_meters: 1, elevation_meters: 0 },
+    { gear_id: 'b2', name: 'B', rides: 12, moving_seconds: 1, distance_meters: 1, elevation_meters: 0 },
+  ];
+  assert.equal(gearAwards(stats).find(a => a.type === 'gear_daily_driver').gear_id, 'b2');
+});
+
+test('gearAwards: climber → bike with most elevation_meters', () => {
+  const stats = [
+    { gear_id: 'b1', name: 'A', rides: 1, moving_seconds: 1, distance_meters: 1, elevation_meters: 5000 },
+    { gear_id: 'b2', name: 'B', rides: 1, moving_seconds: 1, distance_meters: 1, elevation_meters: 9000 },
+  ];
+  assert.equal(gearAwards(stats).find(a => a.type === 'gear_climber').gear_id, 'b2');
+});
+
+test('gearAwards: ties broken alphabetically by name', () => {
+  const stats = [
+    { gear_id: 'b1', name: 'Zebra', rides: 5, moving_seconds: 1000, distance_meters: 1000, elevation_meters: 100 },
+    { gear_id: 'b2', name: 'Apple', rides: 5, moving_seconds: 1000, distance_meters: 1000, elevation_meters: 100 },
+  ];
+  const awards = gearAwards(stats);
+  assert.equal(awards.length, 4);
+  for (const a of awards) {
+    assert.equal(a.gear_id, 'b2', `${a.type} should pick alphabetical first on tie`);
+  }
+});
+
+test('gearAwards: skips unassigned bucket (null gear_id)', () => {
+  const stats = [
+    { gear_id: null, name: 'Unassigned', rides: 100, moving_seconds: 100000, distance_meters: 100000, elevation_meters: 100000 },
+    { gear_id: 'b1', name: 'Real', rides: 1, moving_seconds: 60, distance_meters: 1000, elevation_meters: 50 },
+  ];
+  const awards = gearAwards(stats);
+  assert.ok(awards.length > 0);
+  for (const a of awards) {
+    assert.equal(a.gear_id, 'b1', 'unassigned must never win');
+  }
+});
+
+test('gearAwards: skips zero-value categories', () => {
+  // Bike with zero elevation should not get gear_climber even as sole candidate
+  const stats = [
+    { gear_id: 'b1', name: 'Flat Bike', rides: 5, moving_seconds: 1000, distance_meters: 5000, elevation_meters: 0 },
+  ];
+  const awards = gearAwards(stats);
+  assert.ok(!awards.find(a => a.type === 'gear_climber'),
+    'no climber award when elevation is zero');
+  assert.ok(awards.find(a => a.type === 'gear_workhorse'),
+    'workhorse still fires');
+});
+
+test('gearAwards: single bike sweeps all four awards', () => {
+  const stats = [
+    { gear_id: 'b1', name: 'Only', rides: 10, moving_seconds: 36000, distance_meters: 50000, elevation_meters: 5000 },
+  ];
+  const awards = gearAwards(stats);
+  assert.equal(awards.length, 4);
+  for (const a of awards) assert.equal(a.gear_id, 'b1');
+  const types = new Set(awards.map(a => a.type));
+  assert.deepEqual(types, new Set([
+    'gear_workhorse', 'gear_long_hauler', 'gear_daily_driver', 'gear_climber'
+  ]));
+});


### PR DESCRIPTION
Closes #204 (partial — totals-based slice).

## What

Two pure functions for gear-level aggregation:

- `bikeStats(activities, gears)` → per-bike totals: `moving_seconds`, `distance_meters`, `elevation_meters`, `rides`, `first_used`, `last_used`, plus convenience `hours` / `miles`. Filters cycling activities only (Ride, VirtualRide, EBikeRide, GravelRide, MountainBikeRide). Activities without `gear_id` bucket under an "Unassigned" pseudo-bike (`gear_id: null`) so users can see what's slipping through.
- `gearAwards(stats)` → totals-based awards from a `bikeStats` array:
  - `gear_workhorse` — most moving time
  - `gear_long_hauler` — most distance
  - `gear_daily_driver` — most rides
  - `gear_climber` — most elevation gain

Ties are broken alphabetically by name. Categories where the best value is zero (e.g. flat-only fleet → no climber) don't issue. The Unassigned bucket never wins.

## What this is NOT (yet)

The issue lists many richer awards (Golden Grease 3000mi threshold, Quiver Killer activity-type diversity, PR Machine, Watt-Squeezer, etc.). Those need either thresholds + state, or additional data sources (segment efforts, power data). Deliberately out of scope for this PR — let's land the totals foundation first and layer those on.

No UI integration yet either. This PR is just the engine + tests; wiring it into Dashboard / award-config.js is a follow-up.

## TDD

Built TDD-first as a workflow demo:

1. Stub source so tests import → 22 tests, 20 RED with real assertion failures (not import errors)
2. Implementation → 20/22 green
3. Two remaining failures were **test bugs**, not impl bugs:
   - Float arithmetic: `16093.44 + 8000 = 24093.440000000002` (IEEE 754) — needed `Math.abs(... ) < 1e-6`
   - Date builder set `start_date` AND `start_date_local`; impl prefers `_local`; test override only changed one. Caught the inconsistency before it shipped.
4. After fixes → 22/22 green.

Tests use Node's built-in `node:test` (Node 18+) — zero new dependencies. Run with:

```
node --test test/gear-stats.test.js
```

This adds a JS unit-test surface alongside the existing Playwright integration harness in `test/harness.py`. The two are complementary: harness covers the IndexedDB → engine → DOM path; `node:test` covers pure functions.

## Files

- `src/gear-stats.js` — implementation
- `test/gear-stats.test.js` — 22 tests covering: aggregation, sorting, type filtering, unit conversion, dates, unassigned bucket, unknown gear, missing fields, gear metadata; award winners across all four categories, tie-breaking, unassigned exclusion, zero-value skip, single-bike sweep.