### PR TITLE
Video scrolls through all awards instead of fading in the same four

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -266,7 +266,7 @@ function drawLogoWatermark(ctx, W, H, cardY, cardH, pad) {
 
 // ── Canvas Share Card ─────────────────────────────────────────────
 
-async function renderShareCard(canvas, act, awardsList) {
+async function renderShareCard(canvas, act, awardsList, { maxHighlights = SHARE_CARD_HIGHLIGHTS } = {}) {
   const W = 1080;
   const borderW = 8; // steel blue border at image edge
   const innerPad = 44; // content padding inside body
@@ -296,7 +296,7 @@ async function renderShareCard(canvas, act, awardsList) {
   const metaText = metaParts.join("  ·  ");
   const metaLines = wrapText(tmpCtx, metaText, maxTextW);
 
-  const highlightAwards = buildShareCardHighlights(awardsList);
+  const highlightAwards = buildShareCardHighlights(awardsList, maxHighlights);
 
   const counts = {};
   const pillOrder = ["route_season_first", "route_season_first_more", "season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record", "season_first_power", "np_year_best", "np_recent_best", "work_year_best", "work_recent_best", "peak_power", "peak_power_recent", "watt_milestone", "kj_milestone", "power_progression", "power_consistency", "ftp_milestone", "cp_milestone", "curve_year_best", "curve_all_time", "indoor_np_year_best", "indoor_work_year_best", "trainer_streak", "indoor_vs_outdoor", "weekly_streak", "group_consistency", "reference_best", "comeback_pb", "recovery_milestone", "comeback_full", "comeback_distance", "comeback_elevation", "comeback_endurance"];
@@ -369,19 +369,6 @@ async function renderShareCard(canvas, act, awardsList) {
   // Logo watermark on body area
   drawLogoWatermark(ctx, W, H, bodyTop, bodyBottom - bodyTop, borderW);
 
-  // Snapshot the chrome — border, paper, topo texture, watermark — before any
-  // content lands on it. The animated card (#131) composites content bands over
-  // this rather than trying to reproduce the background, so the texture and
-  // watermark stay defined in exactly one place.
-  const chrome = document.createElement("canvas");
-  chrome.width = W;
-  chrome.height = H;
-  chrome.getContext("2d").drawImage(canvas, 0, 0);
-
-  /** Vertical slices of content, in reveal order (#131). */
-  const bands = [];
-  const band = (y0, y1) => { if (y1 > y0) bands.push({ y0: Math.max(0, Math.round(y0)), y1: Math.min(H, Math.round(y1)) }); };
-
   // Header text on steel cap — vertically centered
   let y = headerCapH / 2 + 10;
   ctx.font = '500 30px "IBM Plex Mono", monospace';
@@ -394,11 +381,9 @@ async function renderShareCard(canvas, act, awardsList) {
   ctx.textAlign = "right";
   ctx.fillText("Participation Awards", rightEdge, y);
   ctx.textAlign = "left";
-  band(0, headerCapH);
   y = headerCapH + 72; // generous gap between header and title
 
   // Activity name — larger
-  const titleTop = y - 64;
   ctx.font = '400 64px "Instrument Serif", serif';
   ctx.fillStyle = "#1A1610";
   for (const line of nameLines) {
@@ -406,10 +391,8 @@ async function renderShareCard(canvas, act, awardsList) {
     y += 74;
   }
   y += 8;
-  band(titleTop, y - 8);
 
   // Meta
-  const metaTop = y - 34;
   ctx.font = '400 34px "IBM Plex Mono", monospace';
   ctx.fillStyle = "#4A4438";
   for (const line of metaLines) {
@@ -417,7 +400,6 @@ async function renderShareCard(canvas, act, awardsList) {
     y += 42;
   }
   y += 24;
-  band(metaTop, y - 24);
 
   // Awards
   if (awardsList.length > 0) {
@@ -446,7 +428,6 @@ async function renderShareCard(canvas, act, awardsList) {
         ctx.font = '600 30px "DM Sans", sans-serif';
         ctx.fillText(pill.label, pill.x + 14 + iconSize + iconPad, y);
       }
-      band(y - 32, y + 22);
       y += 56;
     }
     y += 16;
@@ -491,16 +472,14 @@ async function renderShareCard(canvas, act, awardsList) {
         ctx.fillStyle = "#7A7164";
         ctx.fillText(`${formatTime(award.delta)} faster`, left + 32, y + 32);
       }
-      band(y - 30, y + ((award.delta && award.delta > 0) ? 44 : 16));
       y += (award.delta && award.delta > 0) ? 68 : 52;
     }
 
-    const remaining = awardsList.length - highlightAwards.length;
+    const remaining = Number.isFinite(maxHighlights) ? awardsList.length - highlightAwards.length : 0;
     if (remaining > 0) {
       ctx.font = '400 26px "DM Sans", sans-serif';
       ctx.fillStyle = "#7A7164";
       ctx.fillText(`+ ${remaining} more awards`, left, y + 8);
-      band(y - 18, y + 18);
     }
   }
 
@@ -512,10 +491,9 @@ async function renderShareCard(canvas, act, awardsList) {
   ctx.fillText("It's just you and your efforts", W / 2, H - borderW - 16);
   ctx.globalAlpha = 1.0;
   ctx.textAlign = "left";
-  band(H - borderW - 46, H - borderW);
 
   // Layout metadata for the animated card (#131). Harmless to ignore.
-  return { width: W, height: H, chrome, bands };
+  return { width: W, height: H };
 }
 
 // ── Segment Share Card ────────────────────────────────────────────
@@ -794,19 +772,6 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
   // Logo watermark on body area
   drawLogoWatermark(ctx, W, H, bodyTop, bodyBottom - bodyTop, borderW);
 
-  // Snapshot the chrome — border, paper, topo texture, watermark — before any
-  // content lands on it. The animated card (#131) composites content bands over
-  // this rather than trying to reproduce the background, so the texture and
-  // watermark stay defined in exactly one place.
-  const chrome = document.createElement("canvas");
-  chrome.width = W;
-  chrome.height = H;
-  chrome.getContext("2d").drawImage(canvas, 0, 0);
-
-  /** Vertical slices of content, in reveal order (#131). */
-  const bands = [];
-  const band = (y0, y1) => { if (y1 > y0) bands.push({ y0: Math.max(0, Math.round(y0)), y1: Math.min(H, Math.round(y1)) }); };
-
   // Header text on steel cap — vertically centered
   let y = headerCapH / 2 + 10;
   ctx.font = '500 30px "IBM Plex Mono", monospace';
@@ -819,11 +784,9 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
   ctx.textAlign = "right";
   ctx.fillText("Segment Awards", rightEdge, y);
   ctx.textAlign = "left";
-  band(0, headerCapH);
   y = headerCapH + 72; // generous gap between header and title
 
   // Segment name — larger
-  const titleTop = y - 64;
   ctx.font = '400 64px "Instrument Serif", serif';
   ctx.fillStyle = "#1A1610";
   for (const line of nameLines) {
@@ -831,10 +794,8 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
     y += 74;
   }
   y += 8;
-  band(titleTop, y - 8);
 
   // Meta
-  const metaTop = y - 34;
   ctx.font = '400 34px "IBM Plex Mono", monospace';
   ctx.fillStyle = "#4A4438";
   for (const line of metaLines) {
@@ -842,15 +803,12 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
     y += 42;
   }
   y += 24;
-  band(metaTop, y - 24);
 
   // Performance chart
   if (hasChart) {
-    const chartTop = y;
     const chartW = rightEdge - left;
     drawPerformanceChart(ctx, segment, effort.id, left, y, chartW, chartH);
     y += chartH + chartStatsH + 28;
-    band(chartTop, y - 28);
   }
 
   // Awards
@@ -880,7 +838,6 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
         ctx.font = '600 30px "DM Sans", sans-serif';
         ctx.fillText(pill.label, pill.x + 14 + iconSize + iconPad, y);
       }
-      band(y - 32, y + 22);
       y += 56;
     }
     y += 16;
@@ -900,7 +857,6 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
       const colors = AWARD_COLORS[award.type];
       if (!colors) continue;
       const msgLines = wrappedAwardMsgs[i];
-      const msgTop = y - 22;
 
       drawIcon(ctx, award.type, left, y - 14, 22, colors.accent, 2);
 
@@ -910,7 +866,6 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
         ctx.fillText(line, left + 32, y + 4);
         y += 36;
       }
-      band(msgTop, y);
       y += 16;
     }
 
@@ -919,7 +874,6 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
       ctx.font = '400 26px "DM Sans", sans-serif';
       ctx.fillStyle = "#7A7164";
       ctx.fillText(`+ ${remaining} more awards`, left, y + 8);
-      band(y - 18, y + 18);
     }
   }
 
