### PR TITLE
Render every slide at the deck's common card height

### DIFF
--- a/src/components/ActivityDetail.js
+++ b/src/components/ActivityDetail.js
@@ -270,8 +270,10 @@ function drawLogoWatermark(ctx, W, H, cardY, cardH, pad) {
  * @param {object} opts
  * @param {number} opts.page — which page of highlights to show. Page 0 is the
  *   card as it has always looked; later pages are what the video steps through.
+ * @param {number|null} opts.height — force the card to at least this tall, so
+ *   every slide in a deck is the same size. Ignored if shorter than natural.
  */
-async function renderShareCard(canvas, act, awardsList, { page = 0 } = {}) {
+async function renderShareCard(canvas, act, awardsList, { page = 0, height = null } = {}) {
   const W = 1080;
   const borderW = 8; // steel blue border at image edge
   const innerPad = 44; // content padding inside body
@@ -329,7 +331,11 @@ async function renderShareCard(canvas, act, awardsList, { page = 0 } = {}) {
   bodyH += 24; // tighter bottom padding before tagline
 
   const taglineH = 48;
-  const H = headerCapH + bodyH + taglineH + borderW; // border at edge, no matting
+  // The deck forces every page to a common height so the card does not appear
+  // to change size between slides (#131). Extra height becomes empty paper
+  // below the last row; the tagline stays pinned to the bottom edge.
+  const naturalH = headerCapH + bodyH + taglineH + borderW; // border at edge, no matting
+  const H = Math.max(naturalH, height || 0);
 
   canvas.width = W;
   canvas.height = H;
@@ -1331,7 +1337,9 @@ export function ActivityDetail({ id }) {
       // One page of awards means the still card already shows everything, and
       // a video of a card that never changes is just a slower PNG.
       const slides = Array.from({ length: pages }, (_, page) =>
-        (canvas) => renderShareCard(canvas, act, awards.value, { page })
+        // The second argument carries the deck's common height on the second
+        // pass, so every slide renders the card at the same size.
+        (canvas, opts) => renderShareCard(canvas, act, awards.value, { page, ...opts })
       );
 
       const { blob, type, extension } = await renderShareVideo(slides, {

--- a/src/share-video.js
+++ b/src/share-video.js
@@ -39,7 +39,7 @@ const SLIDE_FADE = 0.4;
 const MAX_DURATION = 30;
 
 const clamp01 = (t) => (t < 0 ? 0 : t > 1 ? 1 : t);
-const even16 = (n) => Math.max(16, Math.ceil(n / 16) * 16);
+const even = (n) => n + (n % 2);
 
 /** Seconds one slide occupies, including its crossfade into the next. */
 const SLIDE_PERIOD = SLIDE_HOLD + SLIDE_FADE;
@@ -162,22 +162,32 @@ export async function renderShareVideo(drawSlides, { onProgress } = {}) {
     throw new Error("Nothing to animate — these awards all fit on one card");
   }
 
+  // Two passes. The first measures — the last page carries fewer rows, so pages
+  // differ in natural height. The second re-renders every page at the tallest,
+  // so the card is the same object on every slide rather than something that
+  // visibly resizes as the deck advances.
+  let cardH = 0;
+  for (const draw of draws) {
+    const probe = document.createElement("canvas");
+    const drawn = await draw(probe);
+    if (!drawn || !drawn.height) throw new Error("A slide returned no layout metadata");
+    cardH = Math.max(cardH, drawn.height);
+  }
+  cardH = even(cardH);
+
   const slides = [];
-  let W = 0, H = 0;
+  let W = 0;
   for (const draw of draws) {
     const canvas = document.createElement("canvas");
-    const drawn = await draw(canvas);
-    if (!drawn || !drawn.height) throw new Error("A slide returned no layout metadata");
+    const drawn = await draw(canvas, { height: cardH });
     slides.push(canvas);
     W = Math.max(W, drawn.width);
-    H = Math.max(H, drawn.height);
   }
 
-  // The deck's frame is the card's own dimensions — the tallest page, since
-  // the last one usually carries fewer rows. Rounded up to a macroblock so
-  // encoders do not have to cope with a ragged edge.
-  W = even16(W);
-  H = even16(H);
+  // H.264 needs even dimensions, nothing more — rounding to a macroblock would
+  // leave a visible strip of matte down one edge of a 1080-wide card.
+  W = even(W);
+  const H = cardH;
   const layout = { width: W, height: H, matte: matteColor(slides[0]) };
 
   const frame = document.createElement("canvas");

--- a/test/share-video.test.js
+++ b/test/share-video.test.js
@@ -110,3 +110,43 @@ test('a card-sized frame exceeds the level that used to be hardcoded', () => {
   assert.equal(mbs, 6800);
   assert.ok(mbs > 3600, 'level 3.1 could never have encoded this');
 });
+
+// --- Uniform slide size (#131) ---
+
+test('every slide is rendered at the deck\'s common height', async () => {
+  const { renderShareVideo } = await import('../src/share-video.js');
+  // Minimal DOM: the module only needs canvases it can hand to the draw
+  // functions. Encoding fails afterwards, which is fine — both render passes
+  // have already run by then.
+  globalThis.document = {
+    createElement: () => ({
+      width: 0, height: 0,
+      getContext: () => ({
+        fillRect() {}, drawImage() {}, fillStyle: '', globalAlpha: 1,
+        getImageData() { throw new Error('no pixels in node'); },
+      }),
+    }),
+  };
+  const naturals = [1600, 1600, 1180];   // last page carries fewer rows
+  const asked = [];
+  const draws = naturals.map((natural, i) => async (canvas, opts) => {
+    asked[i] = opts?.height ?? null;
+    canvas.width = 1080;
+    canvas.height = Math.max(natural, opts?.height || 0);
+    return { width: 1080, height: canvas.height };
+  });
+  // No document in node, so this throws before encoding — the measure/render
+  // passes still run and record what each slide was asked for.
+  try {
+    await renderShareVideo(draws);
+  } catch {
+    // expected: no encoder and no MediaRecorder in node
+  } finally {
+    delete globalThis.document;
+  }
+  assert.equal(asked.length, 3);
+  const forced = asked.filter((h) => h != null);
+  assert.equal(forced.length, 3, 'every slide gets a forced height on pass two');
+  assert.equal(new Set(forced).size, 1, 'and they all get the same one');
+  assert.equal(forced[0], 1600, 'which is the tallest natural height, made even');
+});


### PR DESCRIPTION
#294 merged before this landed, so it's a follow-up rather than a comment on that PR.

**Every slide now renders at the same card height.** The last page carries fewer rows, so pages differed in natural height and the card visibly resized as the deck advanced.

- `renderShareCard(canvas, act, awards, { page, height })` — `height` forces the card to at least that tall. Extra height becomes empty paper below the last row; the tagline stays pinned to the bottom edge. Ignored when shorter than natural, so the still card is unaffected.
- `renderShareVideo` does two passes: measure every page, then re-render them all at the tallest. Slide draw functions now take `(canvas, opts)`.
- Dropped the macroblock rounding on the frame. H.264 needs even dimensions, nothing more, and rounding 1080 up to 1088 left an 8 px strip of matte down one edge. The frame is now exactly the card.

## Verification

Headless Chromium, recording the height each slide was actually rendered at:

| pages (rows each) | slide heights | uniform |
|---|---|---|
| 2 (4, 2) | 1472, 1472 | yes |
| 3 (4, 4, 1) | 1472 x3 | yes |
| 4 (4, 4, 4, 3) | 1472 x4 | yes |

`node --test test/*.test.js` — **71/71 pass**, including a new case that stubs a minimal DOM to assert every slide is asked for the same forced height on the second pass, and that it equals the tallest natural one.