### PR TITLE
Reinstate a segment's headline when the per-type cap empties it

### DIFF
--- a/src/award-config.js
+++ b/src/award-config.js
@@ -150,6 +150,38 @@ export const AWARD_PRIORITY = {
   segment_count:        14,
 };
 
+/**
+ * Lower bound of the all-time-standing band at the top of AWARD_PRIORITY —
+ * matched_pr through comeback_full. Everything below 88 is calendar-window
+ * standing (best this year, this month, since January).
+ */
+export const ALL_TIME_PRIORITY_FLOOR = 88;
+
+/**
+ * Whether an award must be reinstated after the per-activity cap on its type
+ * has run (#131 follow-up).
+ *
+ * The type cap keeps one award type from flooding a ride, and it ranks
+ * instances globally across segments. On a long ride that means a segment can
+ * lose EVERY award it earned because other segments happened to earn stronger
+ * instances of the same types — and a segment with zero awards is dropped from
+ * the activity view, the share card and the LLM export entirely, with nothing
+ * logged. Measured on 2026-08-08 "N ½": "1 Ln Bridge to Store" was the
+ * athlete's 3rd-fastest of 39 efforts and vanished, because it ranked 6th of 6
+ * all_time_top3 (cap 5) and 4th of 4 ytd_best_power (cap 3).
+ *
+ * The invariant: the type cap may thin a segment's awards but must not erase
+ * the segment. Reinstatement is deliberately narrow — only the segment's
+ * headline, and only in the all-time-standing band. Exempting every headline
+ * would refloat a dozen overlapping segments covering the same stretch of road
+ * on a ride like that one; exempting nothing is the bug. Calendar-window
+ * awards (year_best and below) stay capped, which is what the cap is for.
+ */
+export function isCapReinstatable(award) {
+  if (!award || !award._isHeadline) return false;
+  return (AWARD_PRIORITY[award.type] || 0) >= ALL_TIME_PRIORITY_FLOOR;
+}
+
 /** Efforts within this fraction of the PR count as "essentially a PR" for strength. */
 const STRENGTH_PR_WINDOW = 0.10;
 

--- a/src/awards.js
+++ b/src/awards.js
@@ -89,7 +89,7 @@ import { getSegment, getResetEvent, recordRecoveryMilestone, getUserConfig, getA
 import { formatTime, formatDistance } from "./units.js";
 import { detectRoutes, findRouteForActivity } from "./routes.js";
 import { estimateCriticalPower } from "./critical-power.js";
-import { AWARD_PRIORITY, awardScore } from "./award-config.js";
+import { AWARD_PRIORITY, awardScore, isCapReinstatable } from "./award-config.js";
 
 /** Minimum total efforts on a segment before comparative awards apply */
 const MIN_EFFORTS_FOR_AWARDS = 3;
@@ -312,10 +312,23 @@ export function rankSegmentAwards(awards) {
     return typeCounts[a.type] <= cap;
   });
 
-  // Clean up internal tags
-  for (const a of afterTypeCap) delete a._isHeadline;
+  // 7. The type cap ranks instances across segments, so it can strip a segment
+  // of everything it earned. A segment with no awards disappears from the ride
+  // entirely, so put back the headline of any segment the cap emptied.
+  const survivors = new Set(afterTypeCap.map((a) => a.segment_id));
+  const reinstated = [];
+  const seen = new Set();
+  for (const a of ranked) {
+    if (survivors.has(a.segment_id) || seen.has(a.segment_id)) continue;
+    if (!isCapReinstatable(a)) continue;
+    reinstated.push(a);
+    seen.add(a.segment_id);
+  }
 
