### PR TITLE
Fix durability backfill — compute for existing power-metered rides, not just new ones

### DIFF
--- a/lat.md/fitness.md
+++ b/lat.md/fitness.md
@@ -54,7 +54,7 @@ Season context (northern hemisphere cycling seasons) is included for UI display.
 
 ## Within-Ride Durability
 
-Two single-ride fatigue-resistance metrics computed from the per-second watts + heartrate streams during the power-curve sync pass. Entry point: [[src/durability.js#computeDurability]]. Stored on the activity as `durability` (or `false` when power exists but HR does not). Surfaced in the ActivityDetail "Durability" card and the single-ride coach export ([[coaching#Single Ride Export]]).
+Two single-ride fatigue-resistance metrics computed from the per-second watts + heartrate streams during the power-curve sync pass. Entry point: [[src/durability.js#computeDurability]]. Stored on the activity as `durability` (or `false` when no usable stream). Computed in the [[src/sync.js#fetchPowerCurves]] pass for any power-metered ride missing it, so existing history backfills on the next sync — not just new rides. Surfaced in the ActivityDetail "Durability" card and the single-ride coach export ([[coaching#Single Ride Export]]).
 
 These are the within-ride analogue of the athlete-level [[fitness#Aerobic Efficiency]] metric: that one trends Efficiency Factor across weeks of rides; these expose how a single ride held up minute to minute, which Strava does not show.
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -415,14 +415,15 @@ async function fetchActivityDetails() {
 async function fetchPowerCurves() {
   const all = await getAllActivities();
   const pending = all.filter(
-    (a) => a.device_watts && a.has_efforts && a.power_curve !== false && !a.power_curve
+    (a) => a.device_watts && a.has_efforts && a.power_curve !== false &&
+           (!a.power_curve || a.durability === undefined)
   );
   if (pending.length === 0) return;
 
   syncProgress.value = {
     ...syncProgress.value,
     phase: "detail",
-    message: `Fetching power curves: 0/${pending.length}`,
+    message: `Fetching power & durability data: 0/${pending.length}`,
   };
 
   let completed = 0;
@@ -431,7 +432,7 @@ async function fetchPowerCurves() {
     if (isRateLimited()) {
       syncProgress.value = {
         ...syncProgress.value,
-        message: `Power curves paused (rate limit) — ${completed}/${pending.length} done.`,
+        message: `Power & durability data paused (rate limit) — ${completed}/${pending.length} done.`,
       };
       break;
     }
@@ -442,24 +443,24 @@ async function fetchPowerCurves() {
       );
       const watts = data.watts && data.watts.data ? data.watts.data : null;
       const hr = data.heartrate && data.heartrate.data ? data.heartrate.data : null;
-      const curve = watts ? computePowerCurve(watts) : null;
+      const curve = activity.power_curve || (watts ? computePowerCurve(watts) : null);
       const durability = (watts && hr)
         ? computeDurability(watts, hr, hrThresholds(activity.max_heartrate))
         : null;
-      // Use false for permanent "no data" (streams exist but no watts), truthy curve for success
+      // false = permanent "no usable stream data" (no watts, or no HR for durability)
       await putActivity({ ...activity, power_curve: curve || false, durability: durability || false });
     } catch (err) {
       if (err instanceof RateLimitError) {
         syncProgress.value = {
           ...syncProgress.value,
-          message: `Power curves paused (rate limit) — ${completed}/${pending.length} done.`,
+          message: `Power & durability data paused (rate limit) — ${completed}/${pending.length} done.`,
         };
         break;
       }
       if (err.status === 404 || err.status === 403) {
         // No streams available for this activity — mark permanently with false
         // (null is reserved for retryable/legacy entries)
-        await putActivity({ ...activity, power_curve: false });
+        await putActivity({ ...activity, power_curve: false, durability: false });
       } else {
         // Transient error (network, 500, etc.) — skip but leave for retry
         console.warn(`Power curve fetch failed for activity ${activity.id}:`, err.message);
@@ -469,7 +470,7 @@ async function fetchPowerCurves() {
     completed++;
     syncProgress.value = {
       ...syncProgress.value,
-      message: `Fetching power curves: ${completed}/${pending.length}`,
+      message: `Fetching power & durability data: ${completed}/${pending.length}`,
     };
   }
 }


### PR DESCRIPTION
## What

Fixes the durability feature (#286) so it actually populates on existing rides.

## The bug

`fetchPowerCurves()` filtered on `!a.power_curve` — it only processed rides that *didn't yet have a power curve*. Since nearly all synced history already has one, durability was computed for almost nothing. As shipped, only brand-new rides would ever show it. (Caught by Oskar immediately after merging #286.)

## Fix

- **Filter widened** to also catch power-metered rides missing durability:
  `(!a.power_curve || a.durability === undefined)`. Existing history now backfills on the next sync; it's self-healing and rate-limit-aware (same pause behavior as before).
- **Existing curve preserved** — `activity.power_curve || computePowerCurve(watts)` — so backfilling durability never recomputes or clobbers a curve that's already there.
- **404/403 branch** now sets `durability: false` alongside `power_curve: false`, so a ride with no streams is permanently marked and doesn't re-enter the filter forever.
- **Progress messages** updated to "power & durability data" (accurate now).
- Doc note in `lat.md/fitness.md`: backfills existing rides, not just new ones.

## Verification (gate run in-session)

- Filter predicate truth-tabled across 6 ride states — all correct: new ride ✓ backfill, curve-but-no-durability ✓ backfill, already-done ✗ skip, no-HR(false) ✗ skip, no-stream(false) ✗ skip, no-power-meter ✗ skip.
- `node --check src/sync.js` passes.
- `node --test test/durability.test.js` → 12/12 (module unchanged).

## Note

Backfilling re-fetches the `watts,heartrate` stream once per power-metered ride lacking durability — one Strava API call each, spread across syncs if rate-limited. One-time cost; steady-state is new rides only.
