### PR TITLE
Surface Critical Power (CP) and W′ alongside FTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All merged pull requests for [aeyu.io](https://aeyu.io), a Strava-powered cyclin
 
 -----
 
+## 2026-05-25
+
+### Features
+
+- **Critical Power model (CP and W′)** — Fit a physiologically grounded 2-parameter Critical Power model from the all-time best power curve and surface CP and W′ alongside the existing FTP estimate in the Dashboard Power Curve card. CP marks the boundary between sustainable and unsustainable effort; W′ is the finite work reservoir above CP. The AI coach export now includes CP, W′, and predicted time-to-exhaustion above CP. FTP is retained for compatibility with downstream platforms.
+
+-----
+
 ## 2026-03-14
 
 ### Features

--- a/_MAP.md
+++ b/_MAP.md
@@ -1,24 +1,41 @@
 # aeyu.io/
-*Files: 15 | Subdirectories: 3*
+*Files: 17 | Subdirectories: 4*
 
 ## Subdirectories
 
+- [lat.md/](./lat.md/_MAP.md)
 - [src/](./src/_MAP.md)
 - [test/](./test/_MAP.md)
 - [worker/](./worker/_MAP.md)
 
 ## Files
 
+### CHANGELOG.md
+- aeyu.io Changelog `h1` :1
+- 2026-03-14 `h2` :7
+- 2026-03-13 `h2` :39
+- 2026-03-12 `h2` :51
+- 2026-03-11 `h2` :60
+- 2026-03-10 `h2` :95
+- 2026-03-09 `h2` :145
+- 2026-03-08 `h2` :207
+- 2025-05-24 – 2025-05-25 `h2` :220
+
 ### CLAUDE.md
 - CLAUDE.md — aeyu.io (Participation Awards) `h1` :1
 - What This Is `h2` :3
 - Code Navigation `h2` :9
-- Tech Stack `h2` :21
-- Architecture `h2` :30
-- Key Concepts `h2` :71
-- Development Patterns `h2` :89
-- Common Tasks `h2` :103
-- Gotchas `h2` :122
+- Tech Stack `h2` :22
+- Architecture `h2` :31
+- Key Concepts `h2` :72
+- Development Patterns `h2` :90
+- Common Tasks `h2` :113
+- Gotchas `h2` :133
+- Before starting work `h1` :153
+- Post-task checklist (REQUIRED — do not skip) `h1` :158
+- What is lat.md? `h1` :168
+- lat.md Commands `h1` :172
+- lat.md Syntax `h1` :182
 
 ### README.md
 - aeyu.io — Participation Awards `h1` :5
@@ -31,32 +48,60 @@
 - License `h2` :172
 - Acknowledgments `h2` :180
 
+### _FEATURES.md
+- _FEATURES.md — aeyu.io `h1` :1
+- Feature Inventory `h2` :5
+- 1. What the user sees `h2` :10
+- 2. Interactions `h2` :27
+- 3. Invariants `h2` :34
+- 4. Code `h2` :46
+- Page Documentation: `/demo.html` `h1` :65
+- 1. What the User Sees `h2` :69
+- 2. Interactions `h2` :91
+- 3. Invariants `h2` :106
+- 4. Code `h2` :121
+- 1. What the User Sees `h2` :138
+- 2. Interactions `h2` :157
+- 3. Invariants `h2` :164
+- 4. Code `h2` :175
+- 1. What the user sees `h2` :188
+- 2. Interactions `h2` :205
+- 3. Invariants `h2` :212
+- 4. Code `h2` :225
+- 1. What the User Sees `h2` :242
+- 2. Interactions `h2` :248
+- 3. Invariants `h2` :254
+- 4. Code `h2` :264
+
 ### activity.html
 > Imports: `app.js`
-- **showLoadError** (f) :42
-- **clearCacheAndReload** (f) :61
+- **showLoadError** (f) :49
+- **clearCacheAndReload** (f) :70
 
 ### callback.html
 > Imports: `auth.js`
 - *No top-level symbols*
 
+### coach-claude.html
+- *No top-level symbols*
+
 ### dashboard.html
 > Imports: `app.js`
-- **showLoadError** (f) :42
-- **clearCacheAndReload** (f) :61
+- **showLoadError** (f) :49
+- **clearCacheAndReload** (f) :70
 
 ### demo.html
 > Imports: `app.js`
-- **showLoadError** (f) :42
-- **clearCacheAndReload** (f) :61
+- **showLoadError** (f) :49
+- **clearCacheAndReload** (f) :70
 
 ### export.html
 - **getToken** (f) :2
 
 ### index.html
 > Imports: `app.js`
-- **showLoadError** (f) :42
-- **clearCacheAndReload** (f) :61
+- **showLoadError** (f) :49
+- **clearCacheAndReload** (f) :70
 
 ### participation-awards-spec.md
 - Participation Awards — Technical Spec `h1` :1
@@ -70,6 +115,9 @@
 - 7. Future Iterations (post-MVP) `h2` :445
 - 8. Open Questions `h2` :458
 
+### skill-callback.html
+- *No top-level symbols*
+
 ### sw.js
 - *No top-level symbols*
 
@@ -78,6 +126,4 @@
 - CNAME
 - demo-data.json
 - manifest.json
-- package-lock.json
-- package.json
 

--- a/lat.md/_MAP.md
+++ b/lat.md/_MAP.md
@@ -1,0 +1,56 @@
+# lat.md/
+*Files: 7*
+
+## Files
+
+### architecture.md
+- Architecture `h1` :1
+- Tech Stack `h2` :5
+- Data Flow `h2` :11
+- OAuth `h2` :22
+- Worker Proxy `h2` :28
+- Routing `h2` :34
+- Signals `h2` :40
+
+### awards.md
+- Awards `h1` :1
+- Award Computation `h2` :5
+- Data Quality Rules `h2` :11
+- Segment Awards `h2` :23
+- Ride-Level Awards `h2` :37
+- Comeback Mode `h2` :43
+- Streaks `h2` :55
+- Award Ranking `h2` :61
+
+### coaching.md
+- Coaching `h1` :1
+- Context Building `h2` :5
+- Single Ride Export `h2` :11
+- Segment Export `h2` :17
+- Markdown Output `h2` :21
+- Unit Conversion `h2` :25
+- Integration Points `h2` :29
+
+### data.md
+- Data `h1` :1
+- IndexedDB Schema `h2` :5
+- Sync Pipeline `h2` :21
+- Demo Mode `h2` :45
+- Settings Export `h2` :51
+
+### fitness.md
+- Fitness `h1` :1
+- Critical Power Model `h2` :5
+- Performance Capacity `h2` :15
+- Aerobic Efficiency `h2` :31
+- Interpretation `h2` :47
+
+### lat.md
+- *No top-level symbols*
+
+### routes.md
+- Routes `h1` :1
+- Detection Algorithm `h2` :5
+- Matching Activities to Routes `h2` :15
+- Design Decisions `h2` :19
+

--- a/lat.md/coaching.md
+++ b/lat.md/coaching.md
@@ -4,13 +4,13 @@ LLM export pipeline that builds compact context payloads for AI cycling coaching
 
 ## Context Building
 
-[[src/export-llm.js#buildLLMContext]] constructs a full coaching snapshot: recent ride summaries (slimmed to essential fields), weekly rollups with week-over-week deltas, power zone distribution, [[fitness]] summary, [[awards]] highlights, and [[routes#Detection Algorithm]] streak data.
+[[src/export-llm.js#buildLLMContext]] constructs a full coaching snapshot: recent ride summaries (slimmed to essential fields), weekly rollups with week-over-week deltas, power zone distribution, athlete-level Critical Power and W′ (see [[fitness#Critical Power Model]]), [[fitness]] summary, [[awards]] highlights, and [[routes#Detection Algorithm]] streak data.
 
 Activities are filtered by a configurable day window (default 90 days). Each ride is compressed by `slimActivity` to ~10 fields — name, date, distance, time, elevation, power metrics, heart rate. Weekly rollups aggregate distance, elevation, moving time, and ride count.
 
 ## Single Ride Export
 
-[[src/export-llm.js#buildRideExport]] produces a focused payload for coaching a specific ride. Includes the ride's segment efforts with per-segment history context, awards earned, [[fitness]] form snapshot at the time of the ride, and power curve data.
+[[src/export-llm.js#buildRideExport]] produces a focused payload for coaching a specific ride. Includes the ride's segment efforts with per-segment history context, awards earned, [[fitness]] form snapshot at the time of the ride, power curve data, and the athlete's CP/W′ when fittable.
 
 Segment efforts are slimmed to time, rank within history, delta from PR, and whether a power meter was present. This gives an LLM enough context to comment on pacing and effort distribution.
 

--- a/lat.md/fitness.md
+++ b/lat.md/fitness.md
@@ -2,6 +2,16 @@
 
 Two complementary form indicators computed entirely from local IndexedDB data. No additional API calls — uses segment efforts and activity data already synced. Entry point: [[src/fitness.js#computeFitnessSummary]].
 
+## Critical Power Model
+
+The 2-parameter Critical Power model (CP, W′) is a physiologically grounded alternative to FTP. Fitted from the all-time best power curve by [[src/critical-power.js#estimateCriticalPower]] via linear regression W = CP·t + W′ over 3–30 min bests.
+
+CP marks the boundary between two regimes: below CP, oxygen uptake reaches steady-state and effort is sustainable in principle; above CP, oxygen uptake keeps climbing toward maximum and W′ (a finite work reservoir, in joules) depletes linearly with the power excess. Time-to-exhaustion above CP is t = W′ / (P − CP) — exposed as [[src/critical-power.js#timeToExhaustion]].
+
+CP and W′ are surfaced alongside the existing FTP estimate in the Dashboard Power Curve card and in the AI coach export. FTP (95% of 20-min best) is retained for compatibility with downstream training platforms; it lacks direct physiological grounding (PMC7552657) but remains the lingua franca of consumer cycling tools.
+
+Fit quality requires at least two durations spaced ≥300s apart. With only the standard 5-min and 20-min bests (the production [[src/power-curve.js#POWER_CURVE_DURATIONS]]), the fit is exact-2-point (no R²); when richer curves are available (demo data, future enrichment), the regression returns R² as well.
+
 ## Performance Capacity
 
 Measures what the athlete's body can produce on the bike. Uses climb segment performance over time to produce a 0-100 index relative to the athlete's own all-time range. Does not require heart rate or power meter data.

--- a/lat.md/lat.md
+++ b/lat.md/lat.md
@@ -3,6 +3,6 @@ A 100% client-side cycling awards app. Connects to Strava via OAuth, syncs activ
 - [architecture.md](architecture.md) — System design: client-only PWA, OAuth proxy worker, data flow
 - [awards.md] — Award computation engine: 30+ award types, data quality rules, comeback mode
 - [data.md] — IndexedDB schema, Strava sync pipeline, rate limiting, demo mode
-- [fitness.md] — Form indicators: Performance Capacity (climb VAM) and Aerobic Efficiency (NP/HR)
+- [fitness.md] — Form indicators: Critical Power (CP/W′), Performance Capacity (climb VAM), Aerobic Efficiency (NP/HR)
 - [routes.md] — Route detection via segment fingerprinting and Jaccard similarity
 - [coaching.md] — LLM export pipeline for AI cycling coaching integration

--- a/src/_MAP.md
+++ b/src/_MAP.md
@@ -1,5 +1,5 @@
 # src/
-*Files: 15 | Subdirectories: 1*
+*Files: 18 | Subdirectories: 1*
 
 ## Subdirectories
 
@@ -24,17 +24,18 @@
 
 ### award-config.js
 - **AWARD_LABELS** (variable) :9
-- **AWARD_COLORS** (variable) :68
+- **AWARD_COLORS** (variable) :70
+- **AWARD_GROUPS** (variable) :76
 
 ### awards.js
 > Imports: `db.js, units.js, routes.js`
-- **rankSegmentAwards** (f) `(awards)` :241
-- **computeAwards** (f) `(activity, resetEvent = null, referencePoints = [])` :581
-- **computeRideLevelAwards** (f) `(activity, allActivities, resetEvent = null)` :1141
-- **computeAwardsForActivities** (f) `(activities)` :1848
-- **computeWeeklyStreaks** (f) `(allActivities)` :1979
-- **detectGroupRides** (f) `(allActivities)` :2087
-- **computeStreakData** (f) `(allActivities)` :2247
+- **rankSegmentAwards** (f) `(awards)` :248
+- **computeAwards** (f) `(activity, resetEvent = null, referencePoints = [])` :643
+- **computeRideLevelAwards** (f) `(activity, allActivities, resetEvent = null)` :1228
+- **computeAwardsForActivities** (f) `(activities, disabledAwardTypes = null)` :1935
+- **computeWeeklyStreaks** (f) `(allActivities)` :2093
+- **detectGroupRides** (f) `(allActivities, routes = [])` :2215
+- **computeStreakData** (f) `(allActivities, routes = [])` :2416
 
 ### config.js
 - **STRAVA_CLIENT_ID** (variable) :6
@@ -43,6 +44,13 @@
 - **STRAVA_API_BASE** (variable) :9
 - **OAUTH_REDIRECT_URI** (variable) :10
 - **OAUTH_SCOPE** (variable) :11
+
+### critical-power.js
+- **CP_FIT_DURATIONS** (variable) :29
+- **estimateCriticalPower** (f) `(powerCurve)` :48
+- **timeToExhaustion** (f) `(power, cp, wPrime)` :106
+- **sustainablePower** (f) `(seconds, cp, wPrime)` :116
+- **canFitCP** (f) `(powerCurve)` :124
 
 ### db.js
 - **switchToDemoDB** (f) `()` :14
@@ -55,47 +63,68 @@
 - **putActivity** (f) `(activity)` :128
 - **putActivities** (f) `(activities)` :138
 - **getActivity** (f) `(id)` :151
-- **getActivitiesByYear** (f) `(year)` :161
-- **getActivitiesWithoutEfforts** (f) `()` :175
-- **getActivitiesWithoutPower** (f) `()` :194
-- **getActivitiesWithoutHeartRate** (f) `()` :211
-- **getAllActivities** (f) `()` :224
-- **putSegment** (f) `(segment)` :236
-- **getSegment** (f) `(id)` :246
-- **getAllSegments** (f) `()` :256
-- **appendEffort** (f) `(segmentId, segmentData, effort)` :266
-- **removeEffortsForActivity** (f) `(activityId)` :307
-- **getResetEvent** (f) `()` :343
-- **setResetEvent** (f) `(event)` :353
-- **clearResetEvent** (f) `()` :365
-- **recordRecoveryMilestone** (f) `(segmentId, threshold)` :379
-- **getUserConfig** (f) `()` :397
-- **setUserConfig** (f) `(config)` :407
-- **getSyncState** (f) `()` :433
-- **updateSyncState** (f) `(updates)` :443
-- **putRoutes** (f) `(routes)` :457
-- **getAllRoutes** (f) `()` :471
-- **clearAllData** (f) `()` :481
+- **getActivitiesByIds** (f) `(ids)` :161
+- **getActivitiesByYear** (f) `(year)` :173
+- **getActivitiesWithoutEfforts** (f) `()` :187
+- **getActivitiesWithoutPower** (f) `()` :206
+- **getActivitiesWithoutHeartRate** (f) `()` :223
+- **getActivitiesWithoutZones** (f) `()` :236
+- **getAllActivities** (f) `()` :252
+- **putSegment** (f) `(segment)` :264
+- **getSegment** (f) `(id)` :274
+- **getAllSegments** (f) `()` :284
+- **appendEffort** (f) `(segmentId, segmentData, effort)` :294
+- **removeEffortsForActivity** (f) `(activityId)` :335
+- **getResetEvent** (f) `()` :371
+- **setResetEvent** (f) `(event)` :381
+- **clearResetEvent** (f) `()` :393
+- **recordRecoveryMilestone** (f) `(segmentId, threshold)` :407
+- **getUserConfig** (f) `()` :425
+- **setUserConfig** (f) `(config)` :435
+- **getSyncState** (f) `()` :461
+- **updateSyncState** (f) `(updates)` :471
+- **putRoutes** (f) `(routes)` :485
+- **getAllRoutes** (f) `()` :499
+- **putStravaRoutes** (f) `(routes)` :511
+- **getStravaRoutes** (f) `()` :521
+- **exportSettings** (f) `()` :533
+- **importSettings** (f) `(data)` :553
+- **clearAllData** (f) `()` :589
 
 ### demo.js
-> Imports: `signals, db.js, auth.js`
-- **isDemo** (variable) :10
-- **checkDemo** (f) `()` :21
-- **startDemo** (f) `()` :50
-- **exitDemo** (f) `()` :106
+> Imports: `signals, db.js, auth.js, routes.js`
+- **isDemo** (variable) :11
+- **demoError** (variable) :12
+- **checkDemo** (f) `()` :24
+- **startDemo** (f) `()` :53
+- **exitDemo** (f) `()` :127
+
+### export-llm.js
+> Imports: `db.js, fitness.js, awards.js, units.js, award-config.js`...
+- **buildLLMContext** (f) `(options = {})` :318
+- **convertContextUnits** (f) `(ctx)` :416
+- **contextToMarkdown** (f) `(ctx)` :423
+- **buildRideExport** (f) `(activityId, options = {})` :655
+- **rideToMarkdown** (f) `(ctx)` :775
+- **buildSegmentExport** (f) `(segmentId)` :926
+- **segmentToMarkdown** (f) `(ctx)` :980
 
 ### fitness.js
 > Imports: `db.js`
-- **computePerformanceCapacity** (f) `()` :74
-- **computeAerobicEfficiency** (f) `()` :217
-- **computeFitnessSummary** (f) `()` :340
+- **computePerformanceCapacity** (f) `()` :79
+- **computeAerobicEfficiency** (f) `()` :280
+- **computeFitnessSummary** (f) `()` :447
+
+### gear-stats.js
+- **bikeStats** (f) `(activities, gears)` :49
+- **gearAwards** (f) `(stats)` :130
 
 ### icons.js
 > Imports: `preact`
-- **renderIconSVG** (f) `(type, { size = 16, color = "#6B6260", strokeWidth } = {})` :366
-- **AwardIcon** (f) `({ type, size, color, strokeWidth })` :413
-- **drawIcon** (f) `(ctx, type, x, y, size, color, strokeWidth = 2)` :432
-- **ICON_TYPES** (variable) :516
+- **renderIconSVG** (f) `(type, { size = 16, color = "#6B6260", strokeWidth } = {})` :368
+- **AwardIcon** (f) `({ type, size, color, strokeWidth })` :415
+- **drawIcon** (f) `(ctx, type, x, y, size, color, strokeWidth = 2)` :434
+- **ICON_TYPES** (variable) :518
 
 ### install.js
 > Imports: `signals`
@@ -105,35 +134,33 @@
 - **dismissInstallBanner** (f) `()` :62
 
 ### power-curve.js
-> Imports: `config.js, auth.js, db.js, signals`
-- **POWER_CURVE_DURATIONS** (variable) :25
-- **DURATION_LABELS** (variable) :28
-- **powerCurveProgress** (variable) :38
-- **computePowerCurve** (f) `(watts)` :53
-- **estimateFTP** (f) `(powerCurve)` :81
-- **fetchAndComputePowerCurve** (f) `(activityId)` :137
-- **getActivitiesNeedingPowerCurves** (f) `()` :170
-- **getAllTimeBestCurve** (f) `()` :181
+> Imports: `db.js`
+- **POWER_CURVE_DURATIONS** (variable) :22
+- **DURATION_LABELS** (variable) :25
+- **computePowerCurve** (f) `(watts)` :39
+- **estimateFTP** (f) `(powerCurve)` :66
+- **getAllTimeBestCurve** (f) `()` :75
 
 ### routes.js
-- **detectRoutes** (f) `(activities)` :57
-- **findRouteForActivity** (f) `(activity, routes)` :125
+- **detectRoutes** (f) `(activities, stravaRoutes = [])` :102
+- **findRouteForActivity** (f) `(activity, routes)` :223
 
 ### sync.js
-> Imports: `signals, config.js, auth.js, db.js`
-- **syncProgress** (variable) :24
-- **rateLimitStatus** (variable) :33
-- **isSyncing** (variable) :40
-- **startBackfill** (f) `(onProgress)` :551
-- **incrementalSync** (f) `()` :663
-- **updateSyncWindow** (f) `(newEpoch)` :731
-- **manualSync** (f) `(onProgress)` :756
-- **startAutoSync** (f) `(onComplete)` :782
-- **stopAutoSync** (f) `()` :791
-- **resyncActivity** (f) `(activityId)` :858
+> Imports: `signals, config.js, auth.js, db.js, power-curve.js`
+- **syncProgress** (variable) :29
+- **rateLimitStatus** (variable) :38
+- **isSyncing** (variable) :45
+- **syncRoutes** (f) `()` :590
+- **startBackfill** (f) `(onProgress)` :759
+- **incrementalSync** (f) `()` :881
+- **updateSyncWindow** (f) `(newEpoch)` :956
+- **manualSync** (f) `(onProgress)` :981
+- **startAutoSync** (f) `(onComplete)` :1007
+- **stopAutoSync** (f) `()` :1016
+- **resyncActivity** (f) `(activityId)` :1083
 
 ### touch-tooltip.js
-- **initTouchTooltips** (f) `()` :62
+- **initTouchTooltips** (f) `()` :69
 
 ### units.js
 > Imports: `signals, db.js`
@@ -144,8 +171,8 @@
 - **formatElevation** (f) `(meters)` :69
 - **formatSpeed** (f) `(metersPerSecond)` :77
 - **formatTime** (f) `(seconds)` :87
-- **formatDate** (f) `(isoString)` :100
-- **formatDateWeekday** (f) `(isoString)` :109
-- **formatDateFull** (f) `(isoString)` :118
-- **formatPower** (f) `(watts)` :128
+- **formatDate** (f) `(isoString)` :101
+- **formatDateWeekday** (f) `(isoString)` :110
+- **formatDateFull** (f) `(isoString)` :119
+- **formatPower** (f) `(watts)` :129
 

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -56,6 +56,7 @@ import { renderIconSVG } from "../icons.js";
 import { AWARD_LABELS, AWARD_GROUPS } from "../award-config.js";
 import { computeFitnessSummary } from "../fitness.js";
 import { getAllTimeBestCurve, estimateFTP, POWER_CURVE_DURATIONS, DURATION_LABELS } from "../power-curve.js";
+import { estimateCriticalPower } from "../critical-power.js";
 import { StickyHeader, headerCompact } from "./StickyHeader.js";
 import { buildLLMContext, contextToMarkdown, convertContextUnits } from "../export-llm.js";
 import { detectRoutes } from "../routes.js";
@@ -422,7 +423,11 @@ async function loadDashboard() {
     try {
       const bestCurve = await getAllTimeBestCurve();
       if (Object.keys(bestCurve).length > 0) {
-        powerCurveData.value = { curve: bestCurve, ftp: estimateFTP(bestCurve) };
+        powerCurveData.value = {
+          curve: bestCurve,
+          ftp: estimateFTP(bestCurve),
+          cp: estimateCriticalPower(bestCurve),
+        };
       }
     } catch (e) {
       console.warn("Power curve computation failed:", e);
@@ -1082,16 +1087,29 @@ export function Dashboard() {
               <h2 class="inline-flex items-center" style="font-family: var(--font-display); font-size: 1.125rem; color: var(--text); margin: 0;">Power Curve
                 <${ChartHelp} id="power-curve">
                   Your all-time best average power at each standard duration from your power meter data.<br/><br/>
-                  <strong>FTP</strong> (Functional Threshold Power) is estimated as 95% of your best 20-minute power. Durations: 5s sprint, 30s, 1 min, 5 min VO\u2082max, 20 min FTP, 60 min sustained.
+                  <strong>FTP</strong> (Functional Threshold Power) is estimated as 95% of your best 20-minute power. Durations: 5s sprint, 30s, 1 min, 5 min VO\u2082max, 20 min FTP, 60 min sustained.<br/><br/>
+                  <strong>CP</strong> (Critical Power) and <strong>W\u2032</strong> are fitted from your 3\u201330 min bests via W = CP\u00b7t + W\u2032. CP is the boundary between sustainable and unsustainable effort; W\u2032 is the finite work reservoir you can spend above CP (in kJ). More physiologically grounded than FTP \u2014 see the FAQ.
                 <//>
               </h2>
-              ${powerCurveData.value.ftp && html`
-                <div class="flex items-center gap-1.5" title="Estimated FTP: 95% of 20-min best power">
-                  <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">est. FTP</span>
-                  <span style="font-family: var(--font-display); font-size: 1.25rem; color: var(--text);">${powerCurveData.value.ftp}</span>
-                  <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">W</span>
-                </div>
-              `}
+              <div class="flex items-center gap-3">
+                ${powerCurveData.value.cp && html`
+                  <div class="flex items-center gap-1.5" title="Critical Power: boundary between sustainable and unsustainable effort, fitted from 3\u201330 min bests">
+                    <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">CP</span>
+                    <span style="font-family: var(--font-display); font-size: 1.25rem; color: var(--text);">${powerCurveData.value.cp.cp}</span>
+                    <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">W</span>
+                    <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary); margin-left: 0.25rem;">\u00b7 W\u2032</span>
+                    <span style="font-family: var(--font-display); font-size: 1rem; color: var(--text);">${(powerCurveData.value.cp.wPrime / 1000).toFixed(1)}</span>
+                    <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">kJ</span>
+                  </div>
+                `}
+                ${powerCurveData.value.ftp && html`
+                  <div class="flex items-center gap-1.5" title="Estimated FTP: 95% of 20-min best power">
+                    <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">est. FTP</span>
+                    <span style="font-family: var(--font-display); font-size: 1.25rem; color: var(--text);">${powerCurveData.value.ftp}</span>
+                    <span style="font-family: var(--font-body); font-size: 0.75rem; color: var(--text-tertiary);">W</span>
+                  </div>
+                `}
+              </div>
             </div>
             <div style="display: flex; flex-direction: column; gap: 6px;">
               ${POWER_CURVE_DURATIONS.filter((dur) => powerCurveData.value.curve[dur]).map((dur) => {
@@ -1664,6 +1682,19 @@ export function Dashboard() {
                 <div class="pt-3 pb-1 space-y-2" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
                   <p>If you ride with a power meter, the app can fetch your per-second power data and compute your <strong>power curve</strong> — your best average power at standard durations (5s sprint, 30s, 1 min, 5 min VO2max, 20 min FTP proxy, 60 min sustained).</p>
                   <p>Your <strong>FTP</strong> (Functional Threshold Power) is estimated as 95% of your best 20-minute power. Awards like Curve Year Best and Curve Record track improvements at each duration. Power curve data is fetched and cached locally over multiple sync sessions.</p>
+                </div>
+              </details>
+
+              <details class="group py-3">
+                <summary class="flex items-center justify-between cursor-pointer" style="font-family: var(--font-body); font-size: 0.875rem; font-weight: 500; color: var(--text);">
+                  What are CP and W′? Why show them next to FTP?
+                  <svg class="w-4 h-4 group-open:rotate-180 transition-transform flex-shrink-0 ml-2" style="color: var(--text-tertiary);" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                </summary>
+                <div class="pt-3 pb-1 space-y-2" style="font-family: var(--font-body); font-size: 0.875rem; color: var(--text-secondary);">
+                  <p><strong>Critical Power (CP)</strong> is the boundary between two physiologically distinct regimes. Below CP, your oxygen uptake reaches a steady state and effort is sustainable in principle. Above CP, oxygen uptake keeps climbing toward maximum and exhaustion becomes mathematically inevitable.</p>
+                  <p><strong>W′</strong> ("W-prime", in kJ) is the finite work reservoir you can spend above CP. The model predicts time-to-exhaustion at a constant power above CP as t = W′ / (P − CP).</p>
+                  <p>aeyu fits CP and W′ from your power curve via the linear work-time form W = CP·t + W′, using bests in the 3–30 minute range where the model holds.</p>
+                  <p>FTP, by contrast, is an operational definition (95% of a 20-minute max) without direct physiological grounding — it doesn't reliably align with CP, lactate threshold 1, or LT2. We show both: FTP for compatibility with training platforms you already use, CP/W′ for the science.</p>
                 </div>
               </details>
 

--- a/src/components/_MAP.md
+++ b/src/components/_MAP.md
@@ -1,15 +1,15 @@
 # components/
-*Files: 7*
+*Files: 8*
 
 ## Files
 
 ### ActivityDetail.js
 > Imports: `preact, signals, hooks, db.js, awards.js`...
-- **ActivityDetail** (f) `({ id })` :1054
+- **ActivityDetail** (f) `({ id })` :1179
 
 ### Dashboard.js
 > Imports: `preact, signals, hooks, auth.js, sync.js`...
-- **Dashboard** (f) `()` :185
+- **Dashboard** (f) `()` :441
 
 ### InstallBanner.js
 > Imports: `preact, install.js`
@@ -21,7 +21,7 @@
 
 ### SegmentSparkline.js
 > Imports: `preact, hooks, units.js`
-- **SegmentSparkline** (f) `({ segment, currentEffortId })` :58
+- **SegmentSparkline** (f) `({ segment, currentEffortId, stravaSegmentId, onExportLLM, exportLlmStatus })` :58
 
 ### StickyHeader.js
 > Imports: `preact, signals, hooks, auth.js, demo.js`
@@ -43,4 +43,8 @@
 ### SyncProgress.js
 > Imports: `preact, hooks, sync.js, auth.js, app.js`
 - **SyncProgress** (f) `()` :12
+
+### TrendChart.js
+> Imports: `preact, units.js`
+- **TrendChart** (f) `({ rides: rawRides, highlightId })` :6
 

--- a/src/critical-power.js
+++ b/src/critical-power.js
@@ -1,0 +1,136 @@
+/**
+ * Critical Power model — CP and W' from the power curve.
+ *
+ * The 2-parameter CP model (Monod & Scherrer 1965) treats sustainable cycling
+ * as a two-regime system:
+ *
+ *   Below CP: steady-state VO2, sustainable in principle.
+ *   Above CP: VO2 keeps rising toward max; exhaustion is mathematically
+ *             inevitable. W' (a finite work reservoir, in joules) depletes
+ *             linearly with the power excess above CP.
+ *
+ * Linear work-time form (preferred for fitting):  W = CP·t + W'
+ *   where W_i = P_i · t_i is the work done at the duration-i mean maximal power.
+ *
+ * Unlike FTP (operationally 95% of 20-min max), CP has direct physiological
+ * grounding and predicts time-to-exhaustion above threshold via
+ *   t = W' / (P - CP).
+ *
+ * Reference: PMC7552657 (Critical Power narrative review).
+ */
+
+/**
+ * Durations (in seconds) considered valid for CP fitting.
+ *
+ * Lower bound (~3 min): below this, the anaerobic contribution dominates and
+ * breaks the linear assumption. Upper bound (~30 min): above this, aerobic
+ * fatigue accumulates and curves the W vs t line downward.
+ */
+export const CP_FIT_DURATIONS = [180, 300, 600, 720, 900, 1200, 1500, 1800];
+const MIN_CP_DURATION = 180;
+const MAX_CP_DURATION = 1800;
+
+/** Minimum durations required for a fit. Two points → exact 2-parameter solve. */
+const MIN_FIT_POINTS = 2;
+
+/** Minimum spread between shortest and longest fit duration (seconds). */
+const MIN_DURATION_SPREAD = 300;
+
+/**
+ * Estimate Critical Power (CP) and anaerobic work capacity (W') from a
+ * power curve via linear regression of W = CP·t + W'.
+ *
+ * @param {Object} powerCurve — {duration_in_seconds: best_average_watts}
+ * @returns {{cp: number, wPrime: number, fitDurations: number[], rSquared: number|null, points: Array<{t:number, p:number, w:number}>}|null}
+ *   `cp` in watts, `wPrime` in joules. Returns null if fewer than two
+ *   durations fall in the valid CP range or the fit is degenerate.
+ */
+export function estimateCriticalPower(powerCurve) {
+  if (!powerCurve) return null;
+
+  const points = [];
+  for (const dur of CP_FIT_DURATIONS) {
+    const watts = powerCurve[dur];
+    if (!watts || watts <= 0) continue;
+    points.push({ t: dur, p: watts, w: watts * dur });
+  }
+
+  if (points.length < MIN_FIT_POINTS) return null;
+
+  const spread = points[points.length - 1].t - points[0].t;
+  if (spread < MIN_DURATION_SPREAD) return null;
+
+  // Linear regression: W = CP·t + W'  →  slope = CP, intercept = W'
+  const n = points.length;
+  let sumT = 0, sumW = 0, sumTT = 0, sumTW = 0;
+  for (const { t, w } of points) {
+    sumT += t;
+    sumW += w;
+    sumTT += t * t;
+    sumTW += t * w;
+  }
+  const denom = n * sumTT - sumT * sumT;
+  if (denom === 0) return null;
+
+  const cp = (n * sumTW - sumT * sumW) / denom;
+  const wPrime = (sumW - cp * sumT) / n;
+
+  if (!isFinite(cp) || !isFinite(wPrime) || cp <= 0 || wPrime <= 0) return null;
+
+  // Coefficient of determination for fit quality (only meaningful with ≥3 points).
+  let rSquared = null;
+  if (n >= 3) {
+    const meanW = sumW / n;
+    let ssTot = 0, ssRes = 0;
+    for (const { t, w } of points) {
+      const predicted = cp * t + wPrime;
+      ssTot += (w - meanW) ** 2;
+      ssRes += (w - predicted) ** 2;
+    }
+    rSquared = ssTot > 0 ? 1 - ssRes / ssTot : null;
+  }
+
+  return {
+    cp: Math.round(cp),
+    wPrime: Math.round(wPrime),
+    fitDurations: points.map((p) => p.t),
+    rSquared,
+    points,
+  };
+}
+
+/**
+ * Predicted time-to-exhaustion at a constant power above CP.
+ * Returns null for powers at or below CP (sustainable indefinitely in model).
+ */
+export function timeToExhaustion(power, cp, wPrime) {
+  if (!power || !cp || !wPrime || power <= cp) return null;
+  return wPrime / (power - cp);
+}
+
+/**
+ * Predicted sustainable power for a given duration.
+ *   P(t) = CP + W' / t
+ * Returns null for non-positive durations.
+ */
+export function sustainablePower(seconds, cp, wPrime) {
+  if (!seconds || seconds <= 0 || !cp || !wPrime) return null;
+  return cp + wPrime / seconds;
+}
+
+/**
+ * Whether a power curve has enough data in the CP-valid range to fit.
+ */
+export function canFitCP(powerCurve) {
+  if (!powerCurve) return false;
+  let count = 0;
+  let minT = Infinity, maxT = -Infinity;
+  for (const dur of CP_FIT_DURATIONS) {
+    if (powerCurve[dur] && powerCurve[dur] > 0) {
+      count++;
+      if (dur < minT) minT = dur;
+      if (dur > maxT) maxT = dur;
+    }
+  }
+  return count >= MIN_FIT_POINTS && (maxT - minT) >= MIN_DURATION_SPREAD;
+}

--- a/src/export-llm.js
+++ b/src/export-llm.js
@@ -12,6 +12,7 @@ import { computeStreakData, computeAwardsForActivities, computeAwards, computeRi
 import { unitSystem, formatDistance, formatElevation, formatSpeed } from "./units.js";
 import { AWARD_LABELS } from "./award-config.js";
 import { estimateFTP, POWER_CURVE_DURATIONS, DURATION_LABELS, getAllTimeBestCurve } from "./power-curve.js";
+import { estimateCriticalPower } from "./critical-power.js";
 
 function filterByDays(activities, days) {
   const cutoff = Date.now() - days * 86400000;
@@ -335,6 +336,7 @@ export async function buildLLMContext(options = {}) {
   const bestCurve = await getAllTimeBestCurve();
   const estimatedFTP = estimateFTP(bestCurve);
   const ftp = storedFTP || estimatedFTP;
+  const criticalPower = estimateCriticalPower(bestCurve);
 
   const zoneDistribution = buildZoneDistribution(recent, ftp);
   const powerCurveSnapshot = buildPowerCurveSnapshot(sorted);
@@ -349,6 +351,13 @@ export async function buildLLMContext(options = {}) {
     week_over_week: buildWeekOverWeekDelta(weeklyRollups),
     zone_distribution: zoneDistribution,
     power_curve: powerCurveSnapshot,
+    critical_power: criticalPower ? {
+      cp_watts: criticalPower.cp,
+      w_prime_joules: criticalPower.wPrime,
+      w_prime_kj: +(criticalPower.wPrime / 1000).toFixed(2),
+      fit_durations_s: criticalPower.fitDurations,
+      r_squared: criticalPower.rSquared,
+    } : null,
     monthly_trends: buildMonthlyDeltas(recent),
     rides_in_window: recent.length,
   };
@@ -522,6 +531,17 @@ export function contextToMarkdown(ctx) {
       md += `\n`;
     }
     md += `\n`;
+  }
+
+  if (ctx.critical_power) {
+    const cp = ctx.critical_power;
+    md += `## Critical Power Model (all-time bests, linear W = CP·t + W′ fit)\n`;
+    md += `- **CP**: ${cp.cp_watts}W — sustainable/unsustainable boundary\n`;
+    md += `- **W′**: ${cp.w_prime_kj}kJ (${cp.w_prime_joules}J) — finite work reservoir above CP\n`;
+    md += `- Fit durations (s): ${cp.fit_durations_s.join(", ")}`;
+    if (cp.r_squared != null) md += ` · R² ${cp.r_squared.toFixed(3)}`;
+    md += `\n`;
+    md += `- Time to exhaustion at P > CP: t = W′ / (P − CP). At CP+50W: ${Math.round(cp.w_prime_joules / 50)}s. At CP+100W: ${Math.round(cp.w_prime_joules / 100)}s.\n\n`;
   }
 
   if (ctx.monthly_trends.length > 0) {
@@ -703,6 +723,13 @@ export async function buildRideExport(activityId, options = {}) {
       const userCfg = await getUserConfig();
       const bestCurve = await getAllTimeBestCurve();
       const ftp = userCfg.ftp || estimateFTP(bestCurve);
+      const cp = estimateCriticalPower(bestCurve);
+      if (cp) {
+        ctx.athlete_cp = {
+          cp_watts: cp.cp,
+          w_prime_kj: +(cp.wPrime / 1000).toFixed(2),
+        };
+      }
       if (ftp) {
         const BOUNDARIES = [0.55, 0.75, 0.90, 1.05, 1.20, 1.50];
         const zoneNames = ["Z1", "Z2", "Z3", "Z4", "Z5", "Z6", "Z7"];
@@ -786,6 +813,12 @@ export function rideToMarkdown(ctx) {
       md += `\n`;
     }
     md += `\n`;
+  }
+
+  if (ctx.athlete_cp) {
+    md += `## Athlete Critical Power (all-time)\n`;
+    md += `- CP: ${ctx.athlete_cp.cp_watts}W · W′: ${ctx.athlete_cp.w_prime_kj}kJ\n`;
+    md += `- Above CP, time-to-exhaustion = W′ / (P − CP).\n\n`;
   }
 
   if (ctx.ride_awards.length > 0) {

--- a/test/_MAP.md
+++ b/test/_MAP.md
@@ -1,11 +1,15 @@
 # test/
-*Files: 4 | Subdirectories: 1*
+*Files: 5 | Subdirectories: 1*
 
 ## Subdirectories
 
 - [screenshots/](./screenshots/_MAP.md)
 
 ## Files
+
+### gear-stats.test.js
+> Imports: `node:test, strict, gear-stats.js`
+- *No top-level symbols*
 
 ### harness.py
 > Imports: `json, math, os, random, sys`...

--- a/test/critical-power.test.js
+++ b/test/critical-power.test.js
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  estimateCriticalPower,
+  timeToExhaustion,
+  sustainablePower,
+  canFitCP,
+  CP_FIT_DURATIONS,
+} from '../src/critical-power.js';
+
+const synthCurve = (cp, wPrime, durations = CP_FIT_DURATIONS) => {
+  const curve = {};
+  for (const t of durations) curve[t] = cp + wPrime / t;
+  return curve;
+};
+
+test('estimateCriticalPower: exact synthetic data recovers CP and W′', () => {
+  const r = estimateCriticalPower(synthCurve(250, 20000));
+  assert.equal(r.cp, 250);
+  assert.equal(r.wPrime, 20000);
+  assert.ok(r.rSquared > 0.999, `R² should ≈ 1, got ${r.rSquared}`);
+});
+
+test('estimateCriticalPower: 2-point fit (5min + 20min) exact-recovers', () => {
+  const r = estimateCriticalPower(synthCurve(280, 18000, [300, 1200]));
+  assert.equal(r.cp, 280);
+  assert.equal(r.wPrime, 18000);
+  assert.equal(r.rSquared, null, '2-point fit has no R²');
+  assert.deepEqual(r.fitDurations, [300, 1200]);
+});
+
+test('estimateCriticalPower: ignores out-of-range durations', () => {
+  const curve = { 5: 800, 30: 600, 60: 450, ...synthCurve(250, 20000, [300, 1200]), 3600: 200 };
+  const r = estimateCriticalPower(curve);
+  assert.deepEqual(r.fitDurations, [300, 1200]);
+  assert.equal(r.cp, 250);
+});
+
+test('estimateCriticalPower: null inputs and edge cases return null', () => {
+  assert.equal(estimateCriticalPower(null), null);
+  assert.equal(estimateCriticalPower(undefined), null);
+  assert.equal(estimateCriticalPower({}), null);
+  assert.equal(estimateCriticalPower({ 300: 250 }), null, 'single point');
+  assert.equal(estimateCriticalPower({ 5: 800, 30: 600 }), null, 'all below fit range');
+  assert.equal(estimateCriticalPower({ 300: 0, 1200: 0 }), null, 'zero watts');
+});
+
+test('estimateCriticalPower: rejects degenerate spread', () => {
+  const r = estimateCriticalPower({ 300: 300, 360: 290 });
+  assert.equal(r, null, 'spread < 300s should fail');
+});
+
+test('estimateCriticalPower: noisy realistic curve produces sensible fit', () => {
+  const noisy = { 5: 526, 15: 495, 30: 323, 60: 285, 120: 291, 300: 227, 600: 218, 1200: 207, 1800: 198 };
+  const r = estimateCriticalPower(noisy);
+  assert.ok(r.cp > 100 && r.cp < 250, `CP ${r.cp} should be in plausible range`);
+  assert.ok(r.wPrime > 5000 && r.wPrime < 30000, `W′ ${r.wPrime} should be in plausible range`);
+  assert.ok(r.rSquared > 0.95, `R² ${r.rSquared} should be high for monotone curve`);
+});
+
+test('timeToExhaustion: t = W′ / (P − CP) above CP', () => {
+  assert.equal(timeToExhaustion(300, 250, 20000), 400);
+  assert.equal(timeToExhaustion(350, 250, 20000), 200);
+});
+
+test('timeToExhaustion: returns null at or below CP (sustainable in model)', () => {
+  assert.equal(timeToExhaustion(250, 250, 20000), null);
+  assert.equal(timeToExhaustion(200, 250, 20000), null);
+});
+
+test('sustainablePower: P(t) = CP + W′/t', () => {
+  assert.equal(sustainablePower(600, 250, 20000), 250 + 20000 / 600);
+  assert.equal(sustainablePower(300, 250, 20000), 250 + 20000 / 300);
+});
+
+test('sustainablePower: returns null for invalid inputs', () => {
+  assert.equal(sustainablePower(0, 250, 20000), null);
+  assert.equal(sustainablePower(-100, 250, 20000), null);
+});
+
+test('canFitCP: requires ≥2 in-range durations with ≥300s spread', () => {
+  assert.equal(canFitCP(null), false);
+  assert.equal(canFitCP({}), false);
+  assert.equal(canFitCP({ 300: 250 }), false);
+  assert.equal(canFitCP({ 5: 800, 30: 600 }), false);
+  assert.equal(canFitCP({ 300: 250, 1200: 230 }), true);
+  assert.equal(canFitCP({ 300: 250, 360: 245 }), false, 'spread too small');
+});


### PR DESCRIPTION
## Summary

Adds a physiologically grounded 2-parameter Critical Power model — CP and W′ — fit from the all-time best power curve, and surfaces it alongside the existing FTP estimate in the Dashboard and in the AI coach export.

**Why now.** Discussed in [claude-skills #664](https://github.com/oaustegard/claude-skills/discussions/664): FTP is operationally defined (95% of a 20-min max) and, per PMC7552657, doesn't align with Critical Power, lactate threshold 1, or LT2. The CP model treats sustainable cycling as a genuine two-regime system — below CP, oxygen uptake reaches steady-state; above CP, exhaustion is mathematically inevitable, with W′ depleting linearly with the power excess. Time-to-exhaustion above CP is `t = W′ / (P − CP)`.

We augment rather than replace: FTP remains for compatibility with downstream training platforms; CP and W′ are added next to it, with a Dashboard FAQ entry explaining the difference.

## What's in the diff

- **`src/critical-power.js`** — `estimateCriticalPower(powerCurve)` fits `W = CP·t + W′` by linear regression over durations in the 3–30 min CP-valid range. Returns `{cp, wPrime, fitDurations, rSquared, points}`. R² is computed when ≥3 points are available; the production case (5 min + 20 min only) is a degenerate 2-point exact solve. Also exports `timeToExhaustion`, `sustainablePower`, `canFitCP`.
- **`src/components/Dashboard.js`** — Power Curve card now displays `CP · W′` alongside `est. FTP`. Tooltip and a new FAQ entry explain CP/W′ and why we keep FTP.
- **`src/export-llm.js`** — Full coach context and single-ride export include CP, W′, fit durations, R², and TTE predictions at CP+50W / CP+100W. Markdown rendering added for both export modes.
- **`lat.md/`** — New `Critical Power Model` section under `fitness.md`; coaching.md updated to reference it.
- **`test/critical-power.test.js`** — 11 unit tests covering exact and noisy fits, edge cases, degenerate inputs, and the predictive formulas.
- **CHANGELOG** updated.

## Limitations / future work

- W′ reconstitution kinetics (the non-monotonic ~79% / 65% / 86% recovery curve noted in the discussion) requires per-second stream interpretation and is out of scope here.
- Power zones in `ActivityDetail.js` still use FTP. Defining CP-anchored zones is a follow-up.
- A `cp_milestone` award (parallel to `ftp_milestone`) would be a natural next step.

## Test plan

- [ ] `node --test test/critical-power.test.js` passes (11/11 locally)
- [ ] Demo mode renders CP and W′ in the Power Curve card (demo data has bests at 300/600/1200/1800)
- [ ] Real-user data with only 5-min and 20-min bests still renders CP and W′ via the 2-point fit
- [ ] AI coach export markdown contains a "Critical Power Model" section when fittable, omits cleanly when not
