### PR TITLE
Fix 'Encoding task failed' — H.264 level too low for card dimensions

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -1579,7 +1579,7 @@ export function ActivityDetail({ id }) {
                   <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
                   </svg>
-                  Generate Share Image
+                  Generate Share Media
                 </button>
               </div>
 

--- a/src/share-video.js
+++ b/src/share-video.js
@@ -65,18 +65,54 @@ export function drawFrame(ctx, still, layout, t) {
   ctx.globalAlpha = 1;
 }
 
-/** True when the browser can produce a real MP4. */
-export async function canEncodeMp4() {
-  if (typeof VideoEncoder === "undefined") return false;
-  try {
-    const { supported } = await VideoEncoder.isConfigSupported({
-      codec: "avc1.42001f", width: 1080, height: 1080,
-      bitrate: 6_000_000, framerate: FPS,
-    });
-    return !!supported;
-  } catch {
-    return false;
+/**
+ * Max frame size in macroblocks per H.264 level (Table A-1).
+ * The old code hardcoded `avc1.42001f` — Baseline level 3.1, which caps at
+ * 3600 macroblocks, i.e. 1280x720. Share cards are 1080 wide and commonly
+ * 1400-2400 tall, so every real card was over the level's limit. Chrome's
+ * isConfigSupported() does not check dimensions against the level, so it
+ * answered `true` and the encoder then died at runtime with the useless
+ * "Encoding task failed" (#131).
+ */
+const H264_LEVELS = [
+  ["1e", 1620], ["1f", 3600], ["20", 5120], ["28", 8192],
+  ["2a", 8704], ["32", 22080], ["33", 36864], ["34", 36864],
+];
+
+/** Codec strings that can hold a frame this size, weakest profile first. */
+function codecCandidates(width, height) {
+  const mbs = Math.ceil(width / 16) * Math.ceil(height / 16);
+  const out = [];
+  for (const [lvl, maxFs] of H264_LEVELS) {
+    if (maxFs < mbs) continue;
+    out.push(`avc1.4200${lvl}`, `avc1.4d00${lvl}`, `avc1.6400${lvl}`);
   }
+  return out;
+}
+
+/**
+ * Find a config this browser will actually accept for these dimensions.
+ * Probes at the real frame size — the previous check asked about 1080x1080
+ * regardless of the card's actual height, so it was answering a different
+ * question from the one that mattered.
+ */
+export async function pickEncoderConfig(width, height) {
+  if (typeof VideoEncoder === "undefined") return null;
+  for (const codec of codecCandidates(width, height)) {
+    for (const hardwareAcceleration of ["no-preference", "prefer-software"]) {
+      const config = {
+        codec, width, height, bitrate: 6_000_000, framerate: FPS,
+        avc: { format: "avc" }, hardwareAcceleration,
+      };
+      try {
+        const { supported } = await VideoEncoder.isConfigSupported(config);
+        if (supported) return config;
+      } catch {
+        // Malformed codec string for this browser; try the next.
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -106,13 +142,20 @@ export async function renderShareVideo(drawStill, { onProgress } = {}) {
   const duration = videoDuration(layout.bands.length);
   const total = Math.round(duration * FPS);
 
-  if (await canEncodeMp4()) {
-    return encodeMp4(frame, ctx, still, layout, total, onProgress);
+  // isConfigSupported() is advisory — encoders still fail at runtime — so a
+  // failed MP4 attempt degrades to WebM rather than surfacing to the user.
+  const config = await pickEncoderConfig(W, H);
+  if (config) {
+    try {
+      return await encodeMp4(frame, ctx, still, layout, total, onProgress, config);
+    } catch (err) {
+      console.warn("[aeyu] MP4 encode failed, falling back to WebM:", err);
+    }
   }
   return recordWebm(frame, ctx, still, layout, total, onProgress);
 }
 
-async function encodeMp4(frame, ctx, still, layout, total, onProgress) {
+async function encodeMp4(frame, ctx, still, layout, total, onProgress, config) {
   // Loaded on demand: 69 KB of muxer that only matters once someone actually
   // asks for a video, and keeping it out of the static graph lets the pure
   // animation functions above be tested without a browser.
@@ -129,11 +172,7 @@ async function encodeMp4(frame, ctx, still, layout, total, onProgress) {
     output: (chunk, meta) => muxer.addVideoChunk(chunk, meta),
     error: (e) => { encodeError = e; },
   });
-  encoder.configure({
-    codec: "avc1.42001f", width: W, height: H,
-    bitrate: 6_000_000, framerate: FPS,
-    avc: { format: "avc" },
-  });
+  encoder.configure(config);
 
   try {
     for (let i = 0; i < total; i++) {
@@ -146,8 +185,12 @@ async function encodeMp4(frame, ctx, still, layout, total, onProgress) {
       // Keyframe up front, then roughly every second, so scrubbing works.
       encoder.encode(vf, { keyFrame: i % FPS === 0 });
       vf.close();
-      // Let the encoder drain instead of queueing every frame at once.
-      if (encoder.encodeQueueSize > 8) await encoder.flush();
+      // Wait for the queue to drain rather than calling flush() mid-stream —
+      // a mid-stream flush resets some encoders and is itself a plausible
+      // source of "Encoding task failed".
+      while (encoder.encodeQueueSize > 8 && !encodeError) {
+        await new Promise((r) => setTimeout(r, 4));
+      }
       onProgress?.((i + 1) / total);
     }
     await encoder.flush();

--- a/test/share-video.test.js
+++ b/test/share-video.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { FPS, videoDuration, drawFrame } from '../src/share-video.js';
+import { FPS, videoDuration, drawFrame, pickEncoderConfig } from '../src/share-video.js';
 
 // A card shaped like the 2026-08-02 ride: header, title, meta, one pill row,
 // four highlight rows, tagline.
@@ -107,4 +107,27 @@ test('a card with no bands still renders chrome', () => {
   drawFrame(ctx, {}, { ...layout, bands: [] }, 1);
   assert.ok(ctx.calls.some((c) => c.img === layout.chrome));
   assert.equal(drawn(ctx).length, 0);
+});
+
+// --- Encoder configuration (#131) ---
+// The original bug: avc1.42001f is Baseline level 3.1, which tops out at 3600
+// macroblocks (1280x720). Every real share card is taller than that.
+
+test('no encoder config is offered when VideoEncoder is absent', async () => {
+  assert.equal(typeof VideoEncoder, 'undefined');
+  assert.equal(await pickEncoderConfig(1080, 1560), null);
+});
+
+test('level 3.1 cannot hold a real share card', () => {
+  // 1080x1560 -> 68 x 98 macroblocks
+  const mbs = Math.ceil(1080 / 16) * Math.ceil(1560 / 16);
+  assert.equal(mbs, 6664);
+  assert.ok(mbs > 3600, 'this is the frame size the old hardcoded level rejected');
+});
+
+test('candidate levels cover the tallest cards we produce', () => {
+  // A card with many awards can reach ~2400px tall -> 68 x 150 = 10200 MBs,
+  // which needs level 5.0 or better.
+  const mbs = Math.ceil(1080 / 16) * Math.ceil(2400 / 16);
+  assert.ok(mbs <= 36864, 'level 5.1/5.2 must still have headroom');
 });


### PR DESCRIPTION
Fixes the "Encoding task failed" you hit on #291, and renames the button.

## The bug

`encoder.configure()` was hardcoded to `avc1.42001f` — **H.264 Baseline, level 3.1**, which caps at 3600 macroblocks, or 1280x720. Share cards are 1080 wide and typically 1400–2400 tall: a 1080x1560 card is 68 x 98 = **6664 macroblocks**, nearly double the level's limit.

Chrome's `isConfigSupported()` does not validate dimensions against the level, so it answered `true` and the encoder died at runtime with the message you saw. That message is as unhelpful as it looks — it is what WebCodecs emits for essentially any encoder-internal failure.

Compounding it: `canEncodeMp4()` probed at a hardcoded **1080x1080** regardless of the card's real height, so the preflight check was asking about a frame size that never gets encoded.

## The fix

- `codecCandidates(w, h)` computes the macroblock count and returns only codec strings whose level can hold it, weakest profile first (Baseline → Main → High).
- `pickEncoderConfig(w, h)` probes those **at the real frame dimensions**, and tries `hardwareAcceleration: "prefer-software"` as well — some mobile hardware encoders refuse tall portrait frames that the software path accepts.
- A failed MP4 attempt now degrades to the WebM path instead of surfacing an error, since `isConfigSupported()` is advisory and encoders fail at runtime regardless.
- Replaced the mid-loop `encoder.flush()` backpressure with a queue-depth wait. A mid-stream flush resets some encoders and is itself a plausible contributor to the same error.

## Button copy

`Generate Share Image` → **`Generate Share Media`**, since it now produces both.

## Verification, and its limits

- `node --test test/*.test.js` — **70/70 pass**, 3 new covering the macroblock math and the null-encoder path.
- Drove the real module in headless Chromium 141 via Playwright at 1080x1080, 1080x1560 and 1080x2400. Chromium's open-source build ships **no H.264 encoder at all**, so `pickEncoderConfig` correctly returns `null` at every size and the WebM fallback produces valid output (182 KB and 217 KB respectively) with no console errors.

**So the MP4 path itself remains unverified** — I could not obtain a browser with an H.264 encoder in this environment. The level arithmetic is Table A-1 and the fallback chain is exercised, but whether your device's encoder now accepts the config is something only your device can answer. If it still fails, the WebM fallback should at least mean a download rather than an error, and `await (await import('/src/share-video.js')).pickEncoderConfig(1080, 1560)` in the console will show which config was selected.