### PR TITLE
Share video as a slide deck of award pages

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -266,7 +266,12 @@ function drawLogoWatermark(ctx, W, H, cardY, cardH, pad) {
 
 // ── Canvas Share Card ─────────────────────────────────────────────
 
-async function renderShareCard(canvas, act, awardsList, { maxHighlights = SHARE_CARD_HIGHLIGHTS } = {}) {
+/**
+ * @param {object} opts
+ * @param {number} opts.page — which page of highlights to show. Page 0 is the
+ *   card as it has always looked; later pages are what the video steps through.
+ */
+async function renderShareCard(canvas, act, awardsList, { page = 0 } = {}) {
   const W = 1080;
   const borderW = 8; // steel blue border at image edge
   const innerPad = 44; // content padding inside body
@@ -296,7 +301,7 @@ async function renderShareCard(canvas, act, awardsList, { maxHighlights = SHARE_
   const metaText = metaParts.join("  ·  ");
   const metaLines = wrapText(tmpCtx, metaText, maxTextW);
 
-  const highlightAwards = buildShareCardHighlights(awardsList, maxHighlights);
+  const highlightAwards = buildShareCardHighlights(awardsList, SHARE_CARD_HIGHLIGHTS, page * SHARE_CARD_HIGHLIGHTS);
 
   const counts = {};
   const pillOrder = ["route_season_first", "route_season_first_more", "season_first", "year_best", "ytd_best_time", "ytd_best_power", "best_month_ever", "monthly_best", "recent_best", "improvement_streak", "comeback", "closing_in", "top_decile", "top_quartile", "beat_median", "consistency", "milestone", "anniversary", "distance_record", "elevation_record", "segment_count", "endurance_record", "season_first_power", "np_year_best", "np_recent_best", "work_year_best", "work_recent_best", "peak_power", "peak_power_recent", "watt_milestone", "kj_milestone", "power_progression", "power_consistency", "ftp_milestone", "cp_milestone", "curve_year_best", "curve_all_time", "indoor_np_year_best", "indoor_work_year_best", "trainer_streak", "indoor_vs_outdoor", "weekly_streak", "group_consistency", "reference_best", "comeback_pb", "recovery_milestone", "comeback_full", "comeback_distance", "comeback_elevation", "comeback_endurance"];
@@ -475,7 +480,9 @@ async function renderShareCard(canvas, act, awardsList, { maxHighlights = SHARE_
       y += (award.delta && award.delta > 0) ? 68 : 52;
     }
 
-    const remaining = Number.isFinite(maxHighlights) ? awardsList.length - highlightAwards.length : 0;
+    // Only the still card advertises what it is withholding; the video shows
+    // the rest on the following slides instead.
+    const remaining = page === 0 ? awardsList.length - highlightAwards.length : 0;
     if (remaining > 0) {
       ctx.font = '400 26px "DM Sans", sans-serif';
       ctx.fillStyle = "#7A7164";
@@ -930,7 +937,7 @@ const SHARE_CARD_HIGHLIGHTS = 4;
  *     them eating three of four slots. Efforts whose wall-clock spans overlap
  *     are now collapsed to their best award.
  */
-function buildShareCardHighlights(awardsList, slots = SHARE_CARD_HIGHLIGHTS) {
+function buildShareCardHighlights(awardsList, slots = SHARE_CARD_HIGHLIGHTS, offset = 0) {
   // Best award per segment
   const bySegment = new Map();
   for (const a of awardsList) {
@@ -957,7 +964,17 @@ function buildShareCardHighlights(awardsList, slots = SHARE_CARD_HIGHLIGHTS) {
 
   return [...kept, ...rideAwards]
     .sort((a, b) => awardScore(b) - awardScore(a))
-    .slice(0, slots);
+    .slice(offset, offset + slots);
+}
+
+/** How many highlight rows exist in total, across all pages (#131). */
+function countShareCardHighlights(awardsList) {
+  return buildShareCardHighlights(awardsList, Infinity).length;
+}
+
+/** Number of card-sized pages the highlights fill. */
+function shareCardPages(awardsList) {
+  return Math.max(1, Math.ceil(countShareCardHighlights(awardsList) / SHARE_CARD_HIGHLIGHTS));
 }
 
 /**
@@ -1310,25 +1327,18 @@ export function ActivityDetail({ id }) {
     videoError.value = null;
     videoBusy.value = 1;
     try {
-      const segId = segmentCardGenerated.value;
-      const effort = segId ? act.segment_efforts?.find((e) => e.segment.id === segId) : null;
-      const baseName = effort ? effort.segment.name : act.name;
-
-      const { blob, type, extension } = await renderShareVideo(
-        async (canvas) => {
-          if (effort) {
-            const seg = segmentHistory.value.get(effort.segment.id);
-            const segAwards = awards.value.filter((a) => a.segment_id === effort.segment.id);
-            return renderSegmentShareCard(canvas, act, effort, segAwards, seg);
-          }
-          // No highlight cap: the point of the video is to show the awards the
-          // still card has to truncate into "+ N more".
-          return renderShareCard(canvas, act, awards.value, { maxHighlights: Infinity });
-        },
-        { onProgress: (p) => { videoBusy.value = Math.max(1, Math.round(p * 100)); } }
+      const pages = shareCardPages(awards.value);
+      // One page of awards means the still card already shows everything, and
+      // a video of a card that never changes is just a slower PNG.
+      const slides = Array.from({ length: pages }, (_, page) =>
+        (canvas) => renderShareCard(canvas, act, awards.value, { page })
       );
 
-      const filename = `${baseName.replace(/[^a-z0-9]/gi, "-")}-awards.${extension}`;
+      const { blob, type, extension } = await renderShareVideo(slides, {
+        onProgress: (p) => { videoBusy.value = Math.max(1, Math.round(p * 100)); },
+      });
+
+      const filename = `${act.name.replace(/[^a-z0-9]/gi, "-")}-awards.${extension}`;
       const file = new File([blob], filename, { type });
       // WebM gets rejected by most share targets, so only MP4 goes to the sheet.
       if (type === "video/mp4" && navigator.share && navigator.canShare?.({ files: [file] })) {
@@ -1552,6 +1562,7 @@ export function ActivityDetail({ id }) {
                     </svg>
                     Save / Share
                   </button>
+                  ${!segmentCardGenerated.value && shareCardPages(awards.value) > 1 && html`
                   <button
                     onClick=${handleShareVideo}
                     disabled=${videoBusy.value > 0}
@@ -1563,6 +1574,7 @@ export function ActivityDetail({ id }) {
                     </svg>
                     ${videoBusy.value > 0 ? `Rendering ${videoBusy.value}%` : "Share Video"}
                   </button>
+                  `}
                   <button
                     onClick=${copyCanvasToClipboard}
                     class="inline-flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg transition-colors"

--- a/src/share-video.js
+++ b/src/share-video.js
@@ -1,11 +1,16 @@
 /**
- * Animated share cards (#131).
+ * Share card slideshow (#131).
  *
- * The still card can only fit four highlight rows before it has to fall back to
- * "+ N more awards". That truncation is the whole reason to make a video: the
- * card is rendered with NO highlight limit, however tall that makes it, and the
- * video pans down through it. A video that merely faded in the same four rows
- * would carry no information the PNG does not already carry.
+ * The still card fits four highlight rows and then has to say "+ N more
+ * awards". That truncation is the only reason the video exists: it steps
+ * through card-sized pages of awards, one slide at a time, at the card's own
+ * dimensions. Every frame is a complete, screenshot-able card.
+ *
+ * Deliberately not: a fade-in of the same four rows (no information the PNG
+ * lacks), and not a scroll through one very tall card (the card is usually
+ * shorter than a 9:16 frame, so it fits, letterboxes, and never moves).
+ *
+ * A single page produces no video at all — callers check `slideCount` first.
  *
  * Why not ffmpeg.wasm: the core WASM bundle is 31–32 MB and its multithreaded
  * build needs SharedArrayBuffer, which needs COOP/COEP response headers. aeyu
@@ -21,74 +26,71 @@
  * offered as a download rather than a share since social targets reject WebM.
  */
 
-export const FPS = 30;
-/** Story-native 9:16 viewport. Constant regardless of how tall the card is. */
-export const VIEW_W = 1080;
-export const VIEW_H = 1920;
-/** Seconds held on the top of the card before the pan starts. */
-const HOLD_TOP = 0.9;
-/** Seconds held on the bottom after the pan finishes. */
-const HOLD_END = 1.5;
-/** Reading pace, canvas px per second. */
-const SCROLL_SPEED = 430;
-/** Never produce anything longer than this, however many awards there are. */
+/**
+ * Frames per second. Low on purpose: this is a slideshow, not motion, and 10fps
+ * is the floor that players and social uploads handle without complaint.
+ */
+export const FPS = 10;
+/** Seconds each slide is held. */
+const SLIDE_HOLD = 2.4;
+/** Seconds of crossfade between slides. */
+const SLIDE_FADE = 0.4;
+/** Never produce anything longer than this. */
 const MAX_DURATION = 30;
-/** A card shorter than the viewport does not scroll; it just holds. */
-const STATIC_DURATION = 3;
 
-const easeInOut = (t) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
 const clamp01 = (t) => (t < 0 ? 0 : t > 1 ? 1 : t);
+const even16 = (n) => Math.max(16, Math.ceil(n / 16) * 16);
 
-/** How far the card has to travel for all of it to be seen. */
-export function maxScroll(cardHeight, viewH = VIEW_H) {
-  return Math.max(0, cardHeight - viewH);
-}
+/** Seconds one slide occupies, including its crossfade into the next. */
+const SLIDE_PERIOD = SLIDE_HOLD + SLIDE_FADE;
 
-/** Total duration in seconds for a card of this height. */
-export function videoDuration(cardHeight, viewH = VIEW_H) {
-  const travel = maxScroll(cardHeight, viewH);
-  if (travel === 0) return STATIC_DURATION;
-  const panning = travel / SCROLL_SPEED;
-  return +Math.min(MAX_DURATION, HOLD_TOP + panning + HOLD_END).toFixed(3);
+/** Total duration for a deck of this many slides. */
+export function videoDuration(slideCount) {
+  const n = Math.max(1, slideCount);
+  return +Math.min(MAX_DURATION, n * SLIDE_PERIOD - SLIDE_FADE).toFixed(3);
 }
 
 /**
- * Scroll offset in canvas px at time t. Holds at the top, eases through the
- * pan so it does not start and stop abruptly, then holds on the last frame so
- * the final awards stay readable.
+ * Which slides are on screen at time t, and how far the crossfade has got.
+ * Returns the outgoing slide index and the incoming one's opacity.
  */
-export function scrollAt(t, cardHeight, viewH = VIEW_H) {
-  const travel = maxScroll(cardHeight, viewH);
-  if (travel === 0) return 0;
-  const duration = videoDuration(cardHeight, viewH);
-  const panning = Math.max(0.001, duration - HOLD_TOP - HOLD_END);
-  return travel * easeInOut(clamp01((t - HOLD_TOP) / panning));
+export function slideAt(t, slideCount) {
+  const n = Math.max(1, slideCount);
+  const i = Math.min(n - 1, Math.floor(t / SLIDE_PERIOD));
+  const within = t - i * SLIDE_PERIOD;
+  const fade = within <= SLIDE_HOLD || i >= n - 1
+    ? 0
+    : clamp01((within - SLIDE_HOLD) / SLIDE_FADE);
+  return { index: i, next: Math.min(n - 1, i + 1), fade };
 }
 
 /**
- * Draw one frame: the card, offset upward by the current scroll.
- * Areas above or below the card are filled with its own background colour so
- * short cards letterbox cleanly instead of showing black.
+ * Draw one frame. Slides may differ slightly in height — the last page carries
+ * fewer rows — so each is drawn against a matte at the deck's common size.
  */
-export function drawFrame(ctx, still, layout, t) {
-  const viewH = layout.viewH ?? VIEW_H;
-  const viewW = layout.viewW ?? VIEW_W;
+export function drawFrame(ctx, slides, layout, t) {
+  const { width: W, height: H } = layout;
+  const { index, next, fade } = slideAt(t, slides.length);
+
+  ctx.globalAlpha = 1;
   ctx.fillStyle = layout.matte || "#4A5759";
-  ctx.fillRect(0, 0, viewW, viewH);
+  ctx.fillRect(0, 0, W, H);
+  ctx.drawImage(slides[index], 0, 0);
 
-  const y = -scrollAt(t, layout.height, viewH);
-  // Centre a card shorter than the viewport rather than pinning it to the top.
-  const offset = layout.height < viewH ? (viewH - layout.height) / 2 : y;
-  ctx.drawImage(still, 0, offset, layout.width, layout.height);
+  if (fade > 0 && next !== index) {
+    ctx.globalAlpha = fade;
+    ctx.drawImage(slides[next], 0, 0);
+    ctx.globalAlpha = 1;
+  }
 }
 
 /**
  * Sample the card's own border colour so letterboxing matches it. Falls back to
  * the steel blue the card uses if the canvas cannot be read.
  */
-function matteColor(still) {
+function matteColor(canvas) {
   try {
-    const [r, g, b] = still.getContext("2d").getImageData(1, 1, 1, 1).data;
+    const [r, g, b] = canvas.getContext("2d").getImageData(1, 1, 1, 1).data;
     return `rgb(${r}, ${g}, ${b})`;
   } catch {
     return "#4A5759";
@@ -146,46 +148,61 @@ export async function pickEncoderConfig(width, height) {
 }
 
 /**
- * Render an animated share card.
+ * Render a slideshow of share cards.
  *
- * @param {(canvas: HTMLCanvasElement) => Promise<object>} drawStill — renders
- *   the still card and returns its layout metadata. Passed in rather than
- *   imported so this module stays independent of the card's own drawing code.
- * @returns {Promise<{blob: Blob, type: string, extension: string}>}
+ * @param {Array<(canvas: HTMLCanvasElement) => Promise<{width:number,height:number}>>} drawSlides
+ *   One draw function per page, each rendering a complete card. Passed in
+ *   rather than imported so this module stays independent of the card's own
+ *   drawing code.
+ * @returns {Promise<{blob: Blob, type: string, extension: string, slides: number}>}
  */
-export async function renderShareVideo(drawStill, { onProgress } = {}) {
-  const still = document.createElement("canvas");
-  const drawn = await drawStill(still);
-  if (!drawn || !drawn.height) throw new Error("drawStill returned no layout metadata");
+export async function renderShareVideo(drawSlides, { onProgress } = {}) {
+  const draws = Array.isArray(drawSlides) ? drawSlides : [drawSlides];
+  if (draws.length < 2) {
+    throw new Error("Nothing to animate — these awards all fit on one card");
+  }
 
-  // The frame is a fixed 9:16 viewport whatever the card's height. That keeps
-  // the output share-ready, and it keeps the encoder config constant instead of
-  // scaling with the number of awards.
-  const W = VIEW_W;
-  const H = VIEW_H;
-  const layout = { ...drawn, viewW: W, viewH: H, matte: matteColor(still) };
+  const slides = [];
+  let W = 0, H = 0;
+  for (const draw of draws) {
+    const canvas = document.createElement("canvas");
+    const drawn = await draw(canvas);
+    if (!drawn || !drawn.height) throw new Error("A slide returned no layout metadata");
+    slides.push(canvas);
+    W = Math.max(W, drawn.width);
+    H = Math.max(H, drawn.height);
+  }
+
+  // The deck's frame is the card's own dimensions — the tallest page, since
+  // the last one usually carries fewer rows. Rounded up to a macroblock so
+  // encoders do not have to cope with a ragged edge.
+  W = even16(W);
+  H = even16(H);
+  const layout = { width: W, height: H, matte: matteColor(slides[0]) };
 
   const frame = document.createElement("canvas");
   frame.width = W;
   frame.height = H;
   const ctx = frame.getContext("2d");
 
-  const total = Math.round(videoDuration(layout.height, H) * FPS);
+  const total = Math.round(videoDuration(slides.length) * FPS);
 
   // isConfigSupported() is advisory — encoders still fail at runtime — so a
   // failed MP4 attempt degrades to WebM rather than surfacing to the user.
   const config = await pickEncoderConfig(W, H);
   if (config) {
     try {
-      return await encodeMp4(frame, ctx, still, layout, total, onProgress, config);
+      const out = await encodeMp4(frame, ctx, slides, layout, total, onProgress, config);
+      return { ...out, slides: slides.length };
     } catch (err) {
       console.warn("[aeyu] MP4 encode failed, falling back to WebM:", err);
     }
   }
-  return recordWebm(frame, ctx, still, layout, total, onProgress);
+  const out = await recordWebm(frame, ctx, slides, layout, total, onProgress);
+  return { ...out, slides: slides.length };
 }
 
-async function encodeMp4(frame, ctx, still, layout, total, onProgress, config) {
+async function encodeMp4(frame, ctx, slides, layout, total, onProgress, config) {
   // Loaded on demand: 69 KB of muxer that only matters once someone actually
   // asks for a video, and keeping it out of the static graph lets the pure
   // animation functions above be tested without a browser.
@@ -207,7 +224,7 @@ async function encodeMp4(frame, ctx, still, layout, total, onProgress, config) {
   try {
     for (let i = 0; i < total; i++) {
       if (encodeError) throw encodeError;
-      drawFrame(ctx, still, layout, i / FPS);
+      drawFrame(ctx, slides, layout, i / FPS);
       const vf = new VideoFrame(frame, {
         timestamp: Math.round((i / FPS) * 1e6),
         duration: Math.round(1e6 / FPS),
@@ -240,7 +257,7 @@ async function encodeMp4(frame, ctx, still, layout, total, onProgress, config) {
  * Fallback for browsers without VideoEncoder. Produces WebM, which most social
  * targets will not accept — callers should offer this as a download.
  */
-async function recordWebm(frame, ctx, still, layout, total, onProgress) {
+async function recordWebm(frame, ctx, slides, layout, total, onProgress) {
   if (typeof MediaRecorder === "undefined" || !frame.captureStream) {
     throw new Error("This browser cannot record video");
   }
@@ -260,7 +277,7 @@ async function recordWebm(frame, ctx, still, layout, total, onProgress) {
 
   recorder.start();
   for (let i = 0; i < total; i++) {
-    drawFrame(ctx, still, layout, i / FPS);
+    drawFrame(ctx, slides, layout, i / FPS);
     onProgress?.((i + 1) / total);
     // captureStream samples in real time, so this has to play out at wall clock.
     await new Promise((r) => setTimeout(r, 1000 / FPS));

--- a/test/share-video.test.js
+++ b/test/share-video.test.js
@@ -1,106 +1,112 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { FPS, VIEW_H, VIEW_W, videoDuration, maxScroll, scrollAt, drawFrame, pickEncoderConfig }
+import { FPS, videoDuration, slideAt, drawFrame, pickEncoderConfig }
   from '../src/share-video.js';
 
-// A card with every award shown rather than the still card's four — the whole
-// reason the video exists. Roughly what a 12-award ride produces.
-const TALL = { width: VIEW_W, height: 4200 };
-const SHORT = { width: VIEW_W, height: 1200 };
-const layoutFor = (card) => ({ ...card, viewW: VIEW_W, viewH: VIEW_H, matte: '#4A5759' });
+const layout = { width: 1088, height: 1600, matte: '#4A5759' };
+const deck = (n) => Array.from({ length: n }, (_, i) => ({ slide: i }));
 
 function fakeCtx() {
   const calls = [];
   return {
-    calls, fillStyle: '',
+    calls, fillStyle: '', globalAlpha: 1,
     fillRect: (...a) => calls.push({ op: 'fill', a }),
-    drawImage: (...a) => calls.push({ op: 'draw', a }),
+    drawImage(img) { calls.push({ op: 'draw', img, alpha: this.globalAlpha }); },
   };
 }
-const lastDraw = (ctx) => ctx.calls.filter((c) => c.op === 'draw').at(-1);
+const drawn = (ctx) => ctx.calls.filter((c) => c.op === 'draw');
 
-test('a card taller than the viewport scrolls the whole way', () => {
-  assert.equal(maxScroll(TALL.height), TALL.height - VIEW_H);
-  assert.equal(scrollAt(0, TALL.height), 0);
-  const end = videoDuration(TALL.height);
-  assert.ok(Math.abs(scrollAt(end, TALL.height) - maxScroll(TALL.height)) < 1e-6,
-    'the last frame must show the bottom of the card');
+test('duration scales with the number of slides', () => {
+  assert.ok(videoDuration(4) > videoDuration(3));
+  assert.ok(videoDuration(3) > videoDuration(2));
+  assert.ok(videoDuration(50) <= 30, 'a pathological deck must not run forever');
 });
 
-test('a card shorter than the viewport does not scroll', () => {
-  assert.equal(maxScroll(SHORT.height), 0);
-  assert.equal(scrollAt(2, SHORT.height), 0);
-  assert.equal(videoDuration(SHORT.height), 3);
+test('every slide gets screen time', () => {
+  const slides = deck(4);
+  const seen = new Set();
+  const end = videoDuration(slides.length);
+  for (let t = 0; t <= end; t += 1 / FPS) seen.add(slideAt(t, slides.length).index);
+  assert.deepEqual([...seen].sort((a, b) => a - b), [0, 1, 2, 3]);
 });
 
-test('duration grows with the number of awards but stays bounded', () => {
-  assert.ok(videoDuration(4200) > videoDuration(2400));
-  assert.ok(videoDuration(2400) > videoDuration(1200));
-  assert.ok(videoDuration(40000) <= 30, 'a pathological card must not run forever');
-});
-
-test('scroll holds at the top before moving', () => {
-  assert.equal(scrollAt(0.5, TALL.height), 0, 'still holding at 0.5s');
-  assert.ok(scrollAt(1.6, TALL.height) > 0, 'moving by 1.6s');
-});
-
-test('scroll is monotonic — never jumps backwards', () => {
-  const end = videoDuration(TALL.height);
+test('slides advance in order and never go backwards', () => {
+  const n = 5, end = videoDuration(n);
   let prev = -1;
   for (let t = 0; t <= end; t += 1 / FPS) {
-    const y = scrollAt(t, TALL.height);
-    assert.ok(y >= prev - 1e-9, `went backwards at t=${t}`);
-    prev = y;
+    const { index } = slideAt(t, n);
+    assert.ok(index >= prev, `slide went backwards at t=${t}`);
+    prev = index;
   }
 });
 
-test('the frame is a fixed 9:16 viewport whatever the card height', () => {
-  assert.equal(VIEW_W / VIEW_H, 1080 / 1920);
-  for (const card of [SHORT, TALL, { width: VIEW_W, height: 12000 }]) {
-    const ctx = fakeCtx();
-    drawFrame(ctx, {}, layoutFor(card), 1);
-    const fill = ctx.calls.find((c) => c.op === 'fill');
-    assert.deepEqual(fill.a, [0, 0, VIEW_W, VIEW_H]);
+test('the deck opens on the familiar card and ends on the last page', () => {
+  const n = 3;
+  assert.equal(slideAt(0, n).index, 0);
+  assert.equal(slideAt(videoDuration(n), n).index, n - 1);
+});
+
+test('the last slide holds without fading into nothing', () => {
+  const n = 3, end = videoDuration(n);
+  for (let t = end - 0.5; t <= end; t += 1 / FPS) {
+    assert.equal(slideAt(t, n).fade, 0, 'nothing to cross-fade to after the last page');
   }
 });
 
-test('a short card is centred, not pinned to the top', () => {
-  const ctx = fakeCtx();
-  drawFrame(ctx, {}, layoutFor(SHORT), 1);
-  assert.equal(lastDraw(ctx).a[2], (VIEW_H - SHORT.height) / 2);
+test('consecutive slides cross-fade rather than cutting', () => {
+  const n = 3, end = videoDuration(n);
+  let sawFade = false;
+  for (let t = 0; t <= end; t += 1 / FPS) {
+    const { index, next, fade } = slideAt(t, n);
+    if (fade > 0) { sawFade = true; assert.equal(next, index + 1); }
+    assert.ok(fade >= 0 && fade <= 1);
+  }
+  assert.ok(sawFade, 'a multi-slide deck must cross-fade somewhere');
 });
 
-test('a tall card is drawn at the current scroll offset', () => {
+test('a frame paints matte, then the current slide, then the incoming one', () => {
+  const slides = deck(3);
   const ctx = fakeCtx();
-  drawFrame(ctx, {}, layoutFor(TALL), 2.5);
-  assert.equal(lastDraw(ctx).a[2], -scrollAt(2.5, TALL.height));
-});
-
-test('the matte is painted before the card so short cards letterbox', () => {
-  const ctx = fakeCtx();
-  drawFrame(ctx, {}, layoutFor(SHORT), 0);
+  // Find a moment mid-crossfade
+  const end = videoDuration(3);
+  let t = 0;
+  for (let u = 0; u <= end; u += 1 / FPS) if (slideAt(u, 3).fade > 0) { t = u; break; }
+  drawFrame(ctx, slides, layout, t);
   assert.equal(ctx.calls[0].op, 'fill');
+  const d = drawn(ctx);
+  assert.equal(d.length, 2);
+  assert.equal(d[0].alpha, 1);
+  assert.ok(d[1].alpha > 0 && d[1].alpha < 1);
+});
+
+test('outside a crossfade only one slide is drawn', () => {
+  const ctx = fakeCtx();
+  drawFrame(ctx, deck(3), layout, 0.2);
+  assert.equal(drawn(ctx).length, 1);
+  assert.equal(drawn(ctx)[0].alpha, 1);
+});
+
+test('the frame keeps the card dimensions', () => {
+  const ctx = fakeCtx();
+  drawFrame(ctx, deck(2), layout, 0);
+  assert.deepEqual(ctx.calls[0].a, [0, 0, layout.width, layout.height]);
+});
+
+test('the frame rate is slow enough to read but not so slow players choke', () => {
+  assert.ok(FPS >= 10 && FPS <= 15);
 });
 
 // --- Encoder configuration (#131) ---
-// avc1.42001f is Baseline level 3.1 — 3600 macroblocks, or 1280x720. The fixed
-// 1080x1920 viewport is 8160, so the level must be derived, not hardcoded.
+// avc1.42001f is Baseline level 3.1 — 3600 macroblocks. Card-sized frames
+// exceed it, so the level has to be derived rather than hardcoded.
 
 test('no encoder config is offered when VideoEncoder is absent', async () => {
   assert.equal(typeof VideoEncoder, 'undefined');
-  assert.equal(await pickEncoderConfig(VIEW_W, VIEW_H), null);
+  assert.equal(await pickEncoderConfig(1088, 1600), null);
 });
 
-test('the viewport exceeds the level that used to be hardcoded', () => {
-  const mbs = Math.ceil(VIEW_W / 16) * Math.ceil(VIEW_H / 16);
-  assert.equal(mbs, 8160);
+test('a card-sized frame exceeds the level that used to be hardcoded', () => {
+  const mbs = Math.ceil(1088 / 16) * Math.ceil(1600 / 16);
+  assert.equal(mbs, 6800);
   assert.ok(mbs > 3600, 'level 3.1 could never have encoded this');
-  assert.ok(mbs <= 8192, 'level 4.0 can');
-});
-
-test('the encoder frame size no longer varies with award count', () => {
-  // Whatever the card height, the video is always the same dimensions — so the
-  // encoder config is chosen once and cannot drift out of level range.
-  assert.equal(VIEW_W, 1080);
-  assert.equal(VIEW_H, 1920);
 });


### PR DESCRIPTION
Your call, and it removes the failure mode by construction.

## What it does now

The video is a **slide deck of card-sized pages**, at the still card's own dimensions. Highlights paginate four to a page; each slide is a complete, screenshot-able card with the usual header, meta and pills. 10fps — a slideshow needs no motion, and 10 is the floor players and social uploads accept without complaint. 2.4 s per slide, 0.4 s crossfade between them.

## Why this beats both previous attempts

- The fade-in showed the same four rows the PNG already showed. No information gained.
- The scroll assumed a card taller than the frame. It usually isn't — hence a still that sits there.

A deck cannot degenerate that way: **if there is only one page, there is no deck, and the button does not appear.** `shareCardPages(awards) > 1` gates it, and `renderShareVideo` refuses a single-slide array outright rather than emitting a motionless video. Segment cards show all their awards already, so the button is hidden there too.

## Changes

- `buildShareCardHighlights(awards, slots, offset)` — paginated. `renderShareCard(canvas, act, awards, { page })` renders page N. Page 0 is byte-identical to today's card, including its "+ N more awards" line; later pages drop that line since the next slide is the more.
- `share-video.js` rewritten around slides: `videoDuration(slideCount)`, `slideAt(t, n)` returning the outgoing index and the incoming opacity, `drawFrame` compositing matte → current → fading-in next.
- Frame is the tallest page rounded up to a macroblock — the last page usually carries fewer rows, and shorter pages sit on the matte.
- Deleted the scroll machinery: `viewportHeight`, `maxScroll`, `scrollAt`, `VIEW_H_MAX/MIN`, `VISIBLE_FRACTION`.

## Verification

- `node --test test/*.test.js` — **70/70 pass**. Suite rewritten: every slide gets screen time, indices never go backwards, the deck opens on page 0 and ends on the last, the final slide does not fade into nothing, crossfades only ever go to `index + 1`, and a mid-fade frame paints matte then two slides at the right opacities.
- Drove the module in headless Chromium 141 via Playwright:

| pages | duration | output |
|---|---|---|
| 1 | — | refused: "Nothing to animate — these awards all fit on one card" |
| 2 | 5.2 s | 37 KB |
| 3 | 8.0 s | 128 KB |
| 5 | 13.6 s | 213 KB |

Chromium ships no H.264 encoder, so those are the WebM fallback; the MP4 path is exercised only on your device.

`SLIDE_HOLD = 2.4 s` is the number to argue with — long enough to read four rows, short enough that a five-page deck stays under 14 s. Trivial to change.