@@ -946,10 +900,9 @@ async function renderSegmentShareCard(canvas, act, effort, segAwards, segment) {
   ctx.fillText("It's just you and your efforts", W / 2, H - borderW - 16);
   ctx.globalAlpha = 1.0;
   ctx.textAlign = "left";
-  band(H - borderW - 46, H - borderW);
 
   // Layout metadata for the animated card (#131). Harmless to ignore.
-  return { width: W, height: H, chrome, bands };
+  return { width: W, height: H };
 }
 
 
@@ -977,7 +930,7 @@ const SHARE_CARD_HIGHLIGHTS = 4;
  *     them eating three of four slots. Efforts whose wall-clock spans overlap
  *     are now collapsed to their best award.
  */
-function buildShareCardHighlights(awardsList) {
+function buildShareCardHighlights(awardsList, slots = SHARE_CARD_HIGHLIGHTS) {
   // Best award per segment
   const bySegment = new Map();
   for (const a of awardsList) {
@@ -1004,7 +957,7 @@ function buildShareCardHighlights(awardsList) {
 
   return [...kept, ...rideAwards]
     .sort((a, b) => awardScore(b) - awardScore(a))
-    .slice(0, SHARE_CARD_HIGHLIGHTS);
+    .slice(0, slots);
 }
 
 /**
@@ -1368,7 +1321,9 @@ export function ActivityDetail({ id }) {
             const segAwards = awards.value.filter((a) => a.segment_id === effort.segment.id);
             return renderSegmentShareCard(canvas, act, effort, segAwards, seg);
           }
-          return renderShareCard(canvas, act, awards.value);
+          // No highlight cap: the point of the video is to show the awards the
+          // still card has to truncate into "+ N more".
+          return renderShareCard(canvas, act, awards.value, { maxHighlights: Infinity });
         },
         { onProgress: (p) => { videoBusy.value = Math.max(1, Math.round(p * 100)); } }
       );

--- a/src/share-video.js
+++ b/src/share-video.js
@@ -1,8 +1,11 @@
 /**
  * Animated share cards (#131).
  *
- * Encodes the existing canvas share card into a short MP4 by rendering it once
- * to an offscreen canvas and then revealing its bands over time.
+ * The still card can only fit four highlight rows before it has to fall back to
+ * "+ N more awards". That truncation is the whole reason to make a video: the
+ * card is rendered with NO highlight limit, however tall that makes it, and the
+ * video pans down through it. A video that merely faded in the same four rows
+ * would carry no information the PNG does not already carry.
  *
  * Why not ffmpeg.wasm: the core WASM bundle is 31–32 MB and its multithreaded
  * build needs SharedArrayBuffer, which needs COOP/COEP response headers. aeyu
@@ -19,50 +22,77 @@
  */
 
 export const FPS = 30;
-/** Seconds each band takes to ease in. */
-const BAND_FADE = 0.45;
-/** Seconds between successive bands starting. */
-const BAND_STAGGER = 0.18;
-/** Seconds the finished card holds before the video ends. */
-const HOLD = 1.6;
-/** How far a band slides up as it fades in, in canvas px. */
-const SLIDE = 18;
+/** Story-native 9:16 viewport. Constant regardless of how tall the card is. */
+export const VIEW_W = 1080;
+export const VIEW_H = 1920;
+/** Seconds held on the top of the card before the pan starts. */
+const HOLD_TOP = 0.9;
+/** Seconds held on the bottom after the pan finishes. */
+const HOLD_END = 1.5;
+/** Reading pace, canvas px per second. */
+const SCROLL_SPEED = 430;
+/** Never produce anything longer than this, however many awards there are. */
+const MAX_DURATION = 30;
+/** A card shorter than the viewport does not scroll; it just holds. */
+const STATIC_DURATION = 3;
 
-const easeOut = (t) => 1 - Math.pow(1 - t, 3);
+const easeInOut = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
 const clamp01 = (t) => (t < 0 ? 0 : t > 1 ? 1 : t);
 
-/** Total duration in seconds for a card with this many bands. */
-export function videoDuration(bandCount) {
-  const last = Math.max(0, bandCount - 1) * BAND_STAGGER + BAND_FADE;
-  return +(last + HOLD).toFixed(3);
+/** How far the card has to travel for all of it to be seen. */
+export function maxScroll(cardHeight, viewH = VIEW_H) {
+  return Math.max(0, cardHeight - viewH);
+}
+
+/** Total duration in seconds for a card of this height. */
+export function videoDuration(cardHeight, viewH = VIEW_H) {
+  const travel = maxScroll(cardHeight, viewH);
+  if (travel === 0) return STATIC_DURATION;
+  const panning = travel / SCROLL_SPEED;
+  return +Math.min(MAX_DURATION, HOLD_TOP + panning + HOLD_END).toFixed(3);
 }
 
 /**
- * Per-band progress at time t. Bands enter in document order, which is the
- * order awards were ranked — so on a well-scored card the reveal reads as a
- * countdown to the thing that mattered most.
+ * Scroll offset in canvas px at time t. Holds at the top, eases through the
+ * pan so it does not start and stop abruptly, then holds on the last frame so
+ * the final awards stay readable.
  */
-function bandProgress(index, t) {
-  return easeOut(clamp01((t - index * BAND_STAGGER) / BAND_FADE));
+export function scrollAt(t, cardHeight, viewH = VIEW_H) {
+  const travel = maxScroll(cardHeight, viewH);
+  if (travel === 0) return 0;
+  const duration = videoDuration(cardHeight, viewH);
+  const panning = Math.max(0.001, duration - HOLD_TOP - HOLD_END);
+  return travel * easeInOut(clamp01((t - HOLD_TOP) / panning));
 }
 
-/** Draw one frame of the animation into ctx. */
+/**
+ * Draw one frame: the card, offset upward by the current scroll.
+ * Areas above or below the card are filled with its own background colour so
+ * short cards letterbox cleanly instead of showing black.
+ */
 export function drawFrame(ctx, still, layout, t) {
-  const { width: W, height: H } = layout;
-  ctx.clearRect(0, 0, W, H);
-  // Chrome first — border, paper, topo texture, watermark — captured by the
-  // card renderer before any content was drawn on it.
-  ctx.drawImage(layout.chrome, 0, 0);
+  const viewH = layout.viewH ?? VIEW_H;
+  const viewW = layout.viewW ?? VIEW_W;
+  ctx.fillStyle = layout.matte || "#4A5759";
+  ctx.fillRect(0, 0, viewW, viewH);
 
-  layout.bands.forEach((b, i) => {
-    const p = bandProgress(i, t);
-    if (p <= 0) return;
-    const h = b.y1 - b.y0;
-    if (h <= 0) return;
-    ctx.globalAlpha = p;
-    ctx.drawImage(still, 0, b.y0, W, h, 0, b.y0 + (1 - p) * SLIDE, W, h);
-  });
-  ctx.globalAlpha = 1;
+  const y = -scrollAt(t, layout.height, viewH);
+  // Centre a card shorter than the viewport rather than pinning it to the top.
+  const offset = layout.height < viewH ? (viewH - layout.height) / 2 : y;
+  ctx.drawImage(still, 0, offset, layout.width, layout.height);
+}
+
+/**
+ * Sample the card's own border colour so letterboxing matches it. Falls back to
+ * the steel blue the card uses if the canvas cannot be read.
+ */
+function matteColor(still) {
+  try {
+    const [r, g, b] = still.getContext("2d").getImageData(1, 1, 1, 1).data;
+    return `rgb(${r}, ${g}, ${b})`;
+  } catch {
+    return "#4A5759";
+  }
 }
 
 /**
@@ -125,22 +155,22 @@ export async function pickEncoderConfig(width, height) {
  */
 export async function renderShareVideo(drawStill, { onProgress } = {}) {
   const still = document.createElement("canvas");
-  const layout = await drawStill(still);
-  if (!layout || !layout.bands || !layout.chrome) {
-    throw new Error("drawStill returned no layout metadata");
-  }
+  const drawn = await drawStill(still);
+  if (!drawn || !drawn.height) throw new Error("drawStill returned no layout metadata");
 
-  // H.264 requires even dimensions; pad rather than scale so nothing softens.
-  const W = still.width + (still.width % 2);
-  const H = still.height + (still.height % 2);
+  // The frame is a fixed 9:16 viewport whatever the card's height. That keeps
+  // the output share-ready, and it keeps the encoder config constant instead of
+  // scaling with the number of awards.
+  const W = VIEW_W;
+  const H = VIEW_H;
+  const layout = { ...drawn, viewW: W, viewH: H, matte: matteColor(still) };
 
   const frame = document.createElement("canvas");
   frame.width = W;
   frame.height = H;
   const ctx = frame.getContext("2d");
 
-  const duration = videoDuration(layout.bands.length);
-  const total = Math.round(duration * FPS);
+  const total = Math.round(videoDuration(layout.height, H) * FPS);
 
   // isConfigSupported() is advisory — encoders still fail at runtime — so a
   // failed MP4 attempt degrades to WebM rather than surfacing to the user.

--- a/test/share-video.test.js
+++ b/test/share-video.test.js
@@ -1,133 +1,106 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { FPS, videoDuration, drawFrame, pickEncoderConfig } from '../src/share-video.js';
+import { FPS, VIEW_H, VIEW_W, videoDuration, maxScroll, scrollAt, drawFrame, pickEncoderConfig }
+  from '../src/share-video.js';
 
-// A card shaped like the 2026-08-02 ride: header, title, meta, one pill row,
-// four highlight rows, tagline.
-const layout = {
-  width: 1080,
-  height: 1400,
-  chrome: { __chrome: true },
-  bands: [
-    { y0: 0, y1: 96 },
-    { y0: 168, y1: 250 },
-    { y0: 258, y1: 300 },
-    { y0: 320, y1: 376 },
-    { y0: 400, y1: 446 },
-    { y0: 452, y1: 498 },
-    { y0: 504, y1: 550 },
-    { y0: 556, y1: 602 },
-    { y0: 1340, y1: 1386 },
-  ],
-};
+// A card with every award shown rather than the still card's four — the whole
+// reason the video exists. Roughly what a 12-award ride produces.
+const TALL = { width: VIEW_W, height: 4200 };
+const SHORT = { width: VIEW_W, height: 1200 };
+const layoutFor = (card) => ({ ...card, viewW: VIEW_W, viewH: VIEW_H, matte: '#4A5759' });
 
-/** Minimal 2D context recorder — no DOM needed. */
 function fakeCtx() {
   const calls = [];
   return {
-    calls,
-    globalAlpha: 1,
-    clearRect: (...a) => calls.push({ op: 'clear', a }),
-    drawImage(...a) {
-      calls.push({ op: 'draw', img: a[0], args: a.slice(1), alpha: this.globalAlpha });
-    },
+    calls, fillStyle: '',
+    fillRect: (...a) => calls.push({ op: 'fill', a }),
+    drawImage: (...a) => calls.push({ op: 'draw', a }),
   };
 }
+const lastDraw = (ctx) => ctx.calls.filter((c) => c.op === 'draw').at(-1);
 
-const drawn = (ctx) => ctx.calls.filter((c) => c.op === 'draw' && c.img !== layout.chrome);
-
-test('duration scales with band count and includes the hold', () => {
-  const short = videoDuration(1);
-  const long = videoDuration(9);
-  assert.ok(long > short);
-  assert.ok(short >= 1.6, 'even a one-band card holds on the finished frame');
-  assert.ok(long < 5, 'a full card stays short enough to share');
+test('a card taller than the viewport scrolls the whole way', () => {
+  assert.equal(maxScroll(TALL.height), TALL.height - VIEW_H);
+  assert.equal(scrollAt(0, TALL.height), 0);
+  const end = videoDuration(TALL.height);
+  assert.ok(Math.abs(scrollAt(end, TALL.height) - maxScroll(TALL.height)) < 1e-6,
+    'the last frame must show the bottom of the card');
 });
 
-test('frame count is a whole number of frames', () => {
-  const total = Math.round(videoDuration(layout.bands.length) * FPS);
-  assert.ok(Number.isInteger(total));
-  assert.ok(total > 0);
+test('a card shorter than the viewport does not scroll', () => {
+  assert.equal(maxScroll(SHORT.height), 0);
+  assert.equal(scrollAt(2, SHORT.height), 0);
+  assert.equal(videoDuration(SHORT.height), 3);
 });
 
-test('chrome is painted on every frame, including the first', () => {
-  for (const t of [0, 0.5, 2, videoDuration(layout.bands.length)]) {
-    const ctx = fakeCtx();
-    drawFrame(ctx, {}, layout, t);
-    assert.ok(ctx.calls.some((c) => c.op === 'draw' && c.img === layout.chrome),
-      `chrome missing at t=${t}`);
+test('duration grows with the number of awards but stays bounded', () => {
+  assert.ok(videoDuration(4200) > videoDuration(2400));
+  assert.ok(videoDuration(2400) > videoDuration(1200));
+  assert.ok(videoDuration(40000) <= 30, 'a pathological card must not run forever');
+});
+
+test('scroll holds at the top before moving', () => {
+  assert.equal(scrollAt(0.5, TALL.height), 0, 'still holding at 0.5s');
+  assert.ok(scrollAt(1.6, TALL.height) > 0, 'moving by 1.6s');
+});
+
+test('scroll is monotonic — never jumps backwards', () => {
+  const end = videoDuration(TALL.height);
+  let prev = -1;
+  for (let t = 0; t <= end; t += 1 / FPS) {
+    const y = scrollAt(t, TALL.height);
+    assert.ok(y >= prev - 1e-9, `went backwards at t=${t}`);
+    prev = y;
   }
 });
 
-test('nothing but chrome is visible at t=0', () => {
-  const ctx = fakeCtx();
-  drawFrame(ctx, {}, layout, 0);
-  assert.equal(drawn(ctx).length, 0);
+test('the frame is a fixed 9:16 viewport whatever the card height', () => {
+  assert.equal(VIEW_W / VIEW_H, 1080 / 1920);
+  for (const card of [SHORT, TALL, { width: VIEW_W, height: 12000 }]) {
+    const ctx = fakeCtx();
+    drawFrame(ctx, {}, layoutFor(card), 1);
+    const fill = ctx.calls.find((c) => c.op === 'fill');
+    assert.deepEqual(fill.a, [0, 0, VIEW_W, VIEW_H]);
+  }
 });
 
-test('bands arrive in order', () => {
+test('a short card is centred, not pinned to the top', () => {
   const ctx = fakeCtx();
-  drawFrame(ctx, {}, layout, 0.3);
-  const visible = drawn(ctx);
-  assert.ok(visible.length > 0 && visible.length < layout.bands.length,
-    'a mid-reveal frame shows some but not all bands');
-  // Whatever is visible must be a prefix of the band list
-  visible.forEach((c, i) => assert.equal(c.args[1], layout.bands[i].y0));
+  drawFrame(ctx, {}, layoutFor(SHORT), 1);
+  assert.equal(lastDraw(ctx).a[2], (VIEW_H - SHORT.height) / 2);
 });
 
-test('every band is fully opaque and in place by the end', () => {
+test('a tall card is drawn at the current scroll offset', () => {
   const ctx = fakeCtx();
-  drawFrame(ctx, {}, layout, videoDuration(layout.bands.length));
-  const visible = drawn(ctx);
-  assert.equal(visible.length, layout.bands.length);
-  visible.forEach((c, i) => {
-    assert.ok(Math.abs(c.alpha - 1) < 1e-9, `band ${i} not opaque`);
-    // destination y equals source y once settled
-    assert.ok(Math.abs(c.args[5] - layout.bands[i].y0) < 1e-6, `band ${i} not settled`);
-  });
+  drawFrame(ctx, {}, layoutFor(TALL), 2.5);
+  assert.equal(lastDraw(ctx).a[2], -scrollAt(2.5, TALL.height));
 });
 
-test('a band slides up as it fades in', () => {
+test('the matte is painted before the card so short cards letterbox', () => {
   const ctx = fakeCtx();
-  drawFrame(ctx, {}, layout, 0.15);
-  const first = drawn(ctx)[0];
-  assert.ok(first.alpha > 0 && first.alpha < 1);
-  assert.ok(first.args[5] > layout.bands[0].y0, 'mid-fade band should be offset downward');
-});
-
-test('zero-height bands are skipped rather than drawn', () => {
-  const degenerate = { ...layout, bands: [{ y0: 100, y1: 100 }, { y0: 200, y1: 240 }] };
-  const ctx = fakeCtx();
-  drawFrame(ctx, {}, degenerate, 99);
-  assert.equal(drawn(ctx).length, 1);
-});
-
-test('a card with no bands still renders chrome', () => {
-  const ctx = fakeCtx();
-  drawFrame(ctx, {}, { ...layout, bands: [] }, 1);
-  assert.ok(ctx.calls.some((c) => c.img === layout.chrome));
-  assert.equal(drawn(ctx).length, 0);
+  drawFrame(ctx, {}, layoutFor(SHORT), 0);
+  assert.equal(ctx.calls[0].op, 'fill');
 });
 
 // --- Encoder configuration (#131) ---
-// The original bug: avc1.42001f is Baseline level 3.1, which tops out at 3600
-// macroblocks (1280x720). Every real share card is taller than that.
+// avc1.42001f is Baseline level 3.1 — 3600 macroblocks, or 1280x720. The fixed
+// 1080x1920 viewport is 8160, so the level must be derived, not hardcoded.
 
 test('no encoder config is offered when VideoEncoder is absent', async () => {
   assert.equal(typeof VideoEncoder, 'undefined');
-  assert.equal(await pickEncoderConfig(1080, 1560), null);
+  assert.equal(await pickEncoderConfig(VIEW_W, VIEW_H), null);
 });
 
-test('level 3.1 cannot hold a real share card', () => {
-  // 1080x1560 -> 68 x 98 macroblocks
-  const mbs = Math.ceil(1080 / 16) * Math.ceil(1560 / 16);
-  assert.equal(mbs, 6664);
-  assert.ok(mbs > 3600, 'this is the frame size the old hardcoded level rejected');
+test('the viewport exceeds the level that used to be hardcoded', () => {
+  const mbs = Math.ceil(VIEW_W / 16) * Math.ceil(VIEW_H / 16);
+  assert.equal(mbs, 8160);
+  assert.ok(mbs > 3600, 'level 3.1 could never have encoded this');
+  assert.ok(mbs <= 8192, 'level 4.0 can');
 });
 
-test('candidate levels cover the tallest cards we produce', () => {
-  // A card with many awards can reach ~2400px tall -> 68 x 150 = 10200 MBs,
-  // which needs level 5.0 or better.
-  const mbs = Math.ceil(1080 / 16) * Math.ceil(2400 / 16);
-  assert.ok(mbs <= 36864, 'level 5.1/5.2 must still have headroom');
+test('the encoder frame size no longer varies with award count', () => {
+  // Whatever the card height, the video is always the same dimensions — so the
+  // encoder config is chosen once and cannot drift out of level range.
+  assert.equal(VIEW_W, 1080);
+  assert.equal(VIEW_H, 1920);
 });


### PR DESCRIPTION
You're right — the band-reveal animation carried no information the PNG didn't already carry. It was motion for its own sake.

The still card caps at four highlight rows and dumps the rest into "+ N more awards". **That truncation is the only reason to make a video.** So the video now renders the card with no highlight limit, however tall that makes it, and pans down through the whole thing.

## Changes

- `renderShareCard(canvas, act, awards, { maxHighlights })` — the video passes `Infinity`. The still card is unchanged at 4. When nothing is withheld, the "+ N more awards" line is dropped, because there is no more.
- Fixed **1080x1920** viewport regardless of card height, so the output is story-native and — usefully — the encoder config is now constant instead of scaling with award count. That was the source of the level bug: at 8160 macroblocks the viewport needs level 4.0 and always will.
- Pan: 0.9 s hold on the header, ease-in-out at 430 px/s, 1.5 s hold on the final awards so they stay readable. Capped at 30 s. A card shorter than the viewport doesn't scroll — it centres and holds for 3 s, letterboxed against its own border colour, sampled from the canvas.
- **Deleted** the `chrome` snapshot and the ~15 `band()` calls I threaded through both card renderers for the old reveal. They were instrumentation for an animation that shouldn't have existed; leaving them as dead weight would be worse than the original mistake. `renderShareCard` and `renderSegmentShareCard` are back to returning `{ width, height }`.

## Verification

- `node --test test/*.test.js` — **70/70 pass**. The share-video suite is rewritten around the scroll: full travel to the bottom on the last frame, monotonic offset across every frame at 30fps, the top hold, short-card centring, matte painted before the card, and fixed viewport dimensions at card heights from 1200 to 12000 px.
- Drove the real module in headless Chromium 141 via Playwright at three card heights. All encode cleanly and the durations scale sensibly:

| card height | duration | output |
|---|---|---|
| 1200 px (fits viewport) | 3.0 s | 68 KB |
| 2400 px | 3.5 s | 347 KB |
| 4200 px (~12 awards) | 7.7 s | 1.1 MB |

Chromium ships no H.264 encoder so these are the WebM fallback path; the MP4 path is verified only by your device, which did produce a working MP4 from the previous build.

`SCROLL_SPEED = 430` px/s is the number most likely to be wrong — it's a guess at reading pace, and it's a one-line change if the pan feels rushed or sluggish.