-  return [...afterTypeCap, ...rideLevelAwards];
+  const final = [...afterTypeCap, ...reinstated];
+  for (const a of final) delete a._isHeadline;
+
+  return [...final, ...rideLevelAwards];
 }
 
 function formatDate(isoString) {

--- a/test/award-priority.test.js
+++ b/test/award-priority.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { AWARD_PRIORITY, AWARD_LABELS, awardStrength, awardScore } from '../src/award-config.js';
+import { AWARD_PRIORITY, AWARD_LABELS, awardStrength, awardScore, isCapReinstatable, ALL_TIME_PRIORITY_FLOOR } from '../src/award-config.js';
 
 // Fixture: the 2026-08-02 ride that surfaced all of this (#131).
 // Four segments tied at year_best; three of them cover the same Kendale climb.
@@ -124,4 +124,37 @@ test('ride order does not decide ties', () => {
   const late = { ...KENDALE_CLIMB, effort_start_ms: s(9000), effort_end_ms: s(9068) };
   assert.equal(selectHighlights([early, late])[0].segment, 'Kendale Climb');
   assert.equal(selectHighlights([late, early])[0].segment, 'Kendale Climb');
+});
+
+// The per-activity type cap emptied a segment on 2026-08-08 "N ½": "1 Ln Bridge
+// to Store", 3rd-fastest of 39 efforts, ranked 6th of 6 all_time_top3 (cap 5)
+// and 4th of 4 ytd_best_power (cap 3), so it vanished from the ride entirely.
+const STRANDED_TOP3 = {
+  type: 'all_time_top3', segment: '1 Ln Bridge to Store', segment_id: 648837,
+  time: 557, all_time_rank: 3, effort_count: 39, pr_gap_pct: 13 / 544,
+  _isHeadline: true,
+};
+
+test('a headline all-time standing is reinstated when the type cap empties its segment', () => {
+  assert.equal(isCapReinstatable(STRANDED_TOP3), true);
+});
+
+test('a calendar-window headline stays capped', () => {
+  for (const type of ['year_best', 'beat_median', 'top_quartile', 'monthly_best']) {
+    assert.ok(AWARD_PRIORITY[type] < ALL_TIME_PRIORITY_FLOOR, `${type} is not all-time standing`);
+    assert.equal(isCapReinstatable({ ...STRANDED_TOP3, type }), false, type);
+  }
+});
+
+test('only the headline is reinstated, never a second award on the same segment', () => {
+  const secondary = { ...STRANDED_TOP3, type: 'ytd_best_power', _isHeadline: false };
+  assert.equal(isCapReinstatable(secondary), false);
+});
+
+test('the all-time band is exactly the top of the priority table', () => {
+  const allTime = Object.entries(AWARD_PRIORITY)
+    .filter(([, p]) => p >= ALL_TIME_PRIORITY_FLOOR)
+    .map(([t]) => t)
+    .sort();
+  assert.deepEqual(allTime, ['all_time_top3', 'closing_in', 'comeback_full', 'curve_all_time', 'matched_pr', 'near_kom']);
 });


### PR DESCRIPTION
## The bug

`rankSegmentAwards` step 6 applies `MAX_AWARDS_PER_TYPE` **across the whole activity**, ranking instances globally by `awardScore`. On a long ride that means a segment can lose *every* award it earned because other segments happened to earn stronger instances of the same types. A segment with zero awards is filtered out of `export-llm.js` (`efforts.filter(e => e.awards?.length > 0)`), the activity view and the share card — with nothing logged.

Surfaced by Oskar on the 2026-08-08 ride "N ½" (88 segment efforts): **1 Ln Bridge to Store**, 9:17, his 3rd-fastest of 39 efforts, 13s off the PR, `pr_rank: 3` — absent from the export entirely.

Replayed the ride's award computation offline against real Strava history for all 87 distinct segments (`/segments/{id}/all_efforts`), stubbing `db.js`. Reproduced exactly: 38 of 88 segments awarded, matching the app's output. Pre-cap, 1 Ln Bridge to Store earned `all_time_top3` **and** `ytd_best_power`; it ranked **6th of 6** `all_time_top3` (cap 5) and **4th of 4** `ytd_best_power` (cap 3). Both were trimmed, leaving nothing.

Seven types saturated their cap on this one ride. Seven segments were emptied.

## The fix

The cap may thin a segment's awards, but it must not erase the segment.

After the type cap runs, reinstate the headline award of any segment left with nothing. Deliberately narrow: headline only, and only in the all-time-standing band at the top of `AWARD_PRIORITY` (`>= 88` — `matched_pr`, `all_time_top3`, `near_kom`, `closing_in`, `curve_all_time`, `comeback_full`). Calendar-window awards stay capped; five "beat your median" rows are exactly what the cap is for.

Reinstated awards still consume a slot in `typeCounts`, so they don't widen the gate for anything below them.

## Effect on the reference ride

38 → 45 segments with awards. All seven additions are genuine `all_time_top3` efforts that the cap had erased. `all_time_top3` goes 5 → 12; every other type count is unchanged.

## Follow-up, not in this PR

Six of the seven reinstated segments overlap the same stretch of Glen Road. Overlap collapse currently lives only in `buildShareCardHighlights`; it arguably belongs in ranking, where the export would benefit from it too. Separately, a segment can still be emptied silently when its headline is *below* the all-time band — the cap is still the only place in the pipeline that can make a segment vanish without a trace.

## Testing

`node --test test/award-priority.test.js` — 14 pass (4 new, covering reinstatement, the calendar-window exclusion, the headline-only restriction, and the exact membership of the all-time band).

Not exercised in a browser